### PR TITLE
Updated for Java 8 (and more)

### DIFF
--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -665,9 +665,8 @@ public class AsciiTable extends AbstractTableData {
     public Object getElement(int row, int col) throws FitsException {
         if (this.data != null) {
             return singleElement(row, col);
-        } else {
-            return parseSingleElement(row, col);
         }
+        return parseSingleElement(row, col);
     }
 
     /**
@@ -707,9 +706,8 @@ public class AsciiTable extends AbstractTableData {
 
         if (this.data != null) {
             return singleRow(row);
-        } else {
-            return parseSingleRow(row);
-        }
+        } 
+        return parseSingleRow(row);
     }
 
     /**
@@ -745,9 +743,8 @@ public class AsciiTable extends AbstractTableData {
     public boolean isNull(int row, int col) {
         if (this.isNull != null) {
             return this.isNull[row * this.nFields + col];
-        } else {
-            return false;
         }
+        return false;
     }
 
     /**
@@ -771,12 +768,10 @@ public class AsciiTable extends AbstractTableData {
         if (extractElement(0, this.lengths[col], res, 0, 0, this.nulls[col])) {
             this.buffer = null;
             return res[0];
-
-        } else {
-
-            this.buffer = null;
-            return null;
-        }
+        } 
+        
+        this.buffer = null;
+        return null;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -43,7 +43,6 @@ import static nom.tam.fits.header.Standard.TZEROn;
 import static nom.tam.fits.header.Standard.XTENSION;
 
 import java.io.PrintStream;
-import java.util.logging.Logger;
 
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.Standard;
@@ -54,8 +53,6 @@ import nom.tam.util.Cursor;
  * FITS ASCII table header/data unit
  */
 public class AsciiTableHDU extends TableHDU<AsciiTable> {
-
-    private static final Logger LOG = Logger.getLogger(AsciiTableHDU.class.getName());
 
     /**
      * The standard column stems for an ASCII table. Note that TBCOL is not
@@ -119,9 +116,9 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
                 }
             }
             return true;
-        } else {
-            return false;
         }
+        
+        return false;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -574,10 +574,10 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
 
         if (newPrimary && !canBePrimary()) {
             throw new FitsException("Invalid attempt to make HDU of type:" + this.getClass().getName() + " primary.");
-        } else {
-            this.isPrimary = newPrimary;
-        }
-
+        } 
+        
+        this.isPrimary = newPrimary;
+       
         // Some FITS readers don't like the PCOUNT and GCOUNT keywords
         // in a primary array or they EXTEND keyword in extensions.
 
@@ -607,7 +607,9 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
             HeaderCard pcard = this.myHeader.findCard(PCOUNT);
             HeaderCard gcard = this.myHeader.findCard(GCOUNT);
 
-            this.myHeader.getCard(2 + naxis);
+            //this.myHeader.getCard(2 + naxis);
+            this.myHeader.findCard(NAXIS.key() + naxis);
+            
             if (pcard == null) {
                 this.myHeader.addValue(PCOUNT, pcount);
             }

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -213,7 +213,7 @@ public class BinaryTable extends AbstractTableData {
     /**
      * A list describing each of the columns in the table
      */
-    private List<ColumnDesc> columnList = new ArrayList<ColumnDesc>();
+    private List<ColumnDesc> columnList = new ArrayList<>();
 
     /**
      * The number of rows in the table.
@@ -263,7 +263,7 @@ public class BinaryTable extends AbstractTableData {
         ColumnTable<SaveState> tab = (ColumnTable<SaveState>) tabIn;
         // This will throw an error if this isn't the correct type.
         SaveState extra = tab.getExtraState();
-        this.columnList = new ArrayList<ColumnDesc>();
+        this.columnList = new ArrayList<>();
         for (ColumnDesc col : extra.columns) {
             ColumnDesc copy = (ColumnDesc) col.clone();
             copy.column = null;
@@ -1631,7 +1631,7 @@ public class BinaryTable extends AbstractTableData {
     }
 
     protected ColumnTable<SaveState> createColumnTable(Object[] arrCol, int[] sizes) throws TableException {
-        return new ColumnTable<SaveState>(arrCol, sizes);
+        return new ColumnTable<>(arrCol, sizes);
     }
 
     /**
@@ -1849,10 +1849,8 @@ public class BinaryTable extends AbstractTableData {
 
         if (Character.isDigit(tform.charAt(0))) {
             return initialNumber(tform);
-
-        } else {
-            return 1;
         }
+        return 1;
     }
 
     /**
@@ -1880,9 +1878,8 @@ public class BinaryTable extends AbstractTableData {
 
         if (tform.length() > ind + 1) {
             return tform.charAt(ind + 1);
-        } else {
-            return 0;
-        }
+        } 
+        return 0;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/FitsFactory.java
+++ b/src/main/java/nom/tam/fits/FitsFactory.java
@@ -126,7 +126,7 @@ public final class FitsFactory {
 
     private static final FitsSettings GLOBAL_SETTINGS = new FitsSettings();
 
-    private static final ThreadLocal<FitsSettings> LOCAL_SETTINGS = new ThreadLocal<FitsSettings>();
+    private static final ThreadLocal<FitsSettings> LOCAL_SETTINGS = new ThreadLocal<>();
 
     private static ExecutorService threadPool;
 

--- a/src/main/java/nom/tam/fits/FitsHeap.java
+++ b/src/main/java/nom/tam/fits/FitsHeap.java
@@ -182,8 +182,7 @@ public class FitsHeap implements FitsElement {
         expandHeap(size);
         ByteArrayOutputStream bo = new ByteArrayOutputStream(size);
 
-        try {
-            BufferedDataOutputStream o = new BufferedDataOutputStream(bo);
+        try (BufferedDataOutputStream o = new BufferedDataOutputStream(bo)) {
             o.writeArray(data);
             o.flush();
             o.close();

--- a/src/main/java/nom/tam/fits/FitsUtil.java
+++ b/src/main/java/nom/tam/fits/FitsUtil.java
@@ -195,9 +195,8 @@ public final class FitsUtil {
     public static long findOffset(Closeable o) {
         if (o instanceof RandomAccess) {
             return ((RandomAccess) o).getFilePointer();
-        } else {
-            return -1;
         }
+        return -1;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -104,7 +104,7 @@ public class Header implements FitsElement {
     /**
      * The actual header data stored as a HashedList of HeaderCard's.
      */
-    private final HashedList<HeaderCard> cards = new HashedList<HeaderCard>();
+    private final HashedList<HeaderCard> cards = new HashedList<>();
 
     /** Offset of this Header in the FITS file */
     private long fileOffset = -1;
@@ -638,9 +638,8 @@ public class Header implements FitsElement {
         HeaderCard card = findCard(key);
         if (card == null) {
             return null;
-        } else {
-            return card.toString();
         }
+        return card.toString();
     }
 
     /**
@@ -1187,9 +1186,8 @@ public class Header implements FitsElement {
     public HeaderCard nextCard() {
         if (cursor().hasNext()) {
             return cursor().next();
-        } else {
-            return null;
         }
+        return null;
     }
 
     /**
@@ -1562,7 +1560,7 @@ public class Header implements FitsElement {
         if (!COMMENT.key().equals(dup.getKey()) && !HISTORY.key().equals(dup.getKey()) && !CONTINUE.key().equals(dup.getKey()) && !dup.getKey().trim().isEmpty()) {
             LOG.log(Level.WARNING, "Multiple occurrences of key:" + dup.getKey());
             if (this.duplicates == null) {
-                this.duplicates = new ArrayList<HeaderCard>();
+                this.duplicates = new ArrayList<>();
             }
             this.duplicates.add(dup);
         }

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -67,8 +67,6 @@ public class HeaderCard implements CursorValue<String> {
 
     private static final int SPACE_NEEDED_FOR_EQUAL_AND_TWO_BLANKS = 3;
 
-    private static final double MAX_DECIMAL_VALUE_TO_USE_PLAIN_STRING = 1.0E16;
-
     private static final Logger LOG = Logger.getLogger(HeaderCard.class.getName());
 
     private static final String CONTINUE_CARD_PREFIX = CONTINUE.key() + "  '";
@@ -251,8 +249,8 @@ public class HeaderCard implements CursorValue<String> {
      * @see nom.tam.fits.header.hierarch.IHierarchKeyFormatter#setCaseSensitive(boolean)
      */
     public static HeaderCard create(String line) throws IllegalArgumentException {
-        try {
-            return new HeaderCard(stringToArrayInputStream(line));
+        try (ArrayDataInput in = stringToArrayInputStream(line)) {
+            return new HeaderCard(in);
         } catch (Exception e) {
             throw new IllegalArgumentException("card not legal", e);
         }
@@ -481,6 +479,7 @@ public class HeaderCard implements CursorValue<String> {
      * @throws TruncatedFileException
      *             is there was not a complete line available in the input.
      */
+    @SuppressWarnings("resource")
     private static String readOneHeaderLine(HeaderCardCountingArrayDataInput dis) throws IOException, TruncatedFileException {
         byte[] buffer = new byte[FITS_HEADER_CARD_SIZE];
         int len;

--- a/src/main/java/nom/tam/fits/HeaderCardBuilder.java
+++ b/src/main/java/nom/tam/fits/HeaderCardBuilder.java
@@ -181,7 +181,6 @@ public class HeaderCardBuilder {
         return this;
     }
 
-    
     /**
      * set the value of the current card.If the card did not exist yet the card
      * will be created.
@@ -209,7 +208,7 @@ public class HeaderCardBuilder {
         }
         return this;
     }
-    
+
     /**
      * set the value of the current card.If the card did not exist yet the card
      * will be created.

--- a/src/main/java/nom/tam/fits/HeaderCardBuilder.java
+++ b/src/main/java/nom/tam/fits/HeaderCardBuilder.java
@@ -32,6 +32,7 @@ package nom.tam.fits;
  */
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.Date;
 
@@ -164,6 +165,33 @@ public class HeaderCardBuilder {
      * @throws HeaderCardException
      *             if the card creation failed.
      */
+    public HeaderCardBuilder value(BigDecimal newValue) throws HeaderCardException {
+        final BigDecimal scaledValue;
+        if (scale >= 0) {
+            scaledValue = newValue.setScale(scale, RoundingMode.HALF_UP);
+        } else {
+            scaledValue = newValue;
+        }
+        if (this.card == null) {
+            this.card = new HeaderCard(this.key.key(), scaledValue, null);
+            this.header.addLine(this.card);
+        } else {
+            this.card.setValue(scaledValue);
+        }
+        return this;
+    }
+
+    
+    /**
+     * set the value of the current card.If the card did not exist yet the card
+     * will be created.
+     * 
+     * @param newValue
+     *            the new value to set.
+     * @return this
+     * @throws HeaderCardException
+     *             if the card creation failed.
+     */
     public HeaderCardBuilder value(double newValue) throws HeaderCardException {
         if (this.card == null) {
             if (scale >= 0) {
@@ -181,33 +209,7 @@ public class HeaderCardBuilder {
         }
         return this;
     }
-
-    /**
-     * set the value of the current card.If the card did not exist yet the card
-     * will be created.
-     * 
-     * @param newValue
-     *            the new value to set.
-     * @return this
-     * @throws HeaderCardException
-     *             if the card creation failed.
-     */
-    public HeaderCardBuilder value(BigDecimal newValue) throws HeaderCardException {
-        final BigDecimal scaledValue;
-        if (scale >= 0) {
-            scaledValue = newValue.setScale(scale, RoundingMode.HALF_UP);
-        } else {
-            scaledValue = newValue;
-        }
-        if (this.card == null) {
-            this.card = new HeaderCard(this.key.key(), scaledValue, null);
-            this.header.addLine(this.card);
-        } else {
-            this.card.setValue(scaledValue);
-        }
-        return this;
-    }
-
+    
     /**
      * set the value of the current card.If the card did not exist yet the card
      * will be created.
@@ -219,20 +221,7 @@ public class HeaderCardBuilder {
      *             if the card creation failed.
      */
     public HeaderCardBuilder value(float newValue) throws HeaderCardException {
-        if (this.card == null) {
-            if (scale >= 0) {
-                this.card = new HeaderCard(this.key.key(), newValue, scale, null);
-            } else {
-                this.card = new HeaderCard(this.key.key(), newValue, null);
-            }
-            this.header.addLine(this.card);
-        } else {
-            if (scale >= 0) {
-                this.card.setValue(newValue, scale);
-            } else {
-                this.card.setValue(newValue);
-            }
-        }
+        value(new BigDecimal(newValue, MathContext.DECIMAL32));
         return this;
     }
 

--- a/src/main/java/nom/tam/fits/HeaderOrder.java
+++ b/src/main/java/nom/tam/fits/HeaderOrder.java
@@ -51,6 +51,8 @@ import java.io.Serializable;
  */
 public class HeaderOrder implements java.util.Comparator<String>, Serializable {
 
+
+    
     /**
      * Serialization id.
      */
@@ -100,9 +102,8 @@ public class HeaderOrder implements java.util.Comparator<String>, Serializable {
             if (naxisNc2 > 0) {
                 if (naxisNc1 < naxisNc2) {
                     return -1;
-                } else {
-                    return 1;
                 }
+                return 1;
             }
             return -1;
         } else if (naxisNc2 > 0) {

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -345,6 +345,7 @@ public class ImageData extends Data {
         return this.byteSize;
     }
 
+    @SuppressWarnings("unchecked")
     protected ArrayDesc parseHeader(Header h) throws FitsException {
         int gCount = h.getIntValue(GCOUNT, 1);
         int pCount = h.getIntValue(PCOUNT, 0);
@@ -354,7 +355,7 @@ public class ImageData extends Data {
         int bitPix = h.getIntValue(BITPIX, 0);
         PrimitiveType<Buffer> primitivType = PrimitiveTypeHandler.valueOf(bitPix);
         if (primitivType == null) {
-            primitivType = PrimitiveTypeHandler.nearestValueOf(bitPix);
+            primitivType = (PrimitiveType<Buffer>) PrimitiveTypeHandler.nearestValueOf(bitPix);
             if (primitivType == PrimitiveTypes.UNKNOWN) {
                 throw new FitsException("illegal bitpix value " + bitPix);
             }

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -143,9 +143,8 @@ public class RandomGroupsData extends Data {
 
         if (this.dataArray != null && this.dataArray.length > 0) {
             return (ArrayFuncs.computeLSize(this.dataArray[0][0]) + ArrayFuncs.computeLSize(this.dataArray[0][1])) * this.dataArray.length;
-        } else {
-            return 0;
         }
+        return 0;
     }
 
     /** Read the RandomGroupsData */

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -42,7 +42,6 @@ import static nom.tam.fits.header.Standard.XTENSION;
 import static nom.tam.fits.header.Standard.XTENSION_IMAGE;
 
 import java.io.PrintStream;
-import java.util.logging.Logger;
 
 import nom.tam.util.ArrayFuncs;
 
@@ -57,14 +56,11 @@ import nom.tam.util.ArrayFuncs;
  */
 public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
 
-    private static final Logger LOG = Logger.getLogger(RandomGroupsHDU.class.getName());
-
     public static RandomGroupsData encapsulate(Object o) throws FitsException {
         if (o instanceof Object[][]) {
             return new RandomGroupsData((Object[][]) o);
-        } else {
-            throw new FitsException("Attempt to encapsulate invalid data in Random Group");
         }
+        throw new FitsException("Attempt to encapsulate invalid data in Random Group");
     }
 
     static Object[] generateSampleRow(Header h) throws FitsException {

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -5,8 +5,6 @@ import static nom.tam.fits.header.Standard.TFIELDS;
 import static nom.tam.fits.header.Standard.TFORMn;
 import static nom.tam.fits.header.Standard.TTYPEn;
 
-import java.util.logging.Logger;
-
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.IFitsHeader;
 
@@ -46,8 +44,6 @@ import nom.tam.fits.header.IFitsHeader;
  * interface.
  */
 public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> {
-
-    private static final Logger LOG = Logger.getLogger(TableHDU.class.getName());
 
     /**
      * Create the TableHDU. Note that this will normally only be invoked by

--- a/src/main/java/nom/tam/fits/compress/CloseIS.java
+++ b/src/main/java/nom/tam/fits/compress/CloseIS.java
@@ -63,6 +63,7 @@ public class CloseIS extends FilterInputStream {
 
     private final Process proc;
 
+    @SuppressWarnings("resource")
     public CloseIS(Process proc, final InputStream compressed) {
         super(new BufferedInputStream(proc.getInputStream(), CompressionManager.ONE_MEGABYTE));
         if (compressed == null) {
@@ -153,13 +154,11 @@ public class CloseIS extends FilterInputStream {
         if (exception != null || exitValue != 0) {
             if (errorText != null && !errorText.trim().isEmpty()) {
                 throw new IOException(errorText, exception);
-            } else {
-                if (exception == null) {
-                    throw new IOException("exit value was " + exitValue);
-                } else {
-                    throw exception;
-                }
             }
+            if (exception == null) {
+                throw new IOException("exit value was " + exitValue);
+            }
+            throw exception;
         }
     }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip2/GZip2Compressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip2/GZip2Compressor.java
@@ -43,7 +43,6 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import nom.tam.fits.compression.algorithm.gzip.GZipCompressor;
-import nom.tam.util.SafeClose;
 import nom.tam.util.type.PrimitiveTypes;
 
 public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T> {
@@ -160,14 +159,10 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
         byte[] pixelBytes = new byte[pixelDataLimit * this.primitiveSize];
         getPixel(pixelData, pixelBytes);
         pixelBytes = shuffle(pixelBytes);
-        GZIPOutputStream zip = null;
-        try {
-            zip = createGZipOutputStream(pixelDataLimit, compressed);
+        try (GZIPOutputStream zip = createGZipOutputStream(pixelDataLimit, compressed)) {
             zip.write(pixelBytes, 0, pixelBytes.length);
         } catch (IOException e) {
             throw new IllegalStateException("could not gzip data", e);
-        } finally {
-            SafeClose.close(zip);
         }
         return true;
     }
@@ -176,9 +171,7 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
     public void decompress(ByteBuffer compressed, T pixelData) {
         int pixelDataLimit = pixelData.limit();
         byte[] pixelBytes = new byte[pixelDataLimit * this.primitiveSize];
-        GZIPInputStream zip = null;
-        try {
-            zip = createGZipInputStream(compressed);
+        try (GZIPInputStream zip = createGZipInputStream(compressed)) {
             int count = 0;
             int offset = 0;
             while (offset < pixelBytes.length && count >= 0) {
@@ -189,8 +182,6 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
             }
         } catch (IOException e) {
             throw new IllegalStateException("could not gunzip data", e);
-        } finally {
-            SafeClose.close(zip);
         }
         pixelBytes = unshuffle(pixelBytes);
         setPixel(pixelData, pixelBytes);

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HDecompress.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HDecompress.java
@@ -700,9 +700,8 @@ public class HDecompress {
         c = inputBit(infile) | c << 1;
         if (c == N62) {
             return 0;
-        } else {
-            return N14;
         }
+        return N14;
     }
 
     private int inputNbits(ByteBuffer infile, int n) {

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
@@ -141,7 +141,6 @@ public class Quantize {
      *            check for null values, if true
      * @param nullvalue
      *            value of null pixels, if nullcheck is true
-     * @return error status
      */
     private void calculateNoise(double[] arrayIn, int nx, int ny) {
         DoubleArrayPointer array = new DoubleArrayPointer(arrayIn);
@@ -283,15 +282,14 @@ public class Quantize {
             for (int index = 0; index < nx; index++) {
                 if (isNull(array.get(index))) {
                     continue;
-                } else {
-                    if (array.get(index) < this.xminval) {
-                        this.xminval = array.get(index);
-                    }
-                    if (array.get(index) > this.xmaxval) {
-                        this.xmaxval = array.get(index);
-                    }
-                    ngoodpix++;
                 }
+                if (array.get(index) < this.xminval) {
+                    this.xminval = array.get(index);
+                }
+                if (array.get(index) > this.xmaxval) {
+                    this.xmaxval = array.get(index);
+                }
+                ngoodpix++;
             }
             setNoiseResult(ngoodpix);
             return true;

--- a/src/main/java/nom/tam/fits/compression/provider/CompressorControlNameComputer.java
+++ b/src/main/java/nom/tam/fits/compression/provider/CompressorControlNameComputer.java
@@ -90,9 +90,8 @@ public class CompressorControlNameComputer {
                     Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_1.equalsIgnoreCase(quantAlgorithm) || //
                     Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_2.equalsIgnoreCase(quantAlgorithm)) {
                 return "Quant";
-            } else {
-                return "Unknown";
             }
+            return "Unknown";
         }
         return "";
     }

--- a/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
+++ b/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
@@ -287,6 +287,9 @@ public class CompressorProvider implements ICompressorProvider {
                 }
             }
         }
+        if (defaultProvider == null) {
+            return null;
+        }
         return defaultProvider.createCompressorControl(quantAlgorithm, compressionAlgorithm, baseType);
     }
 
@@ -300,9 +303,8 @@ public class CompressorProvider implements ICompressorProvider {
                 if (clazz.length > 1) {
                     Class<?> parametersClass = clazz[1];
                     return new TileCompressorControl(compressorClass, parametersClass);
-                } else {
-                    return new TileCompressorControl(compressorClass);
                 }
+                return new TileCompressorControl(compressorClass);
             }
         }
         return null;

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
@@ -79,9 +79,8 @@ public class HeaderAccess implements IHeaderAccess {
         if (this.builder == null) {
             this.builder = this.header.card(key);
             return this.builder;
-        } else {
-            return this.builder.card(key);
         }
+        return this.builder.card(key);
     }
 
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
@@ -64,24 +64,22 @@ public abstract class CompressColumnParameter<T, OPTION> extends CompressParamet
     protected final T initializedColumn() {
         if (this.original != null) {
             return this.original.initializedColumn();
-        } else {
-            final int arraySize = this.size;
-            final Class<T> arrayClass = this.clazz;
-            synchronized (this) {
-                if (this.column == null) {
-                    this.column = arrayClass.cast(Array.newInstance(arrayClass.getComponentType(), arraySize));
-                }
-            }
-            return this.column;
         }
+        final int arraySize = this.size;
+        final Class<T> arrayClass = this.clazz;
+        synchronized (this) {
+            if (this.column == null) {
+                this.column = arrayClass.cast(Array.newInstance(arrayClass.getComponentType(), arraySize));
+            }
+        }
+        return this.column;
     }
 
     protected final T originalColumn() {
         if (this.original != null) {
             return this.original.originalColumn();
-        } else {
-            return this.column;
         }
+        return this.column;
     }
 
     public void setOriginal(CompressColumnParameter<T, OPTION> value) {

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
@@ -80,10 +80,9 @@ public abstract class QuantizeParameters extends CompressParameters {
                 this.quantz,
                 this.blank
             };
-        } else {
-            return new ICompressHeaderParameter[]{
-                this.quantz
-            };
         }
+        return new ICompressHeaderParameter[]{
+            this.quantz
+        };
     }
 }

--- a/src/main/java/nom/tam/fits/header/GenericKey.java
+++ b/src/main/java/nom/tam/fits/header/GenericKey.java
@@ -54,7 +54,7 @@ public final class GenericKey {
     private static final Map<String, IFitsHeader> STANDARD_KEYS;
 
     static {
-        Map<String, IFitsHeader> headers = new HashMap<String, IFitsHeader>();
+        Map<String, IFitsHeader> headers = new HashMap<>();
         for (IFitsHeader key : Standard.values()) {
             headers.put(key.key(), key);
         }

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -611,7 +611,7 @@ public enum Standard implements IFitsHeader {
 
     public static final IFitsHeader NAXIS2 = NAXISn.n(2);
 
-    private static final ThreadLocal<Class<?>> COMMENT_CONTEXT = new ThreadLocal<Class<?>>();
+    private static final ThreadLocal<Class<?>> COMMENT_CONTEXT = new ThreadLocal<>();
 
     /**
      * The value of the XTENSION keword in case of a binary table.
@@ -697,9 +697,8 @@ public enum Standard implements IFitsHeader {
                 String foundcommentReplacement = commentReplacement.getComment();
                 if (foundcommentReplacement == null) {
                     return comment();
-                } else {
-                    return foundcommentReplacement;
                 }
+                return foundcommentReplacement;
             }
         }
         return null;

--- a/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
@@ -40,7 +40,6 @@ import static nom.tam.util.FitsIO.BYTE_4_OF_LONG_MASK;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import nom.tam.fits.BasicHDU;
 import nom.tam.fits.FitsException;
@@ -52,11 +51,6 @@ import nom.tam.util.FitsIO;
 public final class FitsCheckSum {
 
     private static final int CHECKSUM_STRING_SIZE = 16;
-
-    /**
-     * logger to log to.
-     */
-    private static final Logger LOG = Logger.getLogger(FitsCheckSum.class.getName());
 
     private static final int CHECKSUM_BLOCK_SIZE = 4;
 

--- a/src/main/java/nom/tam/fits/utilities/FitsCopy.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCopy.java
@@ -42,25 +42,27 @@ public final class FitsCopy {
 
     public static void main(String[] args) throws Exception {
         String file = args[0];
-        Fits f = new Fits(file);
-        int i = 0;
-        BasicHDU<?> h;
+        try (Fits f = new Fits(file)) {
+            int i = 0;
+            BasicHDU<?> h;
 
-        do {
-            h = f.readHDU();
-            if (h != null) {
-                if (i == 0) {
-                    System.out.println("\n\nPrimary header:\n");
-                } else {
-                    System.out.println("\n\nExtension " + i + ":\n");
+            do {
+                h = f.readHDU();
+                if (h != null) {
+                    if (i == 0) {
+                        System.out.println("\n\nPrimary header:\n");
+                    } else {
+                        System.out.println("\n\nExtension " + i + ":\n");
+                    }
+                    i += 1;
+                    h.info(System.out);
                 }
-                i += 1;
-                h.info(System.out);
+            } while (h != null);
+            f.close();
+            try (BufferedFile bf = new BufferedFile(args[1], "rw")) {
+                f.write(bf);
+                bf.close();
             }
-        } while (h != null);
-        f.close();
-        BufferedFile bf = new BufferedFile(args[1], "rw");
-        f.write(bf);
-        bf.close();
+        }
     }
 }

--- a/src/main/java/nom/tam/fits/utilities/FitsReader.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsReader.java
@@ -43,22 +43,23 @@ public final class FitsReader {
 
         String file = args[0];
 
-        Fits f = new Fits(file);
-        int i = 0;
-        BasicHDU<?> h;
+        try (Fits f = new Fits(file)) {
+            int i = 0;
+            BasicHDU<?> h;
 
-        do {
-            h = f.readHDU();
-            if (h != null) {
-                if (i == 0) {
-                    System.out.println("\n\nPrimary header:\n");
-                } else {
-                    System.out.println("\n\nExtension " + i + ":\n");
+            do {
+                h = f.readHDU();
+                if (h != null) {
+                    if (i == 0) {
+                        System.out.println("\n\nPrimary header:\n");
+                    } else {
+                        System.out.println("\n\nExtension " + i + ":\n");
+                    }
+                    i += 1;
+                    h.info(System.out);
                 }
-                i += 1;
-                h.info(System.out);
-            }
-        } while (h != null);
-        f.close();
+            } while (h != null);
+            f.close();
+        }
     }
 }

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileCompressor.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileCompressor.java
@@ -40,7 +40,6 @@ import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.BufferedDataOutputStream;
 import nom.tam.util.ByteBufferOutputStream;
 import nom.tam.util.ColumnTable;
-import nom.tam.util.SafeClose;
 
 public class BinaryTableTileCompressor extends BinaryTableTile {
 
@@ -62,13 +61,10 @@ public class BinaryTableTileCompressor extends BinaryTableTile {
     @Override
     public void run() {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[getUncompressedSizeInBytes()]);
-        ArrayDataOutput os = new BufferedDataOutputStream(new ByteBufferOutputStream(buffer));
-        try {
+        try (ArrayDataOutput os = new BufferedDataOutputStream(new ByteBufferOutputStream(buffer))) {
             this.data.write(os, this.rowStart, this.rowEnd, this.column);
         } catch (IOException e) {
             throw new IllegalStateException("could not write compressed data", e);
-        } finally {
-            SafeClose.close(os);
         }
         buffer.rewind();
         int spaceForCompression = getUncompressedSizeInBytes();

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
@@ -68,9 +68,9 @@ public class CompressedImageHDU extends BinaryTableHDU {
      */
     static final List<IFitsHeader> TABLE_COLUMN_KEYS = Collections.unmodifiableList(Arrays.asList(binaryTableColumnKeyStems()));
 
-    static final Map<IFitsHeader, BackupRestoreUnCompressedHeaderCard> COMPRESSED_HEADER_MAPPING = new HashMap<IFitsHeader, BackupRestoreUnCompressedHeaderCard>();
+    static final Map<IFitsHeader, BackupRestoreUnCompressedHeaderCard> COMPRESSED_HEADER_MAPPING = new HashMap<>();
 
-    static final Map<IFitsHeader, BackupRestoreUnCompressedHeaderCard> UNCOMPRESSED_HEADER_MAPPING = new HashMap<IFitsHeader, BackupRestoreUnCompressedHeaderCard>();
+    static final Map<IFitsHeader, BackupRestoreUnCompressedHeaderCard> UNCOMPRESSED_HEADER_MAPPING = new HashMap<>();
 
     /**
      * Prepare a compressed image hdu for the specified image. the tile axis

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
@@ -93,7 +93,7 @@ public class CompressedTableData extends BinaryTable {
         if (this.columnCompressionAlgorithms.length < ncols) {
             this.columnCompressionAlgorithms = Arrays.copyOfRange(this.columnCompressionAlgorithms, 0, ncols);
         }
-        this.tiles = new ArrayList<BinaryTableTile>();
+        this.tiles = new ArrayList<>();
         for (int column = 0; column < ncols; column++) {
             addByteVaryingColumn();
             int tileIndex = 1;
@@ -114,7 +114,7 @@ public class CompressedTableData extends BinaryTable {
         int nrows = targetHeader.getIntValue(Standard.NAXIS2);
         int ncols = compressedHeader.getIntValue(TFIELDS);
         this.rowsPerTile = compressedHeader.getIntValue(Compression.ZTILELEN, nrows);
-        this.tiles = new ArrayList<BinaryTableTile>();
+        this.tiles = new ArrayList<>();
         BinaryTable.createColumnDataFor(dataToFill);
         for (int column = 0; column < ncols; column++) {
             int tileIndex = 1;

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -298,12 +298,13 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void readBaseType(Header header) {
         if (getBaseType() == null) {
             int zBitPix = header.getIntValue(ZBITPIX);
             PrimitiveType<Buffer> primitiveType = PrimitiveTypeHandler.valueOf(zBitPix);
             if (primitiveType == null) {
-                primitiveType = PrimitiveTypeHandler.nearestValueOf(zBitPix);
+                primitiveType = (PrimitiveType<Buffer>) PrimitiveTypeHandler.nearestValueOf(zBitPix);
                 if (primitiveType == PrimitiveTypes.UNKNOWN) {
                     throw new IllegalArgumentException("illegal value for zbitpix " + zBitPix);
                 }

--- a/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
@@ -65,13 +65,12 @@ public class AbstractNullPixelMask {
     public byte[] getMaskBytes() {
         if (this.mask == null) {
             return EMPTY_BYTE_ARRAY;
-        } else {
-            int size = this.mask.position();
-            byte[] result = new byte[size];
-            this.mask.rewind();
-            this.mask.get(result);
-            return result;
         }
+        int size = this.mask.position();
+        byte[] result = new byte[size];
+        this.mask.rewind();
+        this.mask.get(result);
+        return result;
     }
 
     public void setMask(ByteBuffer mask) {

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferFactory.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferFactory.java
@@ -40,9 +40,8 @@ public final class TileBufferFactory {
     public static TileBuffer createTileBuffer(PrimitiveType<Buffer> baseType, int dataOffset, int imageWidth, int width, int height) {
         if (imageWidth > width) {
             return new TileBufferColumnBased(baseType, dataOffset, imageWidth, width, height);
-        } else {
-            return new TileBufferRowBased(baseType, dataOffset, width, height);
         }
+        return new TileBufferRowBased(baseType, dataOffset, width, height);
     }
 
     private TileBufferFactory() {

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -91,14 +91,12 @@ public final class ArrayFuncs {
                 }
             }
             return size;
-        } else {
-            PrimitiveType<?> primType = PrimitiveTypeHandler.valueOf(o.getClass());
-            if (primType.individualSize()) {
-                return primType.size(o);
-            } else {
-                return primType.size();
-            }
         }
+        PrimitiveType<?> primType = PrimitiveTypeHandler.valueOf(o.getClass());
+        if (primType.individualSize()) {
+            return primType.size(o);
+        }
+        return primType.size();
     }
 
     /**
@@ -150,9 +148,8 @@ public final class ArrayFuncs {
     public static Object convertArray(Object array, Class<?> newType, boolean reuse) {
         if (getBaseClass(array) == newType && reuse) {
             return array;
-        } else {
-            return convertArray(array, newType);
         }
+        return convertArray(array, newType);
     }
 
     /**
@@ -248,19 +245,18 @@ public final class ArrayFuncs {
             Object result = Array.newInstance(o.getClass().getComponentType(), length);
             System.arraycopy(o, 0, result, 0, length);
             return result;
-        } else {
-            // Get the base type.
-            Class<?> baseClass = getBaseClass(o);
-            // Allocate the array but make all but the first dimension 0.
-            int[] dims = getDimensions(o);
-            Arrays.fill(dims, 1, dims.length, 0);
-            Object copy = ArrayFuncs.newInstance(baseClass, dims);
-            // Now fill in the next level down by recursion.
-            for (int i = 0; i < dims[0]; i++) {
-                Array.set(copy, i, deepClone(Array.get(o, i)));
-            }
-            return copy;
         }
+        // Get the base type.
+        Class<?> baseClass = getBaseClass(o);
+        // Allocate the array but make all but the first dimension 0.
+        int[] dims = getDimensions(o);
+        Arrays.fill(dims, 1, dims.length, 0);
+        Object copy = ArrayFuncs.newInstance(baseClass, dims);
+        // Now fill in the next level down by recursion.
+        for (int i = 0; i < dims[0]; i++) {
+            Array.set(copy, i, deepClone(Array.get(o, i)));
+        }
+        return copy;
     }
 
     /**
@@ -327,9 +323,8 @@ public final class ArrayFuncs {
     public static Object getBaseArray(Object o) {
         if (o.getClass().getComponentType().isArray()) {
             return getBaseArray(Array.get(o, 0));
-        } else {
-            return o;
         }
+        return o;
     }
 
     /**

--- a/src/main/java/nom/tam/util/BufferDecoder.java
+++ b/src/main/java/nom/tam/util/BufferDecoder.java
@@ -147,28 +147,25 @@ public abstract class BufferDecoder {
                 total += get;
                 continue;
 
-            } else {
-
-                // This might be pretty long, but we know that the
-                // old dataBuffer.buffer is exhausted.
-                try {
-                    if (len > this.sharedBuffer.buffer.length) {
-                        checkBuffer(this.sharedBuffer.buffer.length);
-                    } else {
-                        checkBuffer(len);
-                    }
-                } catch (EOFException e) {
-                    if (this.sharedBuffer.bufferLength > 0) {
-                        System.arraycopy(this.sharedBuffer.buffer, 0, buf, offset, this.sharedBuffer.bufferLength);
-                        total += this.sharedBuffer.bufferLength;
-                        this.sharedBuffer.bufferLength = 0;
-                    }
-                    if (total == 0) {
-                        throw e;
-                    } else {
-                        return total;
-                    }
+            }
+            // This might be pretty long, but we know that the
+            // old dataBuffer.buffer is exhausted.
+            try {
+                if (len > this.sharedBuffer.buffer.length) {
+                    checkBuffer(this.sharedBuffer.buffer.length);
+                } else {
+                    checkBuffer(len);
                 }
+            } catch (EOFException e) {
+                if (this.sharedBuffer.bufferLength > 0) {
+                    System.arraycopy(this.sharedBuffer.buffer, 0, buf, offset, this.sharedBuffer.bufferLength);
+                    total += this.sharedBuffer.bufferLength;
+                    this.sharedBuffer.bufferLength = 0;
+                }
+                if (total == 0) {
+                    throw e;
+                }
+                return total;
             }
         }
 

--- a/src/main/java/nom/tam/util/BufferedDataInputStream.java
+++ b/src/main/java/nom/tam/util/BufferedDataInputStream.java
@@ -107,9 +107,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
      * Skip the requested number of bytes. This differs from the skip call in
      * that it takes an long argument and will throw an end of file if the full
      * number of bytes cannot be skipped.
-     * 
-     * @param toSkip
-     *            The number of bytes to skip.
+     *
      */
     private byte[] skipBuf = null;
 
@@ -155,9 +153,8 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
 
         if (i == start) {
             throw e;
-        } else {
-            return (i - start) * length;
         }
+        return (i - start) * length;
     }
 
     @Override
@@ -181,14 +178,12 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
             if (xlen <= 0) {
                 if (total == 0) {
                     throw new EOFException();
-                } else {
-                    return total;
                 }
-            } else {
-                remainingToRead -= xlen;
-                total += xlen;
-                currentOffset += xlen;
+                return total;
             }
+            remainingToRead -= xlen;
+            total += xlen;
+            currentOffset += xlen;
         }
         return total;
     }

--- a/src/main/java/nom/tam/util/BufferedDataOutputStream.java
+++ b/src/main/java/nom/tam/util/BufferedDataOutputStream.java
@@ -276,14 +276,15 @@ public class BufferedDataOutputStream extends BufferedOutputStream implements Ar
     @Override
     public void writeUTF(String s) throws IOException {
         // Punt on this one and use standard routines.
-        DataOutputStream d = new DataOutputStream(this) {
+        try (DataOutputStream d = new DataOutputStream(this) {
 
             @Override
             public void close() throws IOException {
                 flush();
             }
-        };
-        d.writeUTF(s);
-        d.close();
+        }) {
+            d.writeUTF(s);
+            d.close();
+        }
     }
 }

--- a/src/main/java/nom/tam/util/BufferedFile.java
+++ b/src/main/java/nom/tam/util/BufferedFile.java
@@ -102,9 +102,8 @@ public class BufferedFile implements ArrayDataOutput, RandomAccess {
         protected int eofCheck(EOFException e, int start, int index, int length) throws EOFException {
             if (start == index) {
                 throw e;
-            } else {
-                return (index - start) * length;
             }
+            return (index - start) * length;
         }
     };
 

--- a/src/main/java/nom/tam/util/ByteFormatter.java
+++ b/src/main/java/nom/tam/util/ByteFormatter.java
@@ -279,30 +279,28 @@ public final class ByteFormatter {
 
         if (simple) {
             return Math.abs(mantissa(mant, lmant, exp, simple, buf, off, len));
-        } else {
-            off = mantissa(mant, lmant, 0, simple, buf, off, len - lexp - 1);
-            if (off < 0) {
-                off = -off;
-                len -= off;
-                // Handle the expanded exponent by filling
-                if (exp == MAXIMUM_SINGLE_DIGIT_INTEGER || exp == MAXIMUM_TWO_DIGIT_INTEGER) {
-                    // Cannot fit...
-                    if (off + len == minSize) {
-                        truncationFiller(buf, off, len);
-                        return off + len;
-                    } else {
-                        // Steal a character from the mantissa.
-                        off--;
-                    }
-                }
-                exp++;
-                lexp = format(exp, this.tbuf2, 0, ByteFormatter.TEMP_BUFFER_SIZE);
-            }
-            buf[off] = (byte) 'E';
-            off++;
-            System.arraycopy(this.tbuf2, 0, buf, off, lexp);
-            return off + lexp;
         }
+        off = mantissa(mant, lmant, 0, simple, buf, off, len - lexp - 1);
+        if (off < 0) {
+            off = -off;
+            len -= off;
+            // Handle the expanded exponent by filling
+            if (exp == MAXIMUM_SINGLE_DIGIT_INTEGER || exp == MAXIMUM_TWO_DIGIT_INTEGER) {
+                // Cannot fit...
+                if (off + len == minSize) {
+                    truncationFiller(buf, off, len);
+                    return off + len;
+                }
+                // Steal a character from the mantissa.
+                off--;
+            }
+            exp++;
+            lexp = format(exp, this.tbuf2, 0, ByteFormatter.TEMP_BUFFER_SIZE);
+        }
+        buf[off] = (byte) 'E';
+        off++;
+        System.arraycopy(this.tbuf2, 0, buf, off, lexp);
+        return off + lexp;
     }
 
     /**
@@ -401,9 +399,8 @@ public final class ByteFormatter {
         } else if (Double.isInfinite(val)) {
             if (val > 0) {
                 return format(INFINITY, buf, off, len);
-            } else {
-                return format(NEGATIVE_INFINITY, buf, off, len);
             }
+            return format(NEGATIVE_INFINITY, buf, off, len);
         }
 
         int power = (int) (Math.log(pos) * ByteFormatter.I_LOG_10);
@@ -511,9 +508,8 @@ public final class ByteFormatter {
         } else if (Float.isInfinite(val)) {
             if (val > 0) {
                 return format("Infinity", buf, off, len);
-            } else {
-                return format("-Infinity", buf, off, len);
             }
+            return format("-Infinity", buf, off, len);
         }
 
         int power = (int) Math.floor(Math.log(pos) * ByteFormatter.I_LOG_10);
@@ -597,10 +593,9 @@ public final class ByteFormatter {
         if (val == Integer.MIN_VALUE) {
             if (len > ByteFormatter.NUMBER_BASE) {
                 return format("-2147483648", buf, off, len);
-            } else {
-                truncationFiller(buf, off, len);
-                return off + len;
             }
+            truncationFiller(buf, off, len);
+            return off + len;
         }
 
         int pos = Math.abs(val);
@@ -677,10 +672,9 @@ public final class ByteFormatter {
         if (val == Long.MIN_VALUE) {
             if (len > MAX_LONG_LENGTH) {
                 return format("-9223372036854775808", buf, off, len);
-            } else {
-                truncationFiller(buf, off, len);
-                return off + len;
             }
+            truncationFiller(buf, off, len);
+            return off + len;
         }
         long pos = Math.abs(val);
         // First count the number of characters in the result.

--- a/src/main/java/nom/tam/util/ColumnTable.java
+++ b/src/main/java/nom/tam/util/ColumnTable.java
@@ -259,7 +259,7 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.doublePointers[index], arrOffset, size);
             }
         };
-        Map<PrimitiveType<?>, PointerAccess<?>> pointerAccess = new HashMap<PrimitiveType<?>, PointerAccess<?>>();
+        Map<PrimitiveType<?>, PointerAccess<?>> pointerAccess = new HashMap<>();
         pointerAccess.put(PrimitiveTypes.BYTE, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.BYTE.type()]);
         pointerAccess.put(PrimitiveTypes.BOOLEAN, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.BOOLEAN.type()]);
         pointerAccess.put(PrimitiveTypes.CHAR, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.CHAR.type()]);
@@ -380,9 +380,8 @@ public class ColumnTable<T> implements DataTable {
         PointerAccess<Object> accessor = selectPointerAccessor(data);
         if (accessor == null) {
             throw new TableException("Invalid type for added column:" + data.getClass().getComponentType());
-        } else {
-            accessor.set(this, extendArray(accessor.get(this), data));
         }
+        accessor.set(this, extendArray(accessor.get(this), data));
     }
 
     @SuppressWarnings("unchecked")
@@ -460,7 +459,6 @@ public class ColumnTable<T> implements DataTable {
 
         // Now check that that we fill up all of the arrays exactly.
         int ratio = 0;
-        int newRowSize = 0;
 
         this.types = new char[newArrays.length];
         this.bases = new Class[newArrays.length];
@@ -471,7 +469,6 @@ public class ColumnTable<T> implements DataTable {
 
             ratio = checkColumnConsistency(newArrays[i], classname, ratio, newSizes[i]);
 
-            newRowSize += newSizes[i] * ArrayFuncs.getBaseLength(newArrays[i]);
             this.types[i] = classname.charAt(1);
             this.bases[i] = ArrayFuncs.getBaseClass(newArrays[i]);
         }
@@ -509,14 +506,13 @@ public class ColumnTable<T> implements DataTable {
         }
         if (thisRatio > 0) {
             return thisRatio;
-        } else {
-            return ratio;
         }
+        return ratio;
 
     }
 
     public ColumnTable<T> copy() throws TableException {
-        return new ColumnTable<T>((Object[]) ArrayFuncs.deepClone(this.arrays), this.sizes.clone());
+        return new ColumnTable<>((Object[]) ArrayFuncs.deepClone(this.arrays), this.sizes.clone());
     }
 
     /**

--- a/src/main/java/nom/tam/util/HashedList.java
+++ b/src/main/java/nom/tam/util/HashedList.java
@@ -128,11 +128,10 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
         public VALUE next() {
             if (this.current < 0 || this.current >= HashedList.this.ordered.size()) {
                 throw new NoSuchElementException("Outside list");
-            } else {
-                VALUE entry = HashedList.this.ordered.get(this.current);
-                this.current++;
-                return entry;
             }
+            VALUE entry = HashedList.this.ordered.get(this.current);
+            this.current++;
+            return entry;
         }
 
         @Override
@@ -170,10 +169,10 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
     }
 
     /** An ordered list of the keys */
-    private final ArrayList<VALUE> ordered = new ArrayList<VALUE>();
+    private final ArrayList<VALUE> ordered = new ArrayList<>();
 
     /** The key value pairs */
-    private final HashMap<String, VALUE> keyed = new HashMap<String, VALUE>();
+    private final HashMap<String, VALUE> keyed = new HashMap<>();
     
     /**
      * This maintains a 'current' position in the list...
@@ -354,9 +353,8 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
     public Cursor<String, VALUE> iterator(int n) {
         if (n >= 0 && n <= this.ordered.size()) {
             return new HashedListIterator(n);
-        } else {
-            throw new NoSuchElementException("Invalid index for iterator:" + n);
         }
+        throw new NoSuchElementException("Invalid index for iterator:" + n);
     }
     
     
@@ -383,9 +381,8 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
         VALUE entry = this.keyed.get(key);
         if (entry != null) {
             return new HashedListIterator(indexOf(entry));
-        } else {
-            throw new NoSuchElementException("Unknown key for iterator:" + key);
         }
+        throw new NoSuchElementException("Unknown key for iterator:" + key);
     }
 
     /**

--- a/src/main/java/nom/tam/util/array/MultiArrayCopyFactory.java
+++ b/src/main/java/nom/tam/util/array/MultiArrayCopyFactory.java
@@ -554,9 +554,9 @@ public class MultiArrayCopyFactory {
     private static final MultiArrayCopyFactory GENERIC = new Generic();
 
     static {
-        Map<Class<?>, Map<Class<?>, MultiArrayCopyFactory>> factories = new HashMap<Class<?>, Map<Class<?>, MultiArrayCopyFactory>>();
+        Map<Class<?>, Map<Class<?>, MultiArrayCopyFactory>> factories = new HashMap<>();
 
-        Map<Class<?>, MultiArrayCopyFactory> byteMap = new HashMap<Class<?>, MultiArrayCopyFactory>();
+        Map<Class<?>, MultiArrayCopyFactory> byteMap = new HashMap<>();
         byteMap.put(byte.class, new MultiArrayCopyFactory());
         byteMap.put(char.class, new ByteToChar());
         byteMap.put(short.class, new ByteToShort());
@@ -566,7 +566,7 @@ public class MultiArrayCopyFactory {
         byteMap.put(double.class, new ByteToDouble());
         factories.put(byte.class, Collections.unmodifiableMap(byteMap));
 
-        Map<Class<?>, MultiArrayCopyFactory> charMap = new HashMap<Class<?>, MultiArrayCopyFactory>();
+        Map<Class<?>, MultiArrayCopyFactory> charMap = new HashMap<>();
         charMap.put(byte.class, new CharToByte());
         charMap.put(char.class, new MultiArrayCopyFactory());
         charMap.put(short.class, new CharToShort());
@@ -576,7 +576,7 @@ public class MultiArrayCopyFactory {
         charMap.put(double.class, new CharToDouble());
         factories.put(char.class, Collections.unmodifiableMap(charMap));
 
-        Map<Class<?>, MultiArrayCopyFactory> shortMap = new HashMap<Class<?>, MultiArrayCopyFactory>();
+        Map<Class<?>, MultiArrayCopyFactory> shortMap = new HashMap<>();
         shortMap.put(byte.class, new ShortToByte());
         shortMap.put(char.class, new ShortToChar());
         shortMap.put(short.class, new MultiArrayCopyFactory());
@@ -586,7 +586,7 @@ public class MultiArrayCopyFactory {
         shortMap.put(double.class, new ShortToDouble());
         factories.put(short.class, Collections.unmodifiableMap(shortMap));
 
-        Map<Class<?>, MultiArrayCopyFactory> intMap = new HashMap<Class<?>, MultiArrayCopyFactory>();
+        Map<Class<?>, MultiArrayCopyFactory> intMap = new HashMap<>();
         intMap.put(byte.class, new IntToByte());
         intMap.put(char.class, new IntToChar());
         intMap.put(short.class, new IntToShort());
@@ -596,7 +596,7 @@ public class MultiArrayCopyFactory {
         intMap.put(double.class, new IntToDouble());
         factories.put(int.class, Collections.unmodifiableMap(intMap));
 
-        Map<Class<?>, MultiArrayCopyFactory> longMap = new HashMap<Class<?>, MultiArrayCopyFactory>();
+        Map<Class<?>, MultiArrayCopyFactory> longMap = new HashMap<>();
         longMap.put(byte.class, new LongToByte());
         longMap.put(char.class, new LongToChar());
         longMap.put(short.class, new LongToShort());
@@ -606,7 +606,7 @@ public class MultiArrayCopyFactory {
         longMap.put(double.class, new LongToDouble());
         factories.put(long.class, Collections.unmodifiableMap(longMap));
 
-        Map<Class<?>, MultiArrayCopyFactory> floatMap = new HashMap<Class<?>, MultiArrayCopyFactory>();
+        Map<Class<?>, MultiArrayCopyFactory> floatMap = new HashMap<>();
         floatMap.put(byte.class, new FloatToByte());
         floatMap.put(char.class, new FloatToChar());
         floatMap.put(short.class, new FloatToShort());
@@ -616,7 +616,7 @@ public class MultiArrayCopyFactory {
         floatMap.put(double.class, new FloatToDouble());
         factories.put(float.class, Collections.unmodifiableMap(floatMap));
 
-        Map<Class<?>, MultiArrayCopyFactory> doubleMap = new HashMap<Class<?>, MultiArrayCopyFactory>();
+        Map<Class<?>, MultiArrayCopyFactory> doubleMap = new HashMap<>();
         doubleMap.put(byte.class, new DoubleToByte());
         doubleMap.put(char.class, new DoubleToChar());
         doubleMap.put(short.class, new DoubleToShort());

--- a/src/main/java/nom/tam/util/array/MultiArrayIterator.java
+++ b/src/main/java/nom/tam/util/array/MultiArrayIterator.java
@@ -61,20 +61,18 @@ public class MultiArrayIterator {
         if (this.baseIsNoSubArray) {
             if (this.baseNextCalled) {
                 return null;
-            } else {
-                this.baseNextCalled = true;
-                return this.baseArray;
             }
-        } else {
-            Object result = null;
-            while (result == null || Array.getLength(result) == 0) {
-                result = this.pointer.next();
-                if (result == MultiArrayPointer.END) {
-                    return null;
-                }
-            }
-            return result;
+            this.baseNextCalled = true;
+            return this.baseArray;
         }
+        Object result = null;
+        while (result == null || Array.getLength(result) == 0) {
+            result = this.pointer.next();
+            if (result == MultiArrayPointer.END) {
+                return null;
+            }
+        }
+        return result;
     }
 
     public void reset() {

--- a/src/main/java/nom/tam/util/type/PrimitiveTypeHandler.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveTypeHandler.java
@@ -51,7 +51,7 @@ public final class PrimitiveTypeHandler {
     static {
         byBitPix = new PrimitiveType[BIT_PIX_OFFSET * 2 + 1];
         byType = new PrimitiveType[MAX_TYPE_VALUE];
-        Map<Class<?>, PrimitiveType<?>> initialByClass = new HashMap<Class<?>, PrimitiveType<?>>();
+        Map<Class<?>, PrimitiveType<?>> initialByClass = new HashMap<>();
         for (PrimitiveType<?> type : values()) {
             if (type.bitPix() != 0) {
                 byBitPix[type.bitPix() + BIT_PIX_OFFSET] = type;
@@ -66,21 +66,21 @@ public final class PrimitiveTypeHandler {
         byClass = Collections.unmodifiableMap(initialByClass);
     }
 
-    public static <B extends Buffer> PrimitiveType<B> nearestValueOf(int bitPix) {
+    public static PrimitiveType<?> nearestValueOf(int bitPix) {
         if (bitPix >= PrimitiveTypes.FLOAT.bitPix() && bitPix < 0) {
-            return (PrimitiveType<B>) PrimitiveTypes.FLOAT;
+            return PrimitiveTypes.FLOAT;
         } else if (bitPix >= PrimitiveTypes.DOUBLE.bitPix() && bitPix < PrimitiveTypes.FLOAT.bitPix()) {
-            return (PrimitiveType<B>) PrimitiveTypes.DOUBLE;
+            return PrimitiveTypes.DOUBLE;
         } else if (bitPix > 0 && bitPix <= PrimitiveTypes.BYTE.bitPix()) {
-            return (PrimitiveType<B>) PrimitiveTypes.BYTE;
+            return PrimitiveTypes.BYTE;
         } else if (bitPix > PrimitiveTypes.BYTE.bitPix() && bitPix <= PrimitiveTypes.SHORT.bitPix()) {
-            return (PrimitiveType<B>) PrimitiveTypes.SHORT;
+            return PrimitiveTypes.SHORT;
         } else if (bitPix > PrimitiveTypes.SHORT.bitPix() && bitPix <= PrimitiveTypes.INT.bitPix()) {
-            return (PrimitiveType<B>) PrimitiveTypes.INT;
+            return PrimitiveTypes.INT;
         } else if (bitPix > PrimitiveTypes.INT.bitPix() && bitPix <= PrimitiveTypes.LONG.bitPix()) {
-            return (PrimitiveType<B>) PrimitiveTypes.LONG;
+            return PrimitiveTypes.LONG;
         }
-        return (PrimitiveType<B>) PrimitiveTypes.UNKNOWN;
+        return PrimitiveTypes.UNKNOWN;
     }
 
     public static PrimitiveType<Buffer> valueOf(char type) {


### PR DESCRIPTION
The source code has been updated to be Java 8 compliant, plus some other fixes.

- Use _try-with-resources_ to manage streams where possible. (Or, add a `@SuppressWarnings` directive, where stream must stay open).
- Use diamond `<>` where appropriate.

Other changes:

- Remove references to deprecated API where possible.
- Remove superfluous `else` blocks.
- Remove unused `private` constants.
- Remove unused variables.