### PR TITLE
Minor fixes prior to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ release.properties
 /target/
 .idea
 nom-tam-fits.iml
+coverage
+javadoc

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -247,18 +247,10 @@ public class HeaderCard implements CursorValue<String> {
 
         DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.US);
 
-        if (decimalValue.compareTo(BigDecimal.valueOf(1)) == 1 || decimalValue.compareTo(BigDecimal.valueOf(-1)) == -1) {
-            if (useD) {
-                symbols.setExponentSeparator("D+");
-            } else {
-                symbols.setExponentSeparator("E+");
-            }
+        if (useD) {
+            symbols.setExponentSeparator("D");
         } else {
-            if (useD) {
-                symbols.setExponentSeparator("D");
-            } else {
-                symbols.setExponentSeparator("E");
-            }
+            symbols.setExponentSeparator("E");
         }
         DecimalFormat format = new DecimalFormat("0.0E0", symbols);
         format.setRoundingMode(RoundingMode.HALF_UP);

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -460,6 +460,11 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
         this.myHeader.addLine(new HeaderCard(key + (index + 1), value, precision, comment));
     }
 
+    public void setColumnMeta(int index, String key, double value, int precision, boolean useD, String comment, boolean after) throws FitsException {
+        setCurrentColumn(index, after);
+        this.myHeader.addLine(new HeaderCard(key + (index + 1), value, precision, useD, comment));
+    }
+
     public void setColumnMeta(int index, String key, long value, String comment, boolean after) throws FitsException {
         setCurrentColumn(index, after);
         this.myHeader.addLine(new HeaderCard(key + (index + 1), value, comment));

--- a/src/test/java/nom/tam/fits/test/BinaryTableTest.java
+++ b/src/test/java/nom/tam/fits/test/BinaryTableTest.java
@@ -45,8 +45,12 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -478,6 +482,7 @@ public class BinaryTableTest {
             bhdu.setColumnMeta(i, "TX", i + 1, null, true);
             bhdu.setColumnMeta(i, "TY", 2. * (i + 1), null, true);
             bhdu.setColumnMeta(i, "TZ", 3. * (i + 1), i + 1, null, true);
+            bhdu.setColumnMeta(i, "TSCI", 3. * (i + 1), i + 1, false,null, true);
         }
         bhdu.setCurrentColumn(1);
         Assert.assertEquals(-1, bhdu.findColumn("XXX"));
@@ -495,10 +500,13 @@ public class BinaryTableTest {
             hdr.findCard("TTYPE" + (i + 1));
             HeaderCard hc = hdr.nextCard();
             assertEquals("M" + i + "0", "TTYPE" + (i + 1), hc.getKey());
+            assertEquals(String.format("NAM%d", i+1),hc.getValue());
             hc = hdr.nextCard();
             assertEquals("M" + i + "A", "TCOMM" + (i + 1), hc.getKey());
+            assertEquals("T", hc.getValue());
             hc = hdr.nextCard();
             assertEquals("M" + i + "B", "TFORM" + (i + 1), hc.getKey());
+
             hc = hdr.nextCard();
             // There may have been a TDIM keyword inserted automatically. Let's
             // skip it if it was. It should only appear immediately after the
@@ -507,12 +515,25 @@ public class BinaryTableTest {
                 hc = hdr.nextCard();
             }
             assertEquals("M" + i + "C", "TUNIT" + (i + 1), hc.getKey());
+            assertEquals(hc.getValue(),String.format("UNIT%d", i+1));
             hc = hdr.nextCard();
             assertEquals("M" + i + "D", "TX" + (i + 1), hc.getKey());
+            assertEquals(String.format("%d", i+1),hc.getValue());
             hc = hdr.nextCard();
             assertEquals("M" + i + "E", "TY" + (i + 1), hc.getKey());
+            assertEquals(String.format("%.1f", 2. * (i + 1)), hc.getValue());
             hc = hdr.nextCard();
             assertEquals("M" + i + "F", "TZ" + (i + 1), hc.getKey());
+            assertEquals(String.format("%."+(i+1)+"f", 3. * (i + 1)), hc.getValue());
+            hc = hdr.nextCard();
+            assertEquals("M" + i + "F", "TSCI" + (i + 1), hc.getKey());
+            DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(Locale.US);
+            DecimalFormat format = new DecimalFormat("0.0E0", symbols);
+            format.setRoundingMode(RoundingMode.HALF_UP);
+            format.setMinimumFractionDigits(i+1);
+            format.setMaximumFractionDigits(i+1);
+            String value = format.format(3. * (i + 1));
+            assertEquals(value, hc.getValue());
         }
     }
 

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -190,8 +190,8 @@ public class HeaderCardTest {
     public void testBigDecimal1() throws Exception {
         HeaderCard hc = new HeaderCard("TEST", new BigDecimal("12345678901234567890123456789012345678901234567890123456789012345678901234567.890"), "dummy");
         assertEquals(BigInteger.class, hc.valueType());
-        assertEquals("1.234567890123456789012345678901234567890123456789012345678901235E+76", hc.getValue());
-        assertEquals(new BigInteger("12345678901234567890123456789012345678901234567890123456789012350000000000000"), hc.getValue(BigInteger.class, null));
+        assertEquals("1.2345678901234567890123456789012345678901234567890123456789012346E76", hc.getValue());
+        assertEquals(new BigInteger("12345678901234567890123456789012345678901234567890123456789012346000000000000"), hc.getValue(BigInteger.class, null));
     }
 
     @Test
@@ -210,8 +210,8 @@ public class HeaderCardTest {
                 new BigDecimal("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567.890123456789012345678901234567890"),
                 "dummy");
         assertEquals(BigInteger.class, hc.valueType());
-        assertEquals("1.234567890123456789012345678901234567890123456789012345678901235E+96", hc.getValue());
-        assertEquals(new BigInteger("1234567890123456789012345678901234567890123456789012345678901235000000000000000000000000000000000"), hc.getValue(BigInteger.class, null));
+        assertEquals("1.2345678901234567890123456789012345678901234567890123456789012346E96", hc.getValue());
+        assertEquals(new BigInteger("1234567890123456789012345678901234567890123456789012345678901234600000000000000000000000000000000"), hc.getValue(BigInteger.class, null));
     }
 
     @Test
@@ -240,8 +240,8 @@ public class HeaderCardTest {
     public void testBigInteger() throws Exception {
         HeaderCard hc = new HeaderCard("TEST", new BigInteger("1234567890123456789012345678901234567890123456789012345678901234567890"), "dummy");
         assertEquals(BigInteger.class, hc.valueType());
-        assertEquals("1.234567890123456789012345678901234567890123456789012345678901235E+69", hc.getValue());
-        assertEquals(new BigInteger("1234567890123456789012345678901234567890123456789012345678901235000000"), hc.getValue(BigInteger.class, null));
+        assertEquals("1.2345678901234567890123456789012345678901234567890123456789012346E69", hc.getValue());
+        assertEquals(new BigInteger("1234567890123456789012345678901234567890123456789012345678901234600000"), hc.getValue(BigInteger.class, null));
     }
 
     @Test
@@ -272,7 +272,7 @@ public class HeaderCardTest {
         HeaderCard hc = new HeaderCard("TEST", -123456789012345678.242342429f, "dummy");
         String val = hc.getValue();
         assertEquals(Double.class, hc.valueType());
-        assertEquals(Double.valueOf(-1.234568E+17), hc.getValue(Double.class, null), 1d);
+        assertEquals(Double.valueOf(-1.234568E17), hc.getValue(Double.class, null), 1d);
         hc.setValue(12345.6666f, 2);
         assertEquals(Double.class, hc.valueType());
         assertEquals(Double.valueOf(12345.67d), hc.getValue(Double.class, null), 10000000000d);
@@ -427,18 +427,18 @@ public class HeaderCardTest {
     public void testScientificFloats_1() throws Exception {
         HeaderCard hc = new HeaderCard("TEST", -1234.567f, 4, false, "dummy");
         String val = hc.getValue();
-        assertEquals("tld1", 10, val.length());
-        assertEquals("-1.2346E+3", val);
-        assertEquals(-1.2346E+3f, hc.getValue(Float.class, null), 0.0000001f);
+        assertEquals("tld1", 9, val.length());
+        assertEquals("-1.2346E3", val);
+        assertEquals(-1.2346E3f, hc.getValue(Float.class, null), 0.0000001f);
     }
 
     @Test
     public void testScientificFloats_2() throws Exception {
         HeaderCard hc = new HeaderCard("TEST", 1234.567f, 4, false, "dummy");
         String val = hc.getValue();
-        assertEquals("tld1", 9, val.length());
-        assertEquals("1.2346E+3", val);
-        assertEquals(1.2346E+3f, hc.getValue(Float.class, null), 0.0000001f);
+        assertEquals("tld1", 8, val.length());
+        assertEquals("1.2346E3", val);
+        assertEquals(1.2346E3f, hc.getValue(Float.class, null), 0.0000001f);
     }
 
     @Test
@@ -463,18 +463,18 @@ public class HeaderCardTest {
     public void testScientificDoubles_1() throws Exception {
         HeaderCard hc = new HeaderCard("TEST", -123456.78905D, 6, true, "dummy");
         String val = hc.getValue();
-        assertEquals("tld1", val.length(), 12);
-        assertEquals("-1.234568D+5", val);
-        assertEquals(-1.234568E+5, hc.getValue(Double.class, null), 0.000000001d);
+        assertEquals("tld1", val.length(), 11);
+        assertEquals("-1.234568D5", val);
+        assertEquals(-1.234568E5, hc.getValue(Double.class, null), 0.000000001d);
     }
 
     @Test
     public void testScientificDoubles_2() throws Exception {
         HeaderCard hc = new HeaderCard("TEST", 123456.78905D, 6, true, "dummy");
         String val = hc.getValue();
-        assertEquals("tld1", val.length(), 11);
-        assertEquals("1.234568D+5", val);
-        assertEquals(1.234568E+5, hc.getValue(Double.class, null), 0.000000001d);
+        assertEquals("tld1", val.length(), 10);
+        assertEquals("1.234568D5", val);
+        assertEquals(1.234568E5, hc.getValue(Double.class, null), 0.000000001d);
     }
 
     @Test
@@ -501,9 +501,9 @@ public class HeaderCardTest {
                 new BigDecimal("123456789012345678901234567890123456789012345678901234567.8901234567890123456789012345678901234567890123456789012345678901234567890"),
                 9, true,"dummy");
         String val = hc.getValue();
-        assertEquals("tld1", 15, val.length());
-        assertEquals("1.234567890D+56", val);
-        assertEquals(new BigDecimal("1.234567890E+56"), hc.getValue(BigDecimal.class, null));
+        assertEquals("tld1", 14, val.length());
+        assertEquals("1.234567890D56", val);
+        assertEquals(new BigDecimal("1.234567890E56"), hc.getValue(BigDecimal.class, null));
     }
 
     @Test
@@ -512,9 +512,9 @@ public class HeaderCardTest {
                 new BigDecimal("-123456789012345678901234567890123456789012345678901234567.8901234567890123456789012345678901234567890123456789012345678901234567890"),
                 9, true,"dummy");
         String val = hc.getValue();
-        assertEquals("tld1", 16, val.length());
-        assertEquals("-1.234567890D+56", val);
-        assertEquals(new BigDecimal("-1.234567890E+56"), hc.getValue(BigDecimal.class, null));
+        assertEquals("tld1", 15, val.length());
+        assertEquals("-1.234567890D56", val);
+        assertEquals(new BigDecimal("-1.234567890E56"), hc.getValue(BigDecimal.class, null));
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/test/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderTest.java
@@ -1177,26 +1177,26 @@ public class HeaderTest {
         hdr.addExpValue( "SCI_E", 1234.12f, 2,"SciNotation with E");
         hdr.addExpValue("BIGDEC2", new BigDecimal("-12345678901234567890.1234567890"), 8,"Another Big Desc Sci Note");
 
-        assertEquals("1.2346D+4", hdr.findCard("SCI_D").getValue());
+        assertEquals("1.2346D4", hdr.findCard("SCI_D").getValue());
         assertEquals(12346.0f, hdr.getFloatValue("SCI_D"), 0.00001f);
-        assertEquals("1.2345678901D+19",hdr.findCard("BIGDEC").getValue());
+        assertEquals("1.2345678901D19",hdr.findCard("BIGDEC").getValue());
         assertEquals(new BigDecimal("1.2345678901E19"), hdr.getBigDecimalValue("BIGDEC"));
-        assertEquals("1.23E+3", hdr.findCard("SCI_E").getValue());
+        assertEquals("1.23E3", hdr.findCard("SCI_E").getValue());
         assertEquals(1230.0, hdr.getDoubleValue("SCI_E"), 0.00001);
-        assertEquals("-1.23456789E+19",hdr.findCard("BIGDEC2").getValue());
+        assertEquals("-1.23456789E19",hdr.findCard("BIGDEC2").getValue());
         assertEquals(new BigDecimal("-1.23456789E+19"), hdr.getBigDecimalValue("BIGDEC2"));
 
         // Update the cards
         hdr.findCard("SCI_E").setExpValue(2468.123f, 1, false);
-        assertEquals("2.5E+3", hdr.findCard("SCI_E").getValue());
+        assertEquals("2.5E3", hdr.findCard("SCI_E").getValue());
         assertEquals(2500.0f, hdr.getFloatValue("SCI_E"), 0.00001f);
 
         hdr.findCard("SCI_D").setExpValue(13456.76344, 3, true);
-        assertEquals("1.346D+4", hdr.findCard("SCI_D").getValue());
+        assertEquals("1.346D4", hdr.findCard("SCI_D").getValue());
         assertEquals(13460.0, hdr.getDoubleValue("SCI_D"), 0.00001);
 
         hdr.findCard("SCI_D").setExpValue(13456.76344, 3);
-        assertEquals("1.346E+4", hdr.findCard("SCI_D").getValue());
+        assertEquals("1.346E4", hdr.findCard("SCI_D").getValue());
         assertEquals(13460.0, hdr.getDoubleValue("SCI_D"), 0.00001);
 
         hdr.findCard("BIGDEC").setExpValue(new BigDecimal("0.0000707703"), 4, true);


### PR DESCRIPTION
Removed the explicit '+' from the exponent of the scientific notation format (wasn't needed).
Added a scientific notation version of setColumnMeta method to TableHDU