### PR TITLE
Fix serious FITS character handling bug

### DIFF
--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -83,6 +83,10 @@ public class HeaderCard implements CursorValue<String> {
 
     private static final String HIERARCH_WITH_DOT = NonStandard.HIERARCH.key() + ".";
 
+    private static final char CHR20 = 0x20;
+
+    private static final char CHR7E = 0x7e;
+
     /**
      * regexp for IEEE floats
      */
@@ -1118,6 +1122,26 @@ public class HeaderCard implements CursorValue<String> {
     }
 
     /**
+     * Takes an arbitrary String object and turns it into a string with
+     * characters than can be harmlessly output to a FITS header.
+     * The FITS standard excludes certain characters; moreover writing
+     * non-7-bit characters can end up producing multiple bytes per
+     * character in some text encodings, leading to a corrupted header.
+     *
+     * @param str input string
+     * @return  sanitized string
+     */
+    private static String sanitize(String str) {
+        int nc = str.length();
+        char[] cbuf = new char[nc];
+        for (int ic = 0; ic < nc; ic++) {
+            char c = str.charAt(ic);
+            cbuf[ic] = (c >= CHR20 && c <= CHR7E) ? c : '?';
+        }
+        return new String(cbuf);
+    }
+
+    /**
      * Return the modulo 80 character card image, the toString tries to preserve
      * as much as possible of the comment value by reducing the alignment of the
      * Strings if the comment is longer and if longString is enabled the string
@@ -1204,7 +1228,7 @@ public class HeaderCard implements CursorValue<String> {
             }
         }
         buf.completeLine();
-        return buf.toString();
+        return sanitize(buf.toString());
     }
 
     /**


### PR DESCRIPTION
When a header card is created with a non-ASCII or control char, this may result in a corrupted FITS file.
The attached (rebased) patch [6cc2947](https://github.com/Starlink/starjava/commit/6cc2947a088c8769f1e362a59daeb5b2864e93bb) from @mbtaylor ensures that only valid chars are written to FITS.
Without this patch, the according test in [Starjava `uk.ac.starlink.fits.Tamfits`](https://github.com/Starlink/starjava/blob/0c9f0da084c3c136dc485969a21edc4b6016a208/fits/src/testcases/uk/ac/starlink/fits/TamfitsTest.java#L46-L57) will fail.

