### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order (part 1)

### DIFF
--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -70,6 +70,20 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
         TUNITn
     };
 
+
+
+    /**
+     * Create an ASCII table header/data unit.
+     *
+     * @param h
+     *            the template specifying the ASCII table.
+     * @param d
+     *            the FITS data structure containing the table data.
+     */
+    public AsciiTableHDU(Header h, AsciiTable d) {
+        super(h, d);
+    }
+
     /**
      * @return a ASCII table data structure from an array of objects
      *         representing the columns.
@@ -152,18 +166,6 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
         d.fillHeader(hdr);
         hdr.iterator();
         return hdr;
-    }
-
-    /**
-     * Create an ASCII table header/data unit.
-     *
-     * @param h
-     *            the template specifying the ASCII table.
-     * @param d
-     *            the FITS data structure containing the table data.
-     */
-    public AsciiTableHDU(Header h, AsciiTable d) {
-        super(h, d);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -89,6 +89,21 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
 
     public static final int BITPIX_DOUBLE = -64;
 
+
+    /** The associated header. */
+    protected Header myHeader = null;
+
+    /** The associated data unit. */
+    protected DataClass myData = null;
+
+    /** Is this the first HDU in a FITS file? */
+    protected boolean isPrimary = false;
+
+    protected BasicHDU(Header myHeader, DataClass myData) {
+        this.myHeader = myHeader;
+        this.myData = myData;
+    }
+
     /**
      * @return an HDU without content
      */
@@ -128,19 +143,6 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
         return false;
     }
 
-    /** The associated header. */
-    protected Header myHeader = null;
-
-    /** The associated data unit. */
-    protected DataClass myData = null;
-
-    /** Is this the first HDU in a FITS file? */
-    protected boolean isPrimary = false;
-
-    protected BasicHDU(Header myHeader, DataClass myData) {
-        this.myHeader = myHeader;
-        this.myData = myData;
-    }
 
     /**
      * Safely replace a card in the header, knowing that no exception will

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -69,6 +69,11 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
         TDIMn
     };
 
+
+    public BinaryTableHDU(Header hdr, BinaryTable datum) {
+        super(hdr, datum);
+    }
+
     /**
      * @return Encapsulate data in a BinaryTable data type
      * @param o
@@ -137,10 +142,6 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
         Header hdr = new Header();
         data.fillHeader(hdr);
         return hdr;
-    }
-
-    public BinaryTableHDU(Header hdr, BinaryTable datum) {
-        super(hdr, datum);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -133,71 +133,6 @@ public class Fits implements Closeable {
      */
     private static final Logger LOG = Logger.getLogger(Fits.class.getName());
 
-    /**
-     * @return a newly created HDU from the given Data.
-     * @param data
-     *            The data to be described in this HDU.
-     * @param <DataClass>
-     *            the class of the HDU
-     * @throws FitsException
-     *             if the operation failed
-     */
-    public static <DataClass extends Data> BasicHDU<DataClass> makeHDU(DataClass data) throws FitsException {
-        Header hdr = new Header();
-        data.fillHeader(hdr);
-        return FitsFactory.hduFactory(hdr, data);
-    }
-
-    /**
-     * @return a newly created HDU from the given header.
-     * @param h
-     *            The header which describes the FITS extension
-     * @throws FitsException
-     *             if the header could not be converted to a HDU.
-     */
-    public static BasicHDU<?> makeHDU(Header h) throws FitsException {
-        Data d = FitsFactory.dataFactory(h);
-        return FitsFactory.hduFactory(h, d);
-    }
-
-    /**
-     * @return a newly created HDU from the given data kernel.
-     * @param o
-     *            The data to be described in this HDU.
-     * @throws FitsException
-     *             if the parameter could not be converted to a HDU.
-     */
-    public static BasicHDU<?> makeHDU(Object o) throws FitsException {
-        return FitsFactory.hduFactory(o);
-    }
-
-    /**
-     * @return the version of the library.
-     */
-    public static String version() {
-        Properties props = new Properties();
-        InputStream versionProperties = null;
-        try {
-            versionProperties = Fits.class.getResourceAsStream("/META-INF/maven/gov.nasa.gsfc.heasarc/nom-tam-fits/pom.properties");
-            props.load(versionProperties);
-            return props.getProperty("version");
-        } catch (IOException e) {
-            LOG.log(Level.INFO, "reading version failed, ignoring", e);
-            return "unknown";
-        } finally {
-            saveClose(versionProperties);
-        }
-    }
-
-    /**
-     * close the input stream, and ignore eventual errors.
-     * 
-     * @param in
-     *            the input stream to close.
-     */
-    public static void saveClose(InputStream in) {
-        SaveClose.close(in);
-    }
 
     /**
      * The input stream associated with this Fits object.
@@ -396,6 +331,72 @@ public class Fits implements Closeable {
         this(myURL);
         LOG.log(Level.INFO, "compression ignored, will be autodetected. was set to " + compressed);
     }
+    /**
+     * @return a newly created HDU from the given Data.
+     * @param data
+     *            The data to be described in this HDU.
+     * @param <DataClass>
+     *            the class of the HDU
+     * @throws FitsException
+     *             if the operation failed
+     */
+    public static <DataClass extends Data> BasicHDU<DataClass> makeHDU(DataClass data) throws FitsException {
+        Header hdr = new Header();
+        data.fillHeader(hdr);
+        return FitsFactory.hduFactory(hdr, data);
+    }
+
+    /**
+     * @return a newly created HDU from the given header.
+     * @param h
+     *            The header which describes the FITS extension
+     * @throws FitsException
+     *             if the header could not be converted to a HDU.
+     */
+    public static BasicHDU<?> makeHDU(Header h) throws FitsException {
+        Data d = FitsFactory.dataFactory(h);
+        return FitsFactory.hduFactory(h, d);
+    }
+
+    /**
+     * @return a newly created HDU from the given data kernel.
+     * @param o
+     *            The data to be described in this HDU.
+     * @throws FitsException
+     *             if the parameter could not be converted to a HDU.
+     */
+    public static BasicHDU<?> makeHDU(Object o) throws FitsException {
+        return FitsFactory.hduFactory(o);
+    }
+
+    /**
+     * @return the version of the library.
+     */
+    public static String version() {
+        Properties props = new Properties();
+        InputStream versionProperties = null;
+        try {
+            versionProperties = Fits.class.getResourceAsStream("/META-INF/maven/gov.nasa.gsfc.heasarc/nom-tam-fits/pom.properties");
+            props.load(versionProperties);
+            return props.getProperty("version");
+        } catch (IOException e) {
+            LOG.log(Level.INFO, "reading version failed, ignoring", e);
+            return "unknown";
+        } finally {
+            saveClose(versionProperties);
+        }
+    }
+
+    /**
+     * close the input stream, and ignore eventual errors.
+     *
+     * @param in
+     *            the input stream to close.
+     */
+    public static void saveClose(InputStream in) {
+        SaveClose.close(in);
+    }
+
 
     /**
      * Add an HDU to the Fits object. Users may intermix calls to functions


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.
Soso Tughushi