### PR TITLE
HashedList and HeaderTest leftovers from prior pull request...

### DIFF
--- a/src/main/java/nom/tam/util/HashedList.java
+++ b/src/main/java/nom/tam/util/HashedList.java
@@ -98,16 +98,13 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
 
         @Override
         public void add(VALUE reference) {
-            // AK: Do not advance the iterator if the addition also removed an element
-            //     from before the current position.
-            if (HashedList.this.add(this.current, reference)) {
-                this.current++;
+            HashedList.this.add(this.current, reference);
+            this.current++;
                 
-                // AK: Do not allow the iterator to exceed the header size
-                //     prev() requires this to work properly...
-                if (this.current > HashedList.this.size()) {
-                    this.current = HashedList.this.size();
-                }
+            // AK: Do not allow the iterator to exceed the header size
+            //     prev() requires this to work properly...
+            if (this.current > HashedList.this.size()) {
+                this.current = HashedList.this.size();
             }
         }
 
@@ -197,20 +194,14 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
      * @param reference
      *            The element to add to the list.
      *            
-     * @return false if the addition replaced a previous entry before 
-     *            the insertion point, true otherwise. (Iterators can use
-     *            this information to decide whether to advance or not).
      */
-    private boolean add(int pos, VALUE entry) {
-        boolean advance = true;
-        
+    private void add(int pos, VALUE entry) {     
         String key = entry.getKey();
         if (this.keyed.containsKey(key) && !unkeyedKey(key)) {
             int oldPos = indexOf(entry);
             internalRemove(oldPos, entry);
             if (oldPos < pos) {
                 pos--;
-                advance = false;
             }
         }
         this.keyed.put(key, entry);
@@ -235,8 +226,6 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
         if (pos < cursor.current) {
             cursor.current++;
         }
-        
-        return advance;
     }
 
     private static boolean unkeyedKey(String key) {

--- a/src/test/java/nom/tam/fits/HeaderOrderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderOrderTest.java
@@ -77,42 +77,20 @@ public class HeaderOrderTest {
         Header header = new Header();
         
         header.addValue(BLOCKED, 1);
-        // AK: Set SIMPLE to false initially, we will overwrite it below to 'correct' it...
-        header.addValue(SIMPLE, false);
-        header.addValue(THEAP, 1);  
-        // AK: Test update of non-existing key:
-        //     This should result in appending a new key to the end...
-        header.updateLine(NAXIS, new HeaderCard(NAXIS.key(), 1, ""));
-        // AK: Test appending a key to the end of the header.
-        //     (we will replace it later with a new card at the new end...)
-        header.addValue(END, true);
-        // AK: Add a temporary key to the end, which we remove later...
-        header.addLine(new HeaderCard("TEMP", 0, ""));
-        // AK: Test in-situ updates, while maintaining the current position...
-        header.updateLine(SIMPLE.key(), new HeaderCard(SIMPLE.key(), true, ""));
-        // AK: Test, that the current position was unaffected by the above
-        // AK: Also test removal of existing key, without affecting position...
-        //     I.e., The the next key should be added at the current position, after THEAP,
-        //     and before END
-        header.addValue(NAXIS, 0);
-        // AK: Insert BITPIX before THEAP...
-        header.findCard(THEAP);
-        // AK: Test that deletions do not affect the current position...
-        //     After the deletion, BITPIX should still be inserted to before THEAP 
-        header.deleteKey("TEMP");
+        header.addValue(SIMPLE, true);
         header.addValue(BITPIX, 1);
-        // AK: Test appending a card to the end, and removing existing prior occurrence...
+        header.addValue(THEAP, 1);  
+        header.addValue(NAXIS, 0);
         header.addValue(END, true);
-
+       
         
-        /*
         // Check that the order is what we expect...
         Assert.assertEquals(SIMPLE.key(), header.iterator(1).next().getKey());
         Assert.assertEquals(BITPIX.key(), header.iterator(2).next().getKey());
         Assert.assertEquals(THEAP.key(), header.iterator(3).next().getKey());
         Assert.assertEquals(NAXIS.key(), header.iterator(4).next().getKey());
         Assert.assertEquals(END.key(), header.iterator(5).next().getKey());
-        */
+        
         
         header.write(dos);
         Assert.assertEquals(BLOCKED.key(), header.iterator(3).next().getKey());

--- a/src/test/java/nom/tam/fits/test/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderTest.java
@@ -652,6 +652,45 @@ public class HeaderTest {
             SafeClose.close(f);
         }
     }
+    
+    @Test
+    public void orderTest() throws Exception {
+        Header h = new Header();
+        
+        // Start with an 'existing' header
+        h.addValue("BLAH1", 0, "");
+        h.addValue("BLAH2", 0, "");
+        h.addValue("KEY4", 0, "");
+        h.addValue("BLAH3", 0, "");
+        h.addValue("MARKER", 0, "");
+        h.addValue("BLAH4", 0, "");
+        h.addValue("KEY2", 0, "");
+        
+        
+        // Now insert some keys before MARKER
+        h.findCard("MARKER");
+        h.addValue("KEY1", 1, "");
+        h.addValue("KEY2", 1, "");
+        h.addValue("KEY3", 1, "");
+        h.addValue("KEY4", 1, "");
+        h.addValue("KEY5", 1, "");
+        h.addValue("KEY6", 1, "");
+        
+        // Check to that the keys appear in the expected order...
+        Cursor<String, HeaderCard> c = h.iterator();
+        c.setKey("KEY1");
+        
+        for(int i=1; i<=6; i++) {
+            HeaderCard card = c.next();
+            assertEquals("KEY" + i, card.getKey());
+            assertEquals(1, (int) card.getValue(Integer.class, 0));
+        }
+        
+        
+        
+        
+        
+    }
 
     @Test
     public void addValueTests() throws Exception {

--- a/src/test/java/nom/tam/fits/test/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderTest.java
@@ -674,6 +674,12 @@ public class HeaderTest {
         h.addValue("KEY3", 1, "");
         h.addValue("KEY4", 1, "");
         h.addValue("KEY5", 1, "");
+
+        
+        // Now do an in-place update and a deletion, which should not move
+        // the position.
+        h.updateLine("BLAH2", new HeaderCard("BLAH2A", 1, ""));
+        h.deleteKey("BLAH1");
         h.addValue("KEY6", 1, "");
         
         // Check to that the keys appear in the expected order...
@@ -684,12 +690,7 @@ public class HeaderTest {
             HeaderCard card = c.next();
             assertEquals("KEY" + i, card.getKey());
             assertEquals(1, (int) card.getValue(Integer.class, 0));
-        }
-        
-        
-        
-        
-        
+        }      
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/test/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderTest.java
@@ -676,17 +676,21 @@ public class HeaderTest {
         h.addValue("KEY5", 1, "");
 
         
-        // Now do an in-place update and a deletion, which should not move
-        // the position.
+        // Now do an in-place update and a deletion, which should not affect
+        // the position. The position should remain before MARKER.
         h.updateLine("BLAH2", new HeaderCard("BLAH2A", 1, ""));
         h.deleteKey("BLAH1");
         h.addValue("KEY6", 1, "");
+        
+        // Use updateLine for a non-existent key. This should result in
+        // adding a new card at the current position
+        h.updateLine("KEY7", new HeaderCard("KEY7", 1, ""));
         
         // Check to that the keys appear in the expected order...
         Cursor<String, HeaderCard> c = h.iterator();
         c.setKey("KEY1");
         
-        for(int i=1; i<=6; i++) {
+        for(int i=1; i<=7; i++) {
             HeaderCard card = c.next();
             assertEquals("KEY" + i, card.getKey());
             assertEquals(1, (int) card.getValue(Integer.class, 0));


### PR DESCRIPTION
Just a minor fix to HashedList.internalRemove() -- an off-by-one index in the conditional check. HeaderOrderTest has been reinstated to near its original state, and instead a new orderTest() was added to HeaderTest. (I may continue to expand that test a little further still...)