### PR TITLE
removal of redundent attribute "rowSize" 

### DIFF
--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -58,6 +58,7 @@ import nom.tam.util.Cursor;
 import nom.tam.util.FitsIO;
 import nom.tam.util.RandomAccess;
 import nom.tam.util.TableException;
+import nom.tam.util.type.PrimitiveTypeHandler;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -538,10 +539,12 @@ public class BinaryTable extends AbstractTableData {
     public void deleteColumns(int start, int len) throws FitsException {
         ensureData();
         try {
-            this.rowLen = this.table.deleteColumns(start, len);
+            this.table.deleteColumns(start, len);
             // Need to get rid of the column level metadata.
             for (int i = start + len - 1; i >= start; i -= 1) {
                 if (i >= 0 && i <= this.columnList.size()) {
+                    ColumnDesc columnDesc = this.columnList.get(i);
+                    this.rowLen -= columnDesc.size * PrimitiveTypeHandler.valueOf(columnDesc.base).size();
                     this.columnList.remove(i);
                 }
             }
@@ -1565,7 +1568,7 @@ public class BinaryTable extends AbstractTableData {
         }
         if (colDesc.isVarying) {
             dims = new int[]{
-                2 
+                2
             };
             colBase = int.class;
             bSize = FitsIO.BYTES_IN_INTEGER * 2;

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableHDU.java
@@ -54,6 +54,10 @@ public class CompressedTableHDU extends BinaryTableHDU {
      *            the binary table to compress
      * @param tileRows
      *            the number of rows that should be compressed per tile.
+     * @param columnCompressionAlgorithms
+     *            the compression algorithms to use for the columns (optional
+     *            default compression will be used if a column has no
+     *            compression specified)
      * @return the prepared compressed binaary table hdu.
      * @throws FitsException
      *             if the binary table could not be used to create a compressed


### PR DESCRIPTION
@TomMcGlynn the rowSize attribute caused problems during the binary compression implementation. And will also cause problems when you add a empty column (no rows yet) and add the rows afterward (fixed that in the head).  

But the rowSize attribute is redundant and not necessary, as far as I can see. This pull request contains the changes necessary to delete the attribute, and still have all tests succeed.

@TomMcGlynn could you verify, that my change is correct? If it is just push the merge pull request button.