### PR TITLE
Change array order to be NAXIS1 before NAXIS2 etc.

### DIFF
--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -218,7 +218,7 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
 
         int[] axes = new int[nAxis];
         for (int i = 1; i <= nAxis; i++) {
-            axes[nAxis - i] = this.myHeader.getIntValue(NAXISn.n(i), 0);
+            axes[i - 1] = this.myHeader.getIntValue(NAXISn.n(i), 0);
         }
 
         return axes;


### PR DESCRIPTION
Whilst using this library I came across a potential bug. The getAxes method in the BasicHDU class reverses the order of the NAXISn dimensions.

With this patch the order is maintained and all unit tests still pass.

Of course, this may be the desired behaviour, but it didn't look right.