### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/src/test/java/nom/tam/fits/util/BlackBoxImages.java
+++ b/src/test/java/nom/tam/fits/util/BlackBoxImages.java
@@ -45,6 +45,8 @@ import nom.tam.util.SaveClose;
 
 public class BlackBoxImages {
 
+    private BlackBoxImages(){}
+
     public static String getBlackBoxImage(final String fileName) {
         if (new File("../blackbox-images/" + fileName).exists()) {
             return "../blackbox-images/" + fileName;

--- a/src/test/java/nom/tam/image/tile/operation/Access.java
+++ b/src/test/java/nom/tam/image/tile/operation/Access.java
@@ -35,6 +35,8 @@ import nom.tam.image.tile.operation.buffer.TileBuffer;
 
 public class Access {
 
+    private Access(){}
+
     public static TileBuffer getTileBuffer(AbstractTileOperation tileOperation) {
         return tileOperation.getTileBuffer();
     }

--- a/src/test/java/nom/tam/util/TestArrayFuncs.java
+++ b/src/test/java/nom/tam/util/TestArrayFuncs.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 
 public class TestArrayFuncs {
 
+    private TestArrayFuncs(){}
+
     /** Compare two double arrays using a given tolerance */
     public static boolean doubleArrayEquals(double[] x, double[] y, double tol) {
 

--- a/src/test/java/nom/tam/util/test/ThrowAnyException.java
+++ b/src/test/java/nom/tam/util/test/ThrowAnyException.java
@@ -38,6 +38,8 @@ import nom.tam.fits.HeaderCardException;
 
 public class ThrowAnyException {
 
+    private ThrowAnyException(){}
+
     public static <E extends Throwable> void throwAny(Throwable e) throws E {
         throw (E) e;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Soso Tughushi