### PR TITLE
set FitsFactory.useHierarch to true

### DIFF
--- a/src/main/java/nom/tam/fits/FitsFactory.java
+++ b/src/main/java/nom/tam/fits/FitsFactory.java
@@ -56,7 +56,11 @@ public final class FitsFactory {
 
         private boolean useAsciiTables = true;
 
-        private boolean useHierarch = false;
+        // MBT (28-JUL-2017): change default from false to true.
+        // This is required for HIERARCH-based wide fits processing
+        // (see uk.ac.starlink.fits.WideFits).  If that gets backed out of,
+        // this could be set back to its factory setting (false).
+        private boolean useHierarch = true;
 
         private boolean checkAsciiStrings = false;
 

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -309,6 +309,8 @@ public class HeaderCardTest {
         HeaderCard hc;
         String key = "HIERARCH.TEST1.TEST2.INT";
         boolean thrown = false;
+
+        FitsFactory.setUseHierarch(false);
         try {
             hc = new HeaderCard(key, 123, "Comment");
         } catch (Exception e) {


### PR DESCRIPTION
This is a forwarding followup of the short discussion in commit [fd527d6](https://github.com/Starlink/starjava/commit/fd527d661efe04b05b368051df2bf6a6aa7329c3#commitcomment-23745202) from @mbtaylor:

> Change the static setting that determines whether the `nom.tam.fits` libraries recognise the [ESO HIERARCH convention for hierarchical FITS keywords](https://fits.gsfc.nasa.gov/registry/hierarch_keyword.html) from false (which is how it is configured by default) to true.
> 
> This setting is required to make the hierarchical variant of the WideFits convention work (see [`uk.ac.starlink.fits.WideFits`](https://github.com/Starlink/starjava/blob/master/fits/src/main/uk/ac/starlink/fits/WideFits.java)). There's no way in the nom.tam.fits API to configure HIERARCH-use on a per-call basis, so we have to modify the static setting.
> 
> This will affect other `nom.tam.fits`-dependent code using this library. An alternative would be to set this only when the hierarch convention is potentially or actually in use, but that gets messier,
> since it would still affect other code running in the same JVM, but in less predictable ways.
> 
> So following this change, STIL FITS handling will pick up `HIERARCH` per-table headers which it previously ignored.

I looks that there is no real drawback when enabling this.