### PR TITLE
 Fix management of sub-seconds in FitsDate

### DIFF
--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -75,7 +75,7 @@ public class FitsDate {
     private static final int NEW_FORMAT_YEAR_GROUP = 2;
 
     private static final Pattern NORMAL_REGEX = Pattern
-            .compile("\\s*(([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9]))(T([0-9][0-9]):([0-9][0-9]):([0-9][0-9])(\\.([0-9][0-9][0-9]|[0-9][0-9]))?)?\\s*");
+            .compile("\\s*(([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9]))(T([0-9][0-9]):([0-9][0-9]):([0-9][0-9])(\\.([0-9]+))?)?\\s*");
 
     private static final int OLD_FORMAT_DAY_OF_MONTH_GROUP = 1;
 
@@ -85,9 +85,9 @@ public class FitsDate {
 
     private static final Pattern OLD_REGEX = Pattern.compile("\\s*([0-9][0-9])/([0-9][0-9])/([0-9][0-9])\\s*");
 
-    private static final int TWO_DIGIT_MILISECONDS_FACTOR = 10;
-
     private static final int YEAR_OFFSET = 1900;
+    
+    private static final int NB_DIGITS_MILLIS = 3;
 
     /**
      * @return the current date in FITS date format
@@ -204,11 +204,11 @@ public class FitsDate {
     private static int getMilliseconds(Matcher match, int groupIndex) {
         String value = match.group(groupIndex);
         if (value != null) {
-            int result = Integer.parseInt(value);
-            if (value.length() == 2) {
-                result = result * FitsDate.TWO_DIGIT_MILISECONDS_FACTOR;
+            if (value.length() > NB_DIGITS_MILLIS) {
+                value = value.substring(0, NB_DIGITS_MILLIS);
             }
-            return result;
+            value = String.format("%-3s", value).replace(' ', '0');
+            return Integer.parseInt(value);
         }
         return -1;
     }

--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -88,6 +88,8 @@ public class FitsDate {
     private static final int YEAR_OFFSET = 1900;
     
     private static final int NB_DIGITS_MILLIS = 3;
+    
+    private static final int POW_TEN = 10;
 
     /**
      * @return the current date in FITS date format
@@ -204,11 +206,12 @@ public class FitsDate {
     private static int getMilliseconds(Matcher match, int groupIndex) {
         String value = match.group(groupIndex);
         if (value != null) {
-            if (value.length() > NB_DIGITS_MILLIS) {
-                value = value.substring(0, NB_DIGITS_MILLIS);
-            }
             value = String.format("%-3s", value).replace(' ', '0');
-            return Integer.parseInt(value);
+            int num = Integer.parseInt(value);
+            if (value.length() > NB_DIGITS_MILLIS) {
+                num = (int) Math.round(num / Math.pow(POW_TEN, value.length() - NB_DIGITS_MILLIS));
+            }
+            return num;
         }
         return -1;
     }

--- a/src/test/java/nom/tam/fits/FitsDateTest.java
+++ b/src/test/java/nom/tam/fits/FitsDateTest.java
@@ -44,8 +44,9 @@ public class FitsDateTest {
         Assert.assertEquals(REF_TIME_MS+120, new FitsDate("2018-11-28T12:13:14.12").toDate().getTime());
         Assert.assertEquals(REF_TIME_MS+123, new FitsDate("2018-11-28T12:13:14.123").toDate().getTime());
         Assert.assertEquals(REF_TIME_MS+123, new FitsDate("2018-11-28T12:13:14.1234").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+124, new FitsDate("2018-11-28T12:13:14.1236").toDate().getTime());
         Assert.assertEquals(REF_TIME_MS+123, new FitsDate("2018-11-28T12:13:14.12345").toDate().getTime());
-        Assert.assertEquals(REF_TIME_MS+123, new FitsDate("2018-11-28T12:13:14.123456").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+124, new FitsDate("2018-11-28T12:13:14.123567").toDate().getTime());
         Assert.assertEquals(REF_TIME_MS+10, new FitsDate("2018-11-28T12:13:14.01").toDate().getTime());
         Assert.assertEquals(REF_TIME_MS+1, new FitsDate("2018-11-28T12:13:14.001").toDate().getTime());
         Assert.assertEquals(REF_TIME_MS, new FitsDate("2018-11-28T12:13:14.0001").toDate().getTime());

--- a/src/test/java/nom/tam/fits/FitsDateTest.java
+++ b/src/test/java/nom/tam/fits/FitsDateTest.java
@@ -1,0 +1,53 @@
+package nom.tam.fits;
+
+/*
+* #%L
+* nom.tam FITS library
+* %%
+* Copyright (C) 1996 - 2016 nom-tam-fits
+* %%
+* This is free and unencumbered software released into the public domain.
+* 
+* Anyone is free to copy, modify, publish, use, compile, sell, or
+* distribute this software, either in source code form or as a compiled
+* binary, for any purpose, commercial or non-commercial, and by any
+* means.
+* 
+* In jurisdictions that recognize copyright laws, the author or authors
+* of this software dedicate any and all copyright interest in the
+* software to the public domain. We make this dedication for the benefit
+* of the public at large and to the detriment of our heirs and
+* successors. We intend this dedication to be an overt act of
+* relinquishment in perpetuity of all present and future rights to this
+* software under copyright law.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+* OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+* ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+* #L%
+*/
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FitsDateTest {
+    private static long REF_TIME_MS = 1543407194000L;
+    
+    @Test
+    public void testIsoDateParsing() throws FitsException {
+        Assert.assertEquals(REF_TIME_MS, new FitsDate("2018-11-28T12:13:14").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+100, new FitsDate("2018-11-28T12:13:14.1").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+120, new FitsDate("2018-11-28T12:13:14.12").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+123, new FitsDate("2018-11-28T12:13:14.123").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+123, new FitsDate("2018-11-28T12:13:14.1234").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+123, new FitsDate("2018-11-28T12:13:14.12345").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+123, new FitsDate("2018-11-28T12:13:14.123456").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+10, new FitsDate("2018-11-28T12:13:14.01").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS+1, new FitsDate("2018-11-28T12:13:14.001").toDate().getTime());
+        Assert.assertEquals(REF_TIME_MS, new FitsDate("2018-11-28T12:13:14.0001").toDate().getTime());
+    }
+}


### PR DESCRIPTION
FitsDate does not manage correctly the sub-second part of a date.
The following strings are valid ISO-8601 dates that are not correctly parsed and generate an exception:
```
"2018-11-28T12:13:14.1"
"2018-11-28T12:13:14.1234"
"2018-11-28T12:13:14.123456"
```
This PR fixes this problem.