### PR TITLE
MAX_INTEGER_LENGTH is 11 not 10

### DIFF
--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -63,7 +63,7 @@ import nom.tam.util.RandomAccess;
  */
 public class AsciiTable extends AbstractTableData {
 
-    private static final int MAX_INTEGER_LENGTH = 10;
+    private static final int MAX_INTEGER_LENGTH = 11;
 
     private static final int FLOAT_MAX_LENGTH = 16;
 


### PR DESCRIPTION
Although the decimal representation of Integer.MAX_VALUE (2^31-1)
has 10 characters, it's 11 for Integer.MIN_VALUE (-2^31).
Prior to this fix, ASCII table columns with format I10 were
interpreted as 32-bit integers, which meant that large negative
values could not be read correctly.
Now I10 are read as 64-bit integers.