### PR TITLE
Typesafe BITPIX, fixes to FITS boolean and character arrays, and new ElementType hierarchy

### DIFF
--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -52,6 +52,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataInput;
@@ -634,7 +635,7 @@ public class AsciiTable extends AbstractTableData {
         try {
             Standard.context(AsciiTable.class);
             hdr.setXtension("TABLE");
-            hdr.setBitpix(BasicHDU.BITPIX_BYTE);
+            hdr.setBitpix(Bitpix.BYTE);
             hdr.setNaxes(2);
             hdr.setNaxis(1, this.rowLen);
             hdr.setNaxis(2, this.nRows);

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -62,8 +62,8 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.IFitsHeader;
-import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
 
@@ -77,16 +77,40 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
 
     private static final Logger LOG = getLogger(BasicHDU.class);
 
+    /**
+     * @deprecated Use {@link Bitpix#BITPIX_BYTE} instead.
+     */
+    @Deprecated
     public static final int BITPIX_BYTE = 8;
 
+    /**
+     * @deprecated Use {@link Bitpix#BITPIX_SHORT} instead.
+     */
+    @Deprecated
     public static final int BITPIX_SHORT = 16;
 
+    /**
+     * @deprecated Use {@link Bitpix#BITPIX_INT} instead.
+     */
+    @Deprecated
     public static final int BITPIX_INT = 32;
 
+    /**
+     * @deprecated Use {@link Bitpix#BITPIX_LONG} instead.
+     */
+    @Deprecated
     public static final int BITPIX_LONG = 64;
 
+    /**
+     * @deprecated Use {@link Bitpix#BITPIX_FLOAT} instead.
+     */
+    @Deprecated
     public static final int BITPIX_FLOAT = -32;
 
+    /**
+     * @deprecated Use {@link Bitpix#BITPIX_DOUBLE} instead.
+     */
+    @Deprecated
     public static final int BITPIX_DOUBLE = -64;
 
 
@@ -248,22 +272,25 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
 
         return axes;
     }
+    
+    /** 
+     * Return the Bitpix enum type for this HDU.
+     * 
+     * @return      The Bitpix enum object for this HDU.
+     * 
+     * @throws FitsException    if the BITPIX value in the header is absent or invalid.
+     * 
+     * @since 1.16
+     * 
+     * @see #getBitPix()
+     * @see Header#setBitpix(Bitpix)
+     */
+    public Bitpix getBitpix() throws FitsException {
+        return Bitpix.fromHeader(myHeader);
+    }
 
-    public int getBitPix() throws FitsException {
-        int bitpix = this.myHeader.getIntValue(Standard.BITPIX, -1);
-        switch (bitpix) {
-            case BITPIX_BYTE:
-            case BITPIX_SHORT:
-            case BITPIX_INT:
-            case BITPIX_LONG:
-            case BITPIX_FLOAT:
-            case BITPIX_DOUBLE:
-                break;
-            default:
-                throw new FitsException("Unknown BITPIX type " + bitpix);
-        }
-
-        return bitpix;
+    public final int getBitPix() throws FitsException {
+        return getBitpix().getHeaderValue();
     }
 
     public long getBlankValue() throws FitsException {

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -78,37 +78,37 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
     private static final Logger LOG = getLogger(BasicHDU.class);
 
     /**
-     * @deprecated Use {@link Bitpix#BITPIX_BYTE} instead.
+     * @deprecated Use {@link Bitpix#VALUE_FOR_BYTE} instead.
      */
     @Deprecated
     public static final int BITPIX_BYTE = 8;
 
     /**
-     * @deprecated Use {@link Bitpix#BITPIX_SHORT} instead.
+     * @deprecated Use {@link Bitpix#VALUE_FOR_SHORT} instead.
      */
     @Deprecated
     public static final int BITPIX_SHORT = 16;
 
     /**
-     * @deprecated Use {@link Bitpix#BITPIX_INT} instead.
+     * @deprecated Use {@link Bitpix#VALUE_FOR_INT} instead.
      */
     @Deprecated
     public static final int BITPIX_INT = 32;
 
     /**
-     * @deprecated Use {@link Bitpix#BITPIX_LONG} instead.
+     * @deprecated Use {@link Bitpix#VALUE_FOR_LONG} instead.
      */
     @Deprecated
     public static final int BITPIX_LONG = 64;
 
     /**
-     * @deprecated Use {@link Bitpix#BITPIX_FLOAT} instead.
+     * @deprecated Use {@link Bitpix#VALUE_FOR_FLOAT} instead.
      */
     @Deprecated
     public static final int BITPIX_FLOAT = -32;
 
     /**
-     * @deprecated Use {@link Bitpix#BITPIX_DOUBLE} instead.
+     * @deprecated Use {@link Bitpix#VALUE_FOR_DOUBLE} instead.
      */
     @Deprecated
     public static final int BITPIX_DOUBLE = -64;

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -49,6 +49,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataInput;
@@ -59,7 +60,7 @@ import nom.tam.util.Cursor;
 import nom.tam.util.FitsIO;
 import nom.tam.util.RandomAccess;
 import nom.tam.util.TableException;
-import nom.tam.util.type.PrimitiveTypeHandler;
+import nom.tam.util.type.ElementType;
 
 /**
  * This class defines the methods for accessing FITS binary table data.
@@ -153,7 +154,7 @@ public class BinaryTable extends AbstractTableData {
         }
 
         public int rowLen() {
-            return this.size * PrimitiveTypeHandler.valueOf(this.base).size();
+            return this.size * ElementType.forClass(this.base).size();
         }
 
         /**
@@ -592,7 +593,7 @@ public class BinaryTable extends AbstractTableData {
         try {
             Standard.context(BinaryTable.class);
             h.setXtension(XTENSION_BINTABLE);
-            h.setBitpix(BasicHDU.BITPIX_BYTE);
+            h.setBitpix(Bitpix.BYTE);
             h.setNaxes(2);
             h.setNaxis(1, this.rowLen);
             h.setNaxis(2, this.nRow);

--- a/src/main/java/nom/tam/fits/FitsUtil.java
+++ b/src/main/java/nom/tam/fits/FitsUtil.java
@@ -123,7 +123,18 @@ public final class FitsUtil {
         for (int i = 0; i < res.length; i += 1) {
 
             int start = i * maxLen;
-            int end = start + maxLen;
+
+            // AK: The FITS standard states that a 0 byte terminates the
+            // string before the fixed length, and characters beyond it
+            // are undefined. So, we first check where the string ends.
+            int l = 0;
+            for (; l < maxLen; l++) {
+                if (bytes[l] == 0) {
+                    break;
+                }
+            }
+            int end = start + l;
+
             // Pre-trim the string to avoid keeping memory
             // hanging around. (Suggested by J.C. Segovia, ESA).
 
@@ -170,7 +181,6 @@ public final class FitsUtil {
             }
         }
         return res;
-
     }
 
     /**

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -31,7 +31,6 @@ package nom.tam.fits;
  * #L%
  */
 
-import static nom.tam.fits.header.Standard.BITPIX;
 import static nom.tam.fits.header.Standard.EXTEND;
 import static nom.tam.fits.header.Standard.GCOUNT;
 import static nom.tam.fits.header.Standard.NAXIS;
@@ -45,6 +44,7 @@ import java.nio.Buffer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.Standard;
 import nom.tam.image.StandardImageTiler;
 import nom.tam.util.ArrayDataInput;
@@ -52,9 +52,7 @@ import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
 import nom.tam.util.RandomAccess;
 import nom.tam.util.array.MultiArrayIterator;
-import nom.tam.util.type.PrimitiveType;
-import nom.tam.util.type.PrimitiveTypeHandler;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /**
  * This class instantiates FITS primary HDU and IMAGE extension data.
@@ -221,12 +219,12 @@ public class ImageData extends Data {
     }
 
     public void setBuffer(Buffer data) {
-        PrimitiveType<Buffer> primType = PrimitiveTypeHandler.valueOf(this.dataDescription.type);
+        ElementType<Buffer> elementType = ElementType.forClass(this.dataDescription.type);
         this.dataArray = ArrayFuncs.newInstance(this.dataDescription.type, this.dataDescription.dims);
         MultiArrayIterator iterator = new MultiArrayIterator(this.dataArray);
         Object array = iterator.next();
         while (array != null) {
-            primType.getArray(data, array);
+            elementType.getArray(data, array);
             array = iterator.next();
         }
         this.tiler = new ImageDataTiler(null, 0, this.dataDescription);
@@ -294,34 +292,10 @@ public class ImageData extends Data {
             throw new FitsException("Image data object not array");
         }
 
-        int bitpix;
-        switch (classname.charAt(dimens.length)) {
-            case 'B':
-                bitpix = BasicHDU.BITPIX_BYTE;
-                break;
-            case 'S':
-                bitpix = BasicHDU.BITPIX_SHORT;
-                break;
-            case 'I':
-                bitpix = BasicHDU.BITPIX_INT;
-                break;
-            case 'J':
-                bitpix = BasicHDU.BITPIX_LONG;
-                break;
-            case 'F':
-                bitpix = BasicHDU.BITPIX_FLOAT;
-                break;
-            case 'D':
-                bitpix = BasicHDU.BITPIX_DOUBLE;
-                break;
-            default:
-                throw new FitsException("Invalid Object Type for FITS data:" + classname.charAt(dimens.length));
-        }
-
         // if this is neither a primary header nor an image extension,
         // make it a primary header
         head.setSimple(true);
-        head.setBitpix(bitpix);
+        head.setBitpix(Bitpix.forDataID(classname.charAt(dimens.length)));
         head.setNaxes(dimens.length);
 
         for (int i = 1; i <= dimens.length; i += 1) {
@@ -345,22 +319,15 @@ public class ImageData extends Data {
         return this.byteSize;
     }
 
-    @SuppressWarnings("unchecked")
     protected ArrayDesc parseHeader(Header h) throws FitsException {
         int gCount = h.getIntValue(GCOUNT, 1);
         int pCount = h.getIntValue(PCOUNT, 0);
         if (gCount > 1 || pCount != 0) {
             throw new FitsException("Group data treated as images");
         }
-        int bitPix = h.getIntValue(BITPIX, 0);
-        PrimitiveType<Buffer> primitivType = PrimitiveTypeHandler.valueOf(bitPix);
-        if (primitivType == null) {
-            primitivType = (PrimitiveType<Buffer>) PrimitiveTypeHandler.nearestValueOf(bitPix);
-            if (primitivType == PrimitiveTypes.UNKNOWN) {
-                throw new FitsException("illegal bitpix value " + bitPix);
-            }
-        }
-        Class<?> baseClass = primitivType.primitiveClass();
+        
+        Bitpix bitpix = Bitpix.fromHeader(h);
+        Class<?> baseClass = bitpix.getPrimitiveType();
         int ndim = h.getIntValue(NAXIS, 0);
         int[] dims = new int[ndim];
         // Note that we have to invert the order of the axes
@@ -376,7 +343,7 @@ public class ImageData extends Data {
             this.byteSize *= cdim;
             dims[ndim - i - 1] = cdim;
         }
-        this.byteSize *= primitivType.size();
+        this.byteSize *= bitpix.byteSize();
         if (ndim == 0) {
             this.byteSize = 0;
         }

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -295,7 +295,7 @@ public class ImageData extends Data {
         // if this is neither a primary header nor an image extension,
         // make it a primary header
         head.setSimple(true);
-        head.setBitpix(Bitpix.forDataID(classname.charAt(dimens.length)));
+        head.setBitpix(Bitpix.forArrayID(classname.charAt(dimens.length)));
         head.setNaxes(dimens.length);
 
         for (int i = 1; i <= dimens.length; i += 1) {

--- a/src/main/java/nom/tam/fits/ImageHDU.java
+++ b/src/main/java/nom/tam/fits/ImageHDU.java
@@ -46,9 +46,7 @@ import java.util.logging.Logger;
 
 import nom.tam.image.StandardImageTiler;
 import nom.tam.util.ArrayFuncs;
-import nom.tam.util.type.PrimitiveType;
-import nom.tam.util.type.PrimitiveTypeHandler;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /**
  * FITS image header/data unit
@@ -75,10 +73,10 @@ public class ImageHDU extends BasicHDU<ImageData> {
      */
     public static boolean isData(Object o) {
         if (o.getClass().isArray()) {
-            PrimitiveType<?> type = PrimitiveTypeHandler.valueOf(ArrayFuncs.getBaseClass(o));
-            return type != PrimitiveTypes.BOOLEAN && //
-                    type != PrimitiveTypes.STRING && //
-                    type != PrimitiveTypes.UNKNOWN;
+            ElementType<?> type = ElementType.forClass(ArrayFuncs.getBaseClass(o));
+            return type != ElementType.BOOLEAN && //
+                    type != ElementType.STRING && //
+                    type != ElementType.UNKNOWN;
 
         }
         return false;

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -40,6 +40,7 @@ import java.io.EOFException;
 import java.io.IOException;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
@@ -103,22 +104,7 @@ public class RandomGroupsData extends Data {
         // Got the information we need to build the header.
 
         h.setSimple(true);
-        if (dbase == byte.class) {
-            h.setBitpix(BasicHDU.BITPIX_BYTE);
-        } else if (dbase == short.class) {
-            h.setBitpix(BasicHDU.BITPIX_SHORT);
-        } else if (dbase == int.class) {
-            h.setBitpix(BasicHDU.BITPIX_INT);
-        } else if (dbase == long.class) { // Non-standard
-            h.setBitpix(BasicHDU.BITPIX_LONG);
-        } else if (dbase == float.class) {
-            h.setBitpix(BasicHDU.BITPIX_FLOAT);
-        } else if (dbase == double.class) {
-            h.setBitpix(BasicHDU.BITPIX_DOUBLE);
-        } else {
-            throw new FitsException("Data type:" + dbase + " not supported for random groups");
-        }
-
+        h.setBitpix(Bitpix.forPrimitiveType(dbase));
         h.setNaxes(ddims.length + 1);
         h.addValue(NAXISn.n(1), 0);
         for (int i = 2; i <= ddims.length + 1; i += 1) {

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -43,6 +43,7 @@ import static nom.tam.fits.header.Standard.XTENSION_IMAGE;
 
 import java.io.PrintStream;
 
+import nom.tam.fits.header.Bitpix;
 import nom.tam.util.ArrayFuncs;
 
 /**
@@ -68,32 +69,7 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
         int ndim = h.getIntValue(NAXIS, 0) - 1;
         int[] dims = new int[ndim];
 
-        int bitpix = h.getIntValue(BITPIX, 0);
-
-        Class<?> baseClass;
-
-        switch (bitpix) {
-            case BasicHDU.BITPIX_BYTE:
-                baseClass = Byte.TYPE;
-                break;
-            case BasicHDU.BITPIX_SHORT:
-                baseClass = Short.TYPE;
-                break;
-            case BasicHDU.BITPIX_INT:
-                baseClass = Integer.TYPE;
-                break;
-            case BasicHDU.BITPIX_LONG:
-                baseClass = Long.TYPE;
-                break;
-            case BasicHDU.BITPIX_FLOAT:
-                baseClass = Float.TYPE;
-                break;
-            case BasicHDU.BITPIX_DOUBLE:
-                baseClass = Double.TYPE;
-                break;
-            default:
-                throw new FitsException("Invalid BITPIX:" + bitpix);
-        }
+        Class<?> baseClass = Bitpix.fromHeader(h).getNumberType();
 
         // Note that we have to invert the order of the axes
         // for the FITS file to get the order in the array we

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -31,7 +31,6 @@ package nom.tam.fits;
  * #L%
  */
 
-import static nom.tam.fits.header.Standard.BITPIX;
 import static nom.tam.fits.header.Standard.EXTEND;
 import static nom.tam.fits.header.Standard.GCOUNT;
 import static nom.tam.fits.header.Standard.NAXIS;
@@ -45,6 +44,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
@@ -57,8 +57,6 @@ import nom.tam.util.ArrayFuncs;
 public class UndefinedData extends Data {
 
     private static final Logger LOG = getLogger(UndefinedData.class);
-
-    private static final int BITS_PER_BYTE = 8;
 
     private byte[] data;
 
@@ -78,7 +76,7 @@ public class UndefinedData extends Data {
         if (h.getIntValue(GCOUNT) > 1) {
             size *= h.getIntValue(GCOUNT);
         }
-        size *= Math.abs(h.getIntValue(BITPIX) / BITS_PER_BYTE);
+        size *= Bitpix.fromHeader(h).byteSize();
 
         this.data = new byte[size];
     }
@@ -105,7 +103,7 @@ public class UndefinedData extends Data {
         try {
             Standard.context(UndefinedData.class);
             head.setXtension("UNKNOWN");
-            head.setBitpix(BasicHDU.BITPIX_BYTE);
+            head.setBitpix(Bitpix.BYTE);
             head.setNaxes(1);
             head.addValue(NAXISn.n(1), this.data.length);
             head.addValue(PCOUNT, 0);

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressor.java
@@ -17,9 +17,7 @@ import nom.tam.util.ArrayFuncs;
 import nom.tam.util.ByteBufferInputStream;
 import nom.tam.util.ByteBufferOutputStream;
 import nom.tam.util.FitsIO;
-import nom.tam.util.type.PrimitiveType;
-import nom.tam.util.type.PrimitiveTypeHandler;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /*
  * #%L
@@ -178,9 +176,9 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
 
     private final class TypeConversion<B extends Buffer> {
 
-        private final PrimitiveType<B> from;
+        private final ElementType<B> from;
 
-        private final PrimitiveType<T> to;
+        private final ElementType<T> to;
 
         private final B fromBuffer;
 
@@ -190,9 +188,9 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
 
         private final Object toArray;
 
-        private TypeConversion(PrimitiveType<B> from) {
+        private TypeConversion(ElementType<B> from) {
             this.from = from;
-            this.to = getPrimitiveType(GZipCompressor.this.primitiveSize);
+            this.to = getElementType(GZipCompressor.this.primitiveSize);
             this.toBuffer = GZipCompressor.this.nioBuffer;
             this.fromBuffer = from.asTypedBuffer(ByteBuffer.wrap(GZipCompressor.this.buffer));
             this.fromArray = from.newArray(DEFAULT_GZIP_BUFFER_SIZE / from.size());
@@ -219,7 +217,7 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
 
     protected T nioBuffer;
 
-    private final byte[] sizeArray = new byte[PrimitiveTypes.INT.size()];
+    private final byte[] sizeArray = new byte[ElementType.INT.size()];
 
     private final IntBuffer sizeBuffer = ByteBuffer.wrap(this.sizeArray).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
 
@@ -267,8 +265,8 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
     }
 
     @SuppressWarnings("unchecked")
-    private <B extends Buffer> PrimitiveType<B> getPrimitiveType(int size) {
-        return (PrimitiveType<B>) PrimitiveTypeHandler.valueOf(size * FitsIO.BITS_OF_1_BYTE);
+    private <B extends Buffer> ElementType<B> getElementType(int size) {
+        return (ElementType<B>) ElementType.forBitpix(size * FitsIO.BITS_OF_1_BYTE);
     }
 
     private TypeConversion<Buffer> getTypeConverter(ByteBuffer compressed, int nrOfPrimitiveElements) {
@@ -283,7 +281,7 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
                     if (uncompressedSize % nrOfPrimitiveElements == 0) {
                         int compressedPrimitiveSize = uncompressedSize / nrOfPrimitiveElements;
                         if (compressedPrimitiveSize != this.primitiveSize) {
-                            return new TypeConversion<>(getPrimitiveType(compressedPrimitiveSize));
+                            return new TypeConversion<>(getElementType(compressedPrimitiveSize));
                         }
                     }
                 }

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip2/GZip2Compressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip2/GZip2Compressor.java
@@ -43,7 +43,7 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import nom.tam.fits.compression.algorithm.gzip.GZipCompressor;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T> {
 
@@ -53,7 +53,7 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
     public static class IntGZip2Compressor extends GZip2Compressor<IntBuffer> {
 
         public IntGZip2Compressor() {
-            super(PrimitiveTypes.INT.size());
+            super(ElementType.INT.size());
         }
 
         @Override
@@ -71,7 +71,7 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
     public static class FloatGZip2Compressor extends GZip2Compressor<FloatBuffer> {
 
         public FloatGZip2Compressor() {
-            super(PrimitiveTypes.FLOAT.size());
+            super(ElementType.FLOAT.size());
         }
 
         @Override
@@ -89,7 +89,7 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
     public static class LongGZip2Compressor extends GZip2Compressor<LongBuffer> {
 
         public LongGZip2Compressor() {
-            super(PrimitiveTypes.LONG.size());
+            super(ElementType.LONG.size());
         }
 
         @Override
@@ -107,7 +107,7 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
     public static class DoubleGZip2Compressor extends GZip2Compressor<DoubleBuffer> {
 
         public DoubleGZip2Compressor() {
-            super(PrimitiveTypes.DOUBLE.size());
+            super(ElementType.DOUBLE.size());
         }
 
         @Override
@@ -125,7 +125,7 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
     public static class ShortGZip2Compressor extends GZip2Compressor<ShortBuffer> {
 
         public ShortGZip2Compressor() {
-            super(PrimitiveTypes.SHORT.size());
+            super(ElementType.SHORT.size());
         }
 
         @Override

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressOption.java
@@ -33,13 +33,13 @@ package nom.tam.fits.compression.algorithm.rice;
 
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.provider.param.api.ICompressParameters;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 public class RiceCompressOption implements ICompressOption {
 
     public static final int DEFAULT_RICE_BLOCKSIZE = 32;
 
-    public static final int DEFAULT_RICE_BYTEPIX = PrimitiveTypes.INT.size();
+    public static final int DEFAULT_RICE_BYTEPIX = ElementType.INT.size();
 
     /**
      * this is a circular dependency that still has to be cut.

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
@@ -10,7 +10,7 @@ import nom.tam.fits.compression.algorithm.api.ICompressor;
 import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor.DoubleQuantCompressor;
 import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor.FloatQuantCompressor;
 import nom.tam.util.FitsIO;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /*
  * #%L
@@ -62,7 +62,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private ByteBuffer pixelBuffer;
 
         public ByteRiceCompressor(RiceCompressOption option) {
-            super(option.setDefaultBytePix(PrimitiveTypes.BYTE.size()));
+            super(option.setDefaultBytePix(ElementType.BYTE.size()));
         }
 
         @Override
@@ -108,7 +108,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private IntBuffer pixelBuffer;
 
         public IntRiceCompressor(RiceCompressOption option) {
-            super(option.setDefaultBytePix(PrimitiveTypes.INT.size()));
+            super(option.setDefaultBytePix(ElementType.INT.size()));
         }
 
         @Override
@@ -140,7 +140,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private ShortBuffer pixelBuffer;
 
         public ShortRiceCompressor(RiceCompressOption option) {
-            super(option.setDefaultBytePix(PrimitiveTypes.SHORT.size()));
+            super(option.setDefaultBytePix(ElementType.SHORT.size()));
         }
 
         @Override
@@ -243,15 +243,15 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
 
     private RiceCompressor(RiceCompressOption option) {
         this.blockSize = option.getBlockSize();
-        if (option.getBytePix() == PrimitiveTypes.BYTE.size()) {
+        if (option.getBytePix() == ElementType.BYTE.size()) {
             this.fsBits = FS_BITS_FOR_BYTE;
             this.fsMax = FS_MAX_FOR_BYTE;
             this.bitsPerPixel = FitsIO.BITS_OF_1_BYTE;
-        } else if (option.getBytePix() == PrimitiveTypes.SHORT.size()) {
+        } else if (option.getBytePix() == ElementType.SHORT.size()) {
             this.fsBits = FS_BITS_FOR_SHORT;
             this.fsMax = FS_MAX_FOR_SHORT;
             this.bitsPerPixel = FitsIO.BITS_OF_2_BYTES;
-        } else if (option.getBytePix() == PrimitiveTypes.INT.size()) {
+        } else if (option.getBytePix() == ElementType.INT.size()) {
             this.fsBits = FS_BITS_FOR_INT;
             this.fsMax = FS_MAX_FOR_INT;
             this.bitsPerPixel = FitsIO.BITS_OF_4_BYTES;
@@ -433,11 +433,11 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         /* first x bytes of input buffer contain the value of the first */
         /* x byte integer value, without any encoding */
         long lastpix = 0L;
-        if (this.bitsPerPixel == PrimitiveTypes.BYTE.bitPix()) {
+        if (this.bitsPerPixel == ElementType.BYTE.bitPix()) {
             lastpix = readBuffer.get() & UNSIGNED_BYTE_MASK;
-        } else if (this.bitsPerPixel == PrimitiveTypes.SHORT.bitPix()) {
+        } else if (this.bitsPerPixel == ElementType.SHORT.bitPix()) {
             lastpix = readBuffer.getShort() & UNSIGNED_SHORT_MASK;
-        } else if (this.bitsPerPixel == PrimitiveTypes.INT.bitPix()) {
+        } else if (this.bitsPerPixel == ElementType.INT.bitPix()) {
             lastpix = readBuffer.getInt() & UNSIGNED_INTEGER_MASK;
         }
         long b = readBuffer.get() & BYTE_MASK; /* bit buffer */

--- a/src/main/java/nom/tam/fits/compression/algorithm/uncompressed/NoCompressCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/uncompressed/NoCompressCompressor.java
@@ -9,7 +9,7 @@ import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
 
 import nom.tam.fits.compression.algorithm.api.ICompressor;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /*
  * #%L
@@ -71,7 +71,7 @@ public abstract class NoCompressCompressor<T extends Buffer> implements ICompres
         public boolean compress(DoubleBuffer pixelData, ByteBuffer compressed) {
             int size = pixelData.remaining();
             compressed.asDoubleBuffer().put(pixelData);
-            compressed.position(compressed.position() + size * PrimitiveTypes.DOUBLE.size());
+            compressed.position(compressed.position() + size * ElementType.DOUBLE.size());
             return true;
         }
 
@@ -87,7 +87,7 @@ public abstract class NoCompressCompressor<T extends Buffer> implements ICompres
         public boolean compress(FloatBuffer pixelData, ByteBuffer compressed) {
             int size = pixelData.remaining();
             compressed.asFloatBuffer().put(pixelData);
-            compressed.position(compressed.position() + size * PrimitiveTypes.FLOAT.size());
+            compressed.position(compressed.position() + size * ElementType.FLOAT.size());
 
             return true;
         }
@@ -104,7 +104,7 @@ public abstract class NoCompressCompressor<T extends Buffer> implements ICompres
         public boolean compress(IntBuffer pixelData, ByteBuffer compressed) {
             int size = pixelData.remaining();
             compressed.asIntBuffer().put(pixelData);
-            compressed.position(compressed.position() + size * PrimitiveTypes.INT.size());
+            compressed.position(compressed.position() + size * ElementType.INT.size());
             return true;
         }
 
@@ -120,7 +120,7 @@ public abstract class NoCompressCompressor<T extends Buffer> implements ICompres
         public boolean compress(LongBuffer pixelData, ByteBuffer compressed) {
             int size = pixelData.remaining();
             compressed.asLongBuffer().put(pixelData);
-            compressed.position(compressed.position() + size * PrimitiveTypes.LONG.size());
+            compressed.position(compressed.position() + size * ElementType.LONG.size());
             return true;
         }
 
@@ -136,7 +136,7 @@ public abstract class NoCompressCompressor<T extends Buffer> implements ICompres
         public boolean compress(ShortBuffer pixelData, ByteBuffer compressed) {
             int size = pixelData.remaining();
             compressed.asShortBuffer().put(pixelData);
-            compressed.position(compressed.position() + size * PrimitiveTypes.SHORT.size());
+            compressed.position(compressed.position() + size * ElementType.SHORT.size());
             return true;
         }
 

--- a/src/main/java/nom/tam/fits/header/Bitpix.java
+++ b/src/main/java/nom/tam/fits/header/Bitpix.java
@@ -58,7 +58,7 @@ public enum Bitpix {
     FLOAT(Float.TYPE, ElementType.FLOAT, "32-bit floating point"),
     DOUBLE(Double.TYPE, ElementType.DOUBLE, "64-bit floating point");
     
-    private static final Logger LOG = Logger.getLogger(Header.class.getName());
+    private static final Logger LOG = Logger.getLogger("nom.tam.fits.HeaderCardParser");
     
     private static final int BITS_TO_BYTES_SHIFT = 3;
     
@@ -355,7 +355,7 @@ public enum Bitpix {
             }
             
             if (fixed != 0) {
-                LOG.warning("Repaired invalid BITPIX = " + ival + " --> " + fixed);
+                LOG.warning("Repaired invalid BITPIX value:" + ival + " --> " + fixed);
                 ival = fixed;
             }
         }

--- a/src/main/java/nom/tam/fits/header/Bitpix.java
+++ b/src/main/java/nom/tam/fits/header/Bitpix.java
@@ -1,0 +1,409 @@
+package nom.tam.fits.header;
+
+import java.util.logging.Logger;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import nom.tam.fits.FitsException;
+import nom.tam.fits.FitsFactory;
+import nom.tam.fits.Header;
+import nom.tam.fits.HeaderCard;
+import nom.tam.util.type.ElementType;
+
+/**
+ * Standard BITPIX values and associated functions. Since the FITS BITPIX keyword has 
+ * only a handful of legal values, an <code>enum</code> provides ideal safe
+ * representation. It also allows to interface the value for the type of data
+ * it represents in a natural way.
+ * 
+ * 
+ * @author Attila Kovacs
+ *
+ * @since 1.16
+ */
+public enum Bitpix {
+    BYTE(Byte.TYPE, ElementType.BYTE, "bytes"),
+    SHORT(Short.TYPE, ElementType.SHORT, "16-bit integers"),
+    INTEGER(Integer.TYPE, ElementType.INT, "32-bit integers"),
+    LONG(Long.TYPE, ElementType.LONG, "64-bit integers"),
+    FLOAT(Float.TYPE, ElementType.FLOAT, "32-bit floating point"),
+    DOUBLE(Double.TYPE, ElementType.DOUBLE, "64-bit floating point");
+    
+    private static final Logger LOG = Logger.getLogger(Header.class.getName());
+    
+    private static final int BITS_TO_BYTES_SHIFT = 3;
+    
+    /** BITPIX value for <code>byte</code> type data */
+    public static final int BITPIX_BYTE = 8;
+    
+    /** BITPIX value for <code>short</code> type data */
+    public static final int BITPIX_SHORT = 16;
+    
+    /** BITPIX value for <code>int</code> type data */
+    public static final int BITPIX_INT = 32;
+    
+    /** BITPIX value for <code>long</code> type data */
+    public static final int BITPIX_LONG = 64;
+    
+    /** BITPIX value for <code>float</code> type data */
+    public static final int BITPIX_FLOAT = -32;
+    
+    /** BITPIX value for <code>double</code> type data */
+    public static final int BITPIX_DOUBLE = -64;
+    
+    
+    /** the number subclass represented this BITPIX instance */
+    private Class<? extends Number> numberType;
+    
+    /** the library's element type */
+    private ElementType<?> elementType;
+  
+    /** a concise description of the data type represented */
+    private String description;
+
+    
+    /**
+     * Constructor for a standard BITPIX instance.
+     * 
+     * @param numberType        the Number subclass     
+     * @param elementType       the class of data element
+     * @param desc              a concise description of the data type
+     */
+    Bitpix(Class<? extends Number> numberType, ElementType<?> elementType, String desc) {
+        this.numberType = numberType;
+        this.elementType = elementType;
+        this.description = desc;
+    }
+    
+    public final ElementType<?> getElementType() {
+        return elementType;
+    }
+    
+    /**
+     * Returns the sublass of {@link Number} corresponding for this BITPIX value.
+     * 
+     * @return  the number class for this BITPIX instance.
+     * 
+     * @see #getPrimitiveType()
+     * @see Bitpix#forNumberType(Class)
+     */
+    public final Class<? extends Number> getNumberType() {
+        return numberType;
+    }
+    
+    /**
+     * Returns the primitive built-in Java number type corresponding for this BITPIX value.
+     * 
+     * @return  the primitive class for this BITPIX instance, such as <code>int.class</code>, 
+     *          or <code>double.class</code>.
+     * 
+     * @see #getNumberType()
+     * @see Bitpix#forPrimitiveType(Class)
+     */
+    public final Class<?> getPrimitiveType() {
+        return elementType.primitiveClass();
+    }
+    
+    /**
+     * Returns the FITS standard BITPIX header value for this instance.
+     * 
+     * @return  the standard FITS BITPIX value, such as 8, 16, 32, 64, -32, or -64.
+     * 
+     * @see Bitpix#forValue(int)
+     * @see #getHeaderCard()
+     */
+    public final int getHeaderValue() {
+        return elementType.bitPix();
+    }
+    
+    /**
+     * Returns the FITS data letter ID for this BITPIX instance, such as the letter ID
+     * used by the TTYPE<i>n</i> keywords for the same type of data.
+     * 
+     * @return  The FITS data letter ID for this BITPIX instance. 
+     * 
+     * @see Bitpix#forDataID(char)
+     */
+    public final char getDataID() {
+        return elementType.type();
+    }
+    
+    /**
+     * Returns a concise description of the data type represented by this BITPIX instance.
+     * 
+     * @return  a brief description of the corresponding data type.
+     */
+    public final String getDescription() {
+        return description;
+    }
+    
+    /**
+     * Returns the size of a data element, in bytes, for this BITPIX instance
+     * 
+     * @return      the size of a data element in bytes.
+     */
+    public final int byteSize() {
+        return Math.abs(getHeaderValue()) >>> BITS_TO_BYTES_SHIFT;
+    }
+    
+    /**
+     * Returns the standard FITS header card for this BITPIX instance.
+     * 
+     * @return      the standard FITS header card with the BITPIX keyword and the corresponding value
+     *              for this instance.
+     *              
+     * @see #getHeaderValue()
+     */
+    public final HeaderCard getHeaderCard() {
+        return HeaderCard.create(Standard.BITPIX, getHeaderValue());
+    }
+    
+    /**
+     * Returns the standard BITPIX object for a primitive type.
+     * 
+     * @param dataType      the primitive class, such as <code>int.class</code>.
+     * @return              the standard BITPIX associated to the number type
+     * @throws FitsException    if the class is not a primitive class, or if its not
+     *                          one that has a corresponding BITPIX value (e.g. <code>
+     *                          boolean.class</code>).
+     *                          
+     * @see Bitpix#forNumberType(Class)
+     * @see #getPrimitiveType()
+     */
+    public static Bitpix forPrimitiveType(Class<?> dataType) throws FitsException {
+        if (dataType == byte.class) {
+            return BYTE;
+        }
+        if (dataType == short.class) {
+            return SHORT;
+        }
+        if (dataType == int.class) {
+            return INTEGER;
+        }
+        if (dataType == long.class) {
+            return LONG;
+        }
+        if (dataType == float.class) {
+            return FLOAT;
+        }
+        if (dataType == double.class) {
+            return DOUBLE;
+        }
+        if (Object.class.isAssignableFrom(dataType)) {
+            throw new FitsException("No BITPIX for type: " + dataType + " (expected primitive type)");
+        }
+        
+        throw new FitsException("No BITPIX for primitive type: " + dataType);
+    }
+    
+    /**
+     * Returns the standard BITPIX object for a number type.
+     * 
+     * @param dataType      the class of number, such as {@link Integer#TYPE}.
+     * @return              the standard BITPIX associated to the number type
+     * @throws FitsException    if there is no standard BITPIX value corresponding to the number type
+     *                          (e.g. {@link java.math.BigDecimal}).
+     *                          
+     * @see Bitpix#forPrimitiveType(Class)
+     * @see #getNumberType()
+     */
+    public static Bitpix forNumberType(Class<? extends Number> dataType) throws FitsException {
+        if (Byte.class.isAssignableFrom(dataType)) {
+            return BYTE;
+        }
+        if (Short.class.isAssignableFrom(dataType)) {
+            return SHORT;
+        }
+        if (Integer.class.isAssignableFrom(dataType)) {
+            return INTEGER;
+        }
+        if (Long.class.isAssignableFrom(dataType)) {
+            return LONG;
+        }
+        if (Float.class.isAssignableFrom(dataType)) {
+            return FLOAT;
+        }
+        if (Double.class.isAssignableFrom(dataType)) {
+            return DOUBLE;
+        }
+        throw new FitsException("No BITPIX for Number type " + dataType);
+    }
+    
+    
+    /**
+     * Returns the standard BITPIX object based on the value assigned to the BITPIX keyword in the header
+     * 
+     * @param h             the FITS header
+     * @return              the standard BITPIX enum that matches the header description, or is
+     *                      inferred from an invalid header description (provided 
+     *                      {@link FitsFactory#setAllowHeaderRepairs(boolean)} is enabled).
+     * @throws FitsException    if the header does not contain a BITPIX value or it is invalid
+     *                          and cannot or will not be repaired. 
+     *                          
+     * @see Bitpix#fromHeader(Header, boolean)
+     * @see Bitpix#forValue(int)
+     * @see FitsFactory#setAllowHeaderRepairs(boolean)
+     */
+    public static Bitpix fromHeader(Header h) throws FitsException {
+        return forValue(h.getIntValue(Standard.BITPIX, 0));
+    }
+    
+    /**
+     * Returns the standard BITPIX object based on the value assigned to the BITPIX keyword in the header
+     * 
+     * @param h             the FITS header
+     * @param allowRepair   if we can try repair non-standard (invalid) BITPIX values.
+     * @return              the standard BITPIX enum that matches the header description, or is
+     *                      inferred from an invalid header description.
+     * @throws FitsException    if the header does not contain a BITPIX value or it is invalid
+     *                          and cannot or will not be repaired. 
+     *                          
+     * @see Bitpix#fromHeader(Header)
+     * @see Bitpix#forValue(int, boolean)
+     */
+    public static Bitpix fromHeader(Header h, boolean allowRepair) throws FitsException {
+        return forValue(h.getIntValue(Standard.BITPIX, 0), allowRepair);
+    }
+    
+   /**
+    * Returns the standard BITPIX enum value for a given integer value, such as 8, 16, 32, 64, -32, or -64.
+    * If the value is not one of the standard values, then depending on whether header repairs are enabled
+    * either an exception is thrown, or else the value the value is 'repaired' and a loh entry is made
+    * to the logger of {@link Header}.
+    * 
+    * @param ival          The integer value of BITPIX in the FITS header.
+    * @return              The standard value as a Java object.
+    * @throws FitsException    if the value was invalid or irreparable.
+    * 
+    * @see Bitpix#forValue(int, boolean)
+    * @see FitsFactory#setAllowHeaderRepairs(boolean)
+    * @see #getHeaderValue()
+    */
+   public static Bitpix forValue(int ival) throws FitsException {
+        try {
+            return forValue(ival, FitsFactory.isAllowHeaderRepairs());
+        } catch (FitsException e) {
+            throw new FitsException(e.getMessage() + "\n\n"
+                    + " --> Try FitsFactory.setAllowHeaderRepairs(true).\n");
+        }
+    }
+        
+    /**
+     * Returns the standard BITPIX enum value for a given integer value, such as 8, 16, 32, 64, -32, or -64.
+     * If the value is not one of the standard values, then depending on whether repairs are enabled
+     * either an exception is thrown, or else the value the value is 'repaired' and a loh entry is made
+     * to the logger of {@link Header}.
+     * 
+     * @param ival          The integer value of BITPIX in the FITS header.
+     * @param allowRepair   Whether we can fix up invalid values to make them valid.
+     * @return              The standard value as a Java object.
+     * @throws FitsException    if the value was invalid or irreparable.
+     * 
+     * @see Bitpix#forValue(int)
+     * @see #getHeaderValue()
+     */
+    public static Bitpix forValue(int ival, boolean allowRepair) throws FitsException {
+        
+        if (ival == 0) {
+            throw new FitsException("Invalid BITPIX value:" + ival);
+        }
+        
+        // Normally BITPIX must be one one of the supported values. Unfortunately, some
+        // commercial cameras fill illegal values, such as 20.
+        // We can 'repair' them by rounding up to the next valid value, so 20 repairs to 32, and
+        // maxing at +/- 64, so for example -80 repairs to -64.
+        if (allowRepair) {
+            int fixed = 0;
+
+            if (ival < 0) {
+                fixed = ival < BITPIX_FLOAT ? BITPIX_DOUBLE : BITPIX_FLOAT;
+            } else if (ival < BITPIX_BYTE) {
+                fixed = BITPIX_BYTE;
+            } else if (ival > BITPIX_LONG) {
+                fixed = BITPIX_LONG;
+            } else if (ival > Integer.highestOneBit(ival)) {
+                fixed = (Integer.highestOneBit(ival) << 1);
+            }
+            
+            if (fixed != 0) {
+                LOG.warning("Repaired invalid BITPIX = " + ival + " --> " + fixed);
+                ival = fixed;
+            }
+        }
+        
+        switch (ival) {
+        case BITPIX_BYTE: 
+            return BYTE;
+        case BITPIX_SHORT: 
+            return SHORT;
+        case BITPIX_INT: 
+            return INTEGER;
+        case BITPIX_LONG: 
+            return LONG;
+        case BITPIX_FLOAT: 
+            return FLOAT;
+        case BITPIX_DOUBLE: 
+            return DOUBLE;
+        default:
+            throw new FitsException("Invalid BITPIX value:" + ival);
+        }
+    }
+    
+    /**
+     * Returns the standard BITPIX object for the given data ID. The data ID is the same
+     * letter code as FITS uses for identifying data types for table columns using the TTYPE<i>n</i>
+     * keyword, such as 'I' for 32-bit integer, 'D' for <code>double</code> etc.
+     * 
+     * @param id        The standard FITS letter ID for a data type, same as used for TTYPE<i>n</i> keywords.
+     * @return          The standard BITPIX enum corresponding to the data type.
+     * @throws FitsException    if the data type is unknown or does not have a BITPIX ewquivalent.
+     * 
+     */
+    public static Bitpix forDataID(char id) throws FitsException {
+        switch (id) {
+        case 'B': 
+            return BYTE;
+        case 'S': 
+            return SHORT;
+        case 'I': 
+            return INTEGER;
+        case 'J': 
+            return LONG;
+        case 'F': 
+            return FLOAT;
+        case 'D': 
+            return DOUBLE;
+        default:
+            throw new FitsException("Invalid BITPIX data ID: '" + id + "'");
+        }
+    } 
+}

--- a/src/main/java/nom/tam/fits/header/Bitpix.java
+++ b/src/main/java/nom/tam/fits/header/Bitpix.java
@@ -41,7 +41,7 @@ import nom.tam.util.type.ElementType;
 
 /**
  * Standard BITPIX values and associated functions. Since the FITS BITPIX keyword has 
- * only a handful of legal values, an <code>enum</code> provides ideal safe
+ * only a handful of legal values, an <code>enum</code> provides ideal type-safe
  * representation. It also allows to interface the value for the type of data
  * it represents in a natural way.
  * 
@@ -63,22 +63,22 @@ public enum Bitpix {
     private static final int BITS_TO_BYTES_SHIFT = 3;
     
     /** BITPIX value for <code>byte</code> type data */
-    public static final int BITPIX_BYTE = 8;
+    public static final int VALUE_FOR_BYTE = 8;
     
     /** BITPIX value for <code>short</code> type data */
-    public static final int BITPIX_SHORT = 16;
+    public static final int VALUE_FOR_SHORT = 16;
     
     /** BITPIX value for <code>int</code> type data */
-    public static final int BITPIX_INT = 32;
+    public static final int VALUE_FOR_INT = 32;
     
     /** BITPIX value for <code>long</code> type data */
-    public static final int BITPIX_LONG = 64;
+    public static final int VALUE_FOR_LONG = 64;
     
     /** BITPIX value for <code>float</code> type data */
-    public static final int BITPIX_FLOAT = -32;
+    public static final int VALUE_FOR_FLOAT = -32;
     
     /** BITPIX value for <code>double</code> type data */
-    public static final int BITPIX_DOUBLE = -64;
+    public static final int VALUE_FOR_DOUBLE = -64;
     
     
     /** the number subclass represented this BITPIX instance */
@@ -146,14 +146,15 @@ public enum Bitpix {
     }
     
     /**
-     * Returns the FITS data letter ID for this BITPIX instance, such as the letter ID
-     * used by the TTYPE<i>n</i> keywords for the same type of data.
+     * Returns the Java letter ID for this BITPIX instance, such as the letter ID
+     * used in the Java array representation of that class. For example, an <code>int[]</code>
+     * array has class <code>I[</code>, so the letter ID is <code>I</code>.
      * 
-     * @return  The FITS data letter ID for this BITPIX instance. 
+     * @return  The Java letter ID for arrays corresponding to this BITPIX instance. 
      * 
-     * @see Bitpix#forDataID(char)
+     * @see Bitpix#forArrayID(char)
      */
-    public final char getDataID() {
+    public final char getArrayID() {
         return elementType.type();
     }
     
@@ -345,11 +346,11 @@ public enum Bitpix {
             int fixed = 0;
 
             if (ival < 0) {
-                fixed = ival < BITPIX_FLOAT ? BITPIX_DOUBLE : BITPIX_FLOAT;
-            } else if (ival < BITPIX_BYTE) {
-                fixed = BITPIX_BYTE;
-            } else if (ival > BITPIX_LONG) {
-                fixed = BITPIX_LONG;
+                fixed = ival < VALUE_FOR_FLOAT ? VALUE_FOR_DOUBLE : VALUE_FOR_FLOAT;
+            } else if (ival < VALUE_FOR_BYTE) {
+                fixed = VALUE_FOR_BYTE;
+            } else if (ival > VALUE_FOR_LONG) {
+                fixed = VALUE_FOR_LONG;
             } else if (ival > Integer.highestOneBit(ival)) {
                 fixed = (Integer.highestOneBit(ival) << 1);
             }
@@ -361,17 +362,17 @@ public enum Bitpix {
         }
         
         switch (ival) {
-        case BITPIX_BYTE: 
+        case VALUE_FOR_BYTE: 
             return BYTE;
-        case BITPIX_SHORT: 
+        case VALUE_FOR_SHORT: 
             return SHORT;
-        case BITPIX_INT: 
+        case VALUE_FOR_INT: 
             return INTEGER;
-        case BITPIX_LONG: 
+        case VALUE_FOR_LONG: 
             return LONG;
-        case BITPIX_FLOAT: 
+        case VALUE_FOR_FLOAT: 
             return FLOAT;
-        case BITPIX_DOUBLE: 
+        case VALUE_FOR_DOUBLE: 
             return DOUBLE;
         default:
             throw new FitsException("Invalid BITPIX value:" + ival);
@@ -379,16 +380,18 @@ public enum Bitpix {
     }
     
     /**
-     * Returns the standard BITPIX object for the given data ID. The data ID is the same
-     * letter code as FITS uses for identifying data types for table columns using the TTYPE<i>n</i>
-     * keyword, such as 'I' for 32-bit integer, 'D' for <code>double</code> etc.
+     * Returns the standard BITPIX object for the given Java array ID. The array ID is the same
+     * letter code as Java uses for identifying ptrimitive array types. For example a Java 
+     * array of <code>long[][]</code> has a class name of <code>J[[</code>, so so the array ID for 
+     * <code>long</code> arrays is <code>J</code>.
      * 
-     * @param id        The standard FITS letter ID for a data type, same as used for TTYPE<i>n</i> keywords.
+     * @param id        The Java letter ID for arrays of the underlying primitive type. E.g. <code>J</code>
+     *                  for <code>long</code>.
      * @return          The standard BITPIX enum corresponding to the data type.
      * @throws FitsException    if the data type is unknown or does not have a BITPIX ewquivalent.
      * 
      */
-    public static Bitpix forDataID(char id) throws FitsException {
+    public static Bitpix forArrayID(char id) throws FitsException {
         switch (id) {
         case 'B': 
             return BYTE;

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTile.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTile.java
@@ -41,8 +41,7 @@ import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.fits.compression.provider.CompressorProvider;
 import nom.tam.fits.header.Compression;
 import nom.tam.util.ColumnTable;
-import nom.tam.util.type.PrimitiveType;
-import nom.tam.util.type.PrimitiveTypeHandler;
+import nom.tam.util.type.ElementType;
 
 public abstract class BinaryTableTile implements Runnable {
 
@@ -62,7 +61,7 @@ public abstract class BinaryTableTile implements Runnable {
 
     protected String compressionAlgorithm;
 
-    protected final PrimitiveType<Buffer> type;
+    protected final ElementType<Buffer> type;
 
     protected final int length;
 
@@ -77,7 +76,7 @@ public abstract class BinaryTableTile implements Runnable {
         this.column = description.getColumn();
         this.tileIndex = description.getTileIndex();
         this.compressionAlgorithm = description.getCompressionAlgorithm();
-        this.type = PrimitiveTypeHandler.valueOf(data.getTypes()[this.column]);
+        this.type = ElementType.forDataID(data.getTypes()[this.column]);
         this.length = (this.rowEnd - this.rowStart) * data.getSizes()[this.column];
     }
 

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableHDU.java
@@ -40,7 +40,7 @@ import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
 import nom.tam.fits.header.Standard;
 import nom.tam.util.Cursor;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 public class CompressedTableHDU extends BinaryTableHDU {
 
@@ -106,7 +106,7 @@ public class CompressedTableHDU extends BinaryTableHDU {
     public BinaryTableHDU asBinaryTableHDU() throws FitsException {
         Header header = new Header();
         header.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
-        header.addValue(Standard.BITPIX, PrimitiveTypes.BYTE.bitPix());
+        header.addValue(Standard.BITPIX, ElementType.BYTE.bitPix());
         header.addValue(Standard.NAXIS, 2);
         Cursor<String, HeaderCard> headerIterator = header.iterator();
         Cursor<String, HeaderCard> iterator = getHeader().iterator();

--- a/src/main/java/nom/tam/image/compression/tile/TileCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileCompressionOperation.java
@@ -41,8 +41,7 @@ import nom.tam.image.compression.tile.mask.ImageNullPixelMask;
 import nom.tam.image.tile.operation.AbstractTileOperation;
 import nom.tam.image.tile.operation.ITileOperation;
 import nom.tam.image.tile.operation.TileArea;
-import nom.tam.util.type.PrimitiveTypeHandler;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /**
  * abstract information holder about the a tile that represents a rectangular
@@ -69,7 +68,7 @@ abstract class TileCompressionOperation extends AbstractTileOperation implements
     }
 
     private ByteBuffer convertToBuffer(Object data) {
-        return PrimitiveTypeHandler.valueOf(data.getClass().getComponentType()).convertToByteBuffer(data);
+        return ElementType.forClass(data.getClass().getComponentType()).convertToByteBuffer(data);
     }
 
     /**
@@ -85,7 +84,7 @@ abstract class TileCompressionOperation extends AbstractTileOperation implements
     protected byte[] getCompressedData() {
         byte[] data = new byte[this.compressedData.limit()];
         this.compressedData.rewind();
-        PrimitiveTypes.BYTE.getArray(this.compressedData, data);
+        ElementType.BYTE.getArray(this.compressedData, data);
         return data;
     }
 

--- a/src/main/java/nom/tam/image/compression/tile/TileCompressor.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileCompressor.java
@@ -36,7 +36,7 @@ import java.nio.ByteBuffer;
 import nom.tam.image.compression.tile.mask.ImageNullPixelMask;
 import nom.tam.image.compression.tile.mask.NullPixelMaskPreserver;
 import nom.tam.image.tile.operation.TileArea;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 public class TileCompressor extends TileCompressionOperation {
 
@@ -64,7 +64,7 @@ public class TileCompressor extends TileCompressionOperation {
             getPreviousTileOperation().waitForResult();
             ByteBuffer compressedWholeArea = getCompressedWholeArea();
             this.compressedOffset = compressedWholeArea.position();
-            PrimitiveTypes.BYTE.appendBuffer(compressedWholeArea, this.compressedData);
+            ElementType.BYTE.appendBuffer(compressedWholeArea, this.compressedData);
             replaceCompressedBufferWithTargetArea(compressedWholeArea);
         } else {
             this.compressedOffset = 0;

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -69,9 +69,7 @@ import nom.tam.fits.compression.provider.param.api.HeaderCardAccess;
 import nom.tam.image.compression.tile.mask.ImageNullPixelMask;
 import nom.tam.image.tile.operation.AbstractTiledImageOperation;
 import nom.tam.image.tile.operation.TileArea;
-import nom.tam.util.type.PrimitiveType;
-import nom.tam.util.type.PrimitiveTypeHandler;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /**
  * This class represents a complete tiledImageOperation of tileOperations
@@ -298,18 +296,14 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void readBaseType(Header header) {
         if (getBaseType() == null) {
             int zBitPix = header.getIntValue(ZBITPIX);
-            PrimitiveType<Buffer> primitiveType = PrimitiveTypeHandler.valueOf(zBitPix);
-            if (primitiveType == null) {
-                primitiveType = (PrimitiveType<Buffer>) PrimitiveTypeHandler.nearestValueOf(zBitPix);
-                if (primitiveType == PrimitiveTypes.UNKNOWN) {
-                    throw new IllegalArgumentException("illegal value for zbitpix " + zBitPix);
-                }
+            ElementType<Buffer> elementType = ElementType.forNearestBitpix(zBitPix);
+            if (elementType == ElementType.UNKNOWN) {
+                throw new IllegalArgumentException("illegal value for ZBITPIX " + zBitPix);
             }
-            setBaseType(primitiveType);
+            setBaseType(elementType);
         }
     }
 

--- a/src/main/java/nom/tam/image/compression/tile/mask/NullPixelMaskPreserver.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/NullPixelMaskPreserver.java
@@ -40,7 +40,7 @@ import java.nio.ShortBuffer;
 
 import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.image.tile.operation.buffer.TileBuffer;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /**
  * This class overwrites the pixels specified in the mask with null values.
@@ -53,17 +53,17 @@ public class NullPixelMaskPreserver extends AbstractNullPixelMask {
     }
 
     public void preserveNull() {
-        if (getTileBuffer().getBaseType().is(PrimitiveTypes.DOUBLE)) {
+        if (getTileBuffer().getBaseType().is(ElementType.DOUBLE)) {
             preserveNullDoubles();
-        } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.FLOAT)) {
+        } else if (getTileBuffer().getBaseType().is(ElementType.FLOAT)) {
             preserveNullFloats();
-        } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.LONG)) {
+        } else if (getTileBuffer().getBaseType().is(ElementType.LONG)) {
             preserveNullLongs();
-        } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.INT)) {
+        } else if (getTileBuffer().getBaseType().is(ElementType.INT)) {
             preserveNullInts();
-        } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.SHORT)) {
+        } else if (getTileBuffer().getBaseType().is(ElementType.SHORT)) {
             preserveNullShorts();
-        } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.BYTE)) {
+        } else if (getTileBuffer().getBaseType().is(ElementType.BYTE)) {
             preserveNullBytes();
         }
         if (getMask() != null) {

--- a/src/main/java/nom/tam/image/compression/tile/mask/NullPixelMaskRestorer.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/NullPixelMaskRestorer.java
@@ -40,7 +40,7 @@ import java.nio.ShortBuffer;
 
 import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.image.tile.operation.buffer.TileBuffer;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /**
  * restore the null pixel values of an image.
@@ -57,17 +57,17 @@ public class NullPixelMaskRestorer extends AbstractNullPixelMask {
             ByteBuffer decompressed = ByteBuffer.allocate(getTileBuffer().getPixelSize());
             getCompressorControl().decompress(getMask(), decompressed, getCompressorControl().option());
             setMask(decompressed);
-            if (getTileBuffer().getBaseType().is(PrimitiveTypes.DOUBLE)) {
+            if (getTileBuffer().getBaseType().is(ElementType.DOUBLE)) {
                 restoreNullDoubles();
-            } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.FLOAT)) {
+            } else if (getTileBuffer().getBaseType().is(ElementType.FLOAT)) {
                 restoreNullFloats();
-            } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.LONG)) {
+            } else if (getTileBuffer().getBaseType().is(ElementType.LONG)) {
                 restoreNullLongs();
-            } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.INT)) {
+            } else if (getTileBuffer().getBaseType().is(ElementType.INT)) {
                 restoreNullInts();
-            } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.SHORT)) {
+            } else if (getTileBuffer().getBaseType().is(ElementType.SHORT)) {
                 restoreNullShorts();
-            } else if (getTileBuffer().getBaseType().is(PrimitiveTypes.BYTE)) {
+            } else if (getTileBuffer().getBaseType().is(ElementType.BYTE)) {
                 restoreNullBytes();
             }
         }

--- a/src/main/java/nom/tam/image/tile/operation/AbstractTileOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/AbstractTileOperation.java
@@ -37,7 +37,7 @@ import java.util.concurrent.Future;
 
 import nom.tam.image.tile.operation.buffer.TileBuffer;
 import nom.tam.image.tile.operation.buffer.TileBufferFactory;
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 
 public abstract class AbstractTileOperation implements Runnable, ITileOperation {
 
@@ -101,7 +101,7 @@ public abstract class AbstractTileOperation implements Runnable, ITileOperation 
         }
     }
 
-    protected PrimitiveType<Buffer> getBaseType() {
+    protected ElementType<Buffer> getBaseType() {
         return this.tiledImageOperation.getBaseType();
     }
 

--- a/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
@@ -38,7 +38,7 @@ import java.nio.Buffer;
 import java.util.Arrays;
 
 import nom.tam.fits.FitsException;
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 
 public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperation> implements ITiledImageOperation {
 
@@ -47,7 +47,7 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
     /**
      * Interprets the value of the BITPIX keyword in the uncompressed FITS image
      */
-    private PrimitiveType<Buffer> baseType;
+    private ElementType<Buffer> baseType;
 
     private int[] tileAxes;
 
@@ -60,7 +60,7 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
     }
 
     @Override
-    public PrimitiveType<Buffer> getBaseType() {
+    public ElementType<Buffer> getBaseType() {
         return this.baseType;
     }
 
@@ -147,7 +147,7 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
         return this.tileOperations;
     }
 
-    protected void setBaseType(PrimitiveType<Buffer> baseType) {
+    protected void setBaseType(ElementType<Buffer> baseType) {
         this.baseType = baseType;
     }
 }

--- a/src/main/java/nom/tam/image/tile/operation/ITiledImageOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/ITiledImageOperation.java
@@ -36,12 +36,12 @@ import java.nio.ByteBuffer;
 
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.algorithm.api.ICompressorControl;
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 
 public interface ITiledImageOperation {
     ICompressOption compressOptions();
     
-    PrimitiveType<Buffer> getBaseType();
+    ElementType<Buffer> getBaseType();
     
     ByteBuffer getCompressedWholeArea();
 

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBuffer.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBuffer.java
@@ -33,7 +33,7 @@ package nom.tam.image.tile.operation.buffer;
 
 import java.nio.Buffer;
 
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 
 /**
  * This view on the image data represents a tileOperation that is row based, so
@@ -50,11 +50,11 @@ public abstract class TileBuffer {
     /**
      * the tileOperation this view is connected to
      */
-    private final PrimitiveType<Buffer> baseType;
+    private final ElementType<Buffer> baseType;
 
     private final int width;
 
-    protected TileBuffer(PrimitiveType<Buffer> baseType, int dataOffset, int width, int height) {
+    protected TileBuffer(ElementType<Buffer> baseType, int dataOffset, int width, int height) {
         this.baseType = baseType;
         this.offset = dataOffset;
         this.width = width;
@@ -68,7 +68,7 @@ public abstract class TileBuffer {
     public void finish() {
     }
 
-    public PrimitiveType<Buffer> getBaseType() {
+    public ElementType<Buffer> getBaseType() {
         return this.baseType;
     }
 

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferColumnBased.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferColumnBased.java
@@ -33,8 +33,7 @@ package nom.tam.image.tile.operation.buffer;
 
 import java.nio.Buffer;
 
-import nom.tam.util.type.PrimitiveType;
-import nom.tam.util.type.PrimitiveTypeHandler;
+import nom.tam.util.type.ElementType;
 
 /**
  * This subclass of the row based view, will abstract the problems that occur
@@ -58,7 +57,7 @@ class TileBufferColumnBased extends TileBuffer {
      */
     private final int imageWidth;
 
-    TileBufferColumnBased(PrimitiveType<Buffer> baseType, int dataOffset, int imageWidth, int width, int height) {
+    TileBufferColumnBased(ElementType<Buffer> baseType, int dataOffset, int imageWidth, int width, int height) {
         super(baseType, dataOffset, width, height);
         this.imageWidth = imageWidth;
     }
@@ -85,7 +84,7 @@ class TileBufferColumnBased extends TileBuffer {
         Buffer imagebuffer = getImageBuffer();
         imagebuffer.position(0);
         imagebuffer.limit(0);
-        PrimitiveType<Buffer> type = primitiveType();
+        ElementType<Buffer> type = elementType();
         this.gapLessBuffer = type.newBuffer(getPixelSize());
         while (imagebuffer.limit() < pixelSizeInData) {
             imagebuffer.limit(imagebuffer.position() + getWidth());
@@ -108,7 +107,7 @@ class TileBufferColumnBased extends TileBuffer {
         imagebuffer.rewind();
         this.gapLessBuffer.rewind();
         this.gapLessBuffer.limit(0);
-        PrimitiveType<Buffer> type = primitiveType();
+        ElementType<Buffer> type = elementType();
         while (this.gapLessBuffer.limit() < pixelSize) {
             this.gapLessBuffer.limit(this.gapLessBuffer.position() + getWidth());
             type.appendBuffer(imagebuffer, this.gapLessBuffer);
@@ -126,8 +125,8 @@ class TileBufferColumnBased extends TileBuffer {
         return (getHeight() - 1) * this.imageWidth + getWidth();
     }
 
-    private PrimitiveType<Buffer> primitiveType() {
-        return PrimitiveTypeHandler.valueOf(getImageBuffer().getClass());
+    private ElementType<Buffer> elementType() {
+        return ElementType.forBuffer(getImageBuffer());
     }
 
 }

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferFactory.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferFactory.java
@@ -33,11 +33,11 @@ package nom.tam.image.tile.operation.buffer;
 
 import java.nio.Buffer;
 
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 
 public final class TileBufferFactory {
 
-    public static TileBuffer createTileBuffer(PrimitiveType<Buffer> baseType, int dataOffset, int imageWidth, int width, int height) {
+    public static TileBuffer createTileBuffer(ElementType<Buffer> baseType, int dataOffset, int imageWidth, int width, int height) {
         if (imageWidth > width) {
             return new TileBufferColumnBased(baseType, dataOffset, imageWidth, width, height);
         }

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferRowBased.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferRowBased.java
@@ -33,11 +33,11 @@ package nom.tam.image.tile.operation.buffer;
 
 import java.nio.Buffer;
 
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 
 public class TileBufferRowBased extends TileBuffer {
 
-    public TileBufferRowBased(PrimitiveType<Buffer> baseType, int dataOffset, int width, int height) {
+    public TileBufferRowBased(ElementType<Buffer> baseType, int dataOffset, int width, int height) {
         super(baseType, dataOffset, width, height);
     }
 

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -91,11 +91,11 @@ public final class ArrayFuncs {
             }
             return size;
         }
-        ElementType<?> primType = ElementType.forClass(o.getClass());
-        if (primType.individualSize()) {
-            return primType.size(o);
+        ElementType<?> elementType = ElementType.forClass(o.getClass());
+        if (elementType.isVariableSize()) {
+            return elementType.size(o);
         }
-        return primType.size();
+        return elementType.size();
     }
 
     /**

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -38,8 +38,7 @@ import java.util.logging.Logger;
 
 import nom.tam.util.array.MultiArrayCopier;
 import nom.tam.util.array.MultiArrayIterator;
-import nom.tam.util.type.PrimitiveType;
-import nom.tam.util.type.PrimitiveTypeHandler;
+import nom.tam.util.type.ElementType;
 
 /**
  * This is a package of static functions which perform computations on arrays.
@@ -80,19 +79,19 @@ public final class ArrayFuncs {
                 long length = Array.getLength(array);
                 if (length > 0) {
                     Class<?> componentType = array.getClass().getComponentType();
-                    PrimitiveType<?> primType = PrimitiveTypeHandler.valueOf(componentType);
+                    ElementType<?> elementType = ElementType.forClass(componentType);
                     if (componentType.isPrimitive()) {
-                        size += length * primType.size();
+                        size += length * elementType.size();
                     } else {
                         for (int index = 0; index < length; index++) {
-                            size += primType.size(Array.get(array, index));
+                            size += elementType.size(Array.get(array, index));
                         }
                     }
                 }
             }
             return size;
         }
-        PrimitiveType<?> primType = PrimitiveTypeHandler.valueOf(o.getClass());
+        ElementType<?> primType = ElementType.forClass(o.getClass());
         if (primType.individualSize()) {
             return primType.size(o);
         }
@@ -358,7 +357,7 @@ public final class ArrayFuncs {
         if (o == null) {
             return 0;
         }
-        PrimitiveType<?> type = PrimitiveTypeHandler.valueOf(getBaseClass(o));
+        ElementType<?> type = ElementType.forClass(getBaseClass(o));
         if (type != null && type.size() != 0) {
             return type.size();
         }

--- a/src/main/java/nom/tam/util/BufferPointer.java
+++ b/src/main/java/nom/tam/util/BufferPointer.java
@@ -43,12 +43,12 @@ public class BufferPointer {
     /**
      * The number of valid characters in the buffer
      */
-    protected int bufferLength;
+    protected int length;
 
     /**
      * The current offset into the buffer
      */
-    protected int bufferOffset;
+    protected int pos;
 
     public BufferPointer() {
     }
@@ -60,13 +60,21 @@ public class BufferPointer {
 
     protected BufferPointer init(int bufferSize) {
         this.buffer = new byte[bufferSize];
-        this.bufferOffset = 0;
-        this.bufferLength = 0;
+        this.pos = 0;
+        this.length = 0;
         return this;
     }
 
     protected void invalidate() {
-        this.bufferLength = 0;
-        this.bufferOffset = 0;
+        this.length = 0;
+        this.pos = 0;
+    }
+    
+    public final byte readByte() {
+        return buffer[pos++];
+    }
+    
+    public final void writeByte(byte b) {
+        buffer[pos++] = b;
     }
 }

--- a/src/main/java/nom/tam/util/BufferedDataInputStream.java
+++ b/src/main/java/nom/tam/util/BufferedDataInputStream.java
@@ -158,7 +158,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
     }
 
     @Override
-    public int read(boolean[] b) throws IOException {
+    public final int read(boolean[] b) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -189,7 +189,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
     }
 
     @Override
-    public int read(char[] c) throws IOException {
+    public final int read(char[] c) throws IOException {
         return read(c, 0, c.length);
     }
 
@@ -199,7 +199,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
     }
 
     @Override
-    public int read(double[] d) throws IOException {
+    public final int read(double[] d) throws IOException {
         return read(d, 0, d.length);
     }
 
@@ -209,7 +209,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
     }
 
     @Override
-    public int read(float[] f) throws IOException {
+    public final int read(float[] f) throws IOException {
         return read(f, 0, f.length);
     }
 
@@ -219,7 +219,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
     }
 
     @Override
-    public int read(int[] i) throws IOException {
+    public final int read(int[] i) throws IOException {
         return read(i, 0, i.length);
     }
 
@@ -229,7 +229,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
     }
 
     @Override
-    public int read(long[] l) throws IOException {
+    public final int read(long[] l) throws IOException {
         return read(l, 0, l.length);
     }
 
@@ -239,7 +239,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
     }
 
     @Override
-    public int read(short[] s) throws IOException {
+    public final int read(short[] s) throws IOException {
         return read(s, 0, s.length);
     }
 
@@ -256,7 +256,7 @@ public class BufferedDataInputStream extends BufferedInputStream implements Arra
 
     @Override
     public boolean readBoolean() throws IOException {
-        return read() == 1;
+        return this.bufferDecoder.readBoolean();
     }
 
     @Override

--- a/src/main/java/nom/tam/util/BufferedDataOutputStream.java
+++ b/src/main/java/nom/tam/util/BufferedDataOutputStream.java
@@ -67,15 +67,14 @@ public class BufferedDataOutputStream extends BufferedOutputStream implements Ar
         @Override
         protected void needBuffer(int need) throws IOException {
             BufferedDataOutputStream.this.checkBuf(need);
-            BufferedDataOutputStream.this.bufferPointer.bufferLength = BufferedDataOutputStream.this.count;
-            BufferedDataOutputStream.this.bufferPointer.bufferOffset = BufferedDataOutputStream.this.count;
+            BufferedDataOutputStream.this.bufferPointer.length = BufferedDataOutputStream.this.count;
+            BufferedDataOutputStream.this.bufferPointer.pos = BufferedDataOutputStream.this.count;
             BufferedDataOutputStream.this.count += need;
         }
 
         @Override
         protected void write(byte[] buf, int offset, int length) throws IOException {
             BufferedDataOutputStream.this.write(buf, offset, length);
-
         }
     };
 
@@ -213,7 +212,7 @@ public class BufferedDataOutputStream extends BufferedOutputStream implements Ar
 
     @Override
     public void writeByte(int b) throws IOException {
-        this.bufferEncoder.writeByte(b);
+        this.bufferEncoder.writeByte((byte) (b & FitsIO.BYTE_MASK));
     }
 
     @Override
@@ -223,7 +222,7 @@ public class BufferedDataOutputStream extends BufferedOutputStream implements Ar
 
     @Override
     public void writeChar(int c) throws IOException {
-        this.bufferEncoder.writeChar(c);
+        this.bufferEncoder.writeChar((char) (c & FitsIO.SHORT_MASK));
     }
 
     @Override

--- a/src/main/java/nom/tam/util/ColumnTable.java
+++ b/src/main/java/nom/tam/util/ColumnTable.java
@@ -39,9 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import nom.tam.util.type.PrimitiveType;
-import nom.tam.util.type.PrimitiveTypeHandler;
-import nom.tam.util.type.PrimitiveTypes;
+import nom.tam.util.type.ElementType;
 
 /**
  * A data table is conventionally considered to consist of rows and columns,
@@ -77,11 +75,11 @@ public class ColumnTable<T> implements DataTable {
 
     }
 
-    private static final Map<PrimitiveType<?>, PointerAccess<?>> POINTER_ACCESSORS;
+    private static final Map<ElementType<?>, PointerAccess<?>> POINTER_ACCESSORS;
 
     private static final PointerAccess<?>[] POINTER_ACCESSORS_BY_TYPE = new PointerAccess<?>[MAX_TYPE_VALUE];
     static {
-        POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.BYTE.type()] = new PointerAccess<byte[][]>() {
+        POINTER_ACCESSORS_BY_TYPE[ElementType.BYTE.type()] = new PointerAccess<byte[][]>() {
 
             @Override
             public byte[][] get(ColumnTable<?> table) {
@@ -104,7 +102,7 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.bytePointers[index], arrOffset, size);
             }
         };
-        POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.BOOLEAN.type()] = new PointerAccess<boolean[][]>() {
+        POINTER_ACCESSORS_BY_TYPE[ElementType.BOOLEAN.type()] = new PointerAccess<boolean[][]>() {
 
             @Override
             public boolean[][] get(ColumnTable<?> table) {
@@ -126,7 +124,7 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.booleanPointers[index], arrOffset, size);
             }
         };
-        POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.SHORT.type()] = new PointerAccess<short[][]>() {
+        POINTER_ACCESSORS_BY_TYPE[ElementType.SHORT.type()] = new PointerAccess<short[][]>() {
 
             @Override
             public short[][] get(ColumnTable<?> table) {
@@ -148,7 +146,7 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.shortPointers[index], arrOffset, size);
             }
         };
-        POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.CHAR.type()] = new PointerAccess<char[][]>() {
+        POINTER_ACCESSORS_BY_TYPE[ElementType.CHAR.type()] = new PointerAccess<char[][]>() {
 
             @Override
             public char[][] get(ColumnTable<?> table) {
@@ -171,7 +169,7 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.charPointers[index], arrOffset, size);
             }
         };
-        POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.INT.type()] = new PointerAccess<int[][]>() {
+        POINTER_ACCESSORS_BY_TYPE[ElementType.INT.type()] = new PointerAccess<int[][]>() {
 
             @Override
             public int[][] get(ColumnTable<?> table) {
@@ -193,7 +191,7 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.intPointers[index], arrOffset, size);
             }
         };
-        POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.LONG.type()] = new PointerAccess<long[][]>() {
+        POINTER_ACCESSORS_BY_TYPE[ElementType.LONG.type()] = new PointerAccess<long[][]>() {
 
             @Override
             public long[][] get(ColumnTable<?> table) {
@@ -215,7 +213,7 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.longPointers[index], arrOffset, size);
             }
         };
-        POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.FLOAT.type()] = new PointerAccess<float[][]>() {
+        POINTER_ACCESSORS_BY_TYPE[ElementType.FLOAT.type()] = new PointerAccess<float[][]>() {
 
             @Override
             public float[][] get(ColumnTable<?> table) {
@@ -237,7 +235,7 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.floatPointers[index], arrOffset, size);
             }
         };
-        POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.DOUBLE.type()] = new PointerAccess<double[][]>() {
+        POINTER_ACCESSORS_BY_TYPE[ElementType.DOUBLE.type()] = new PointerAccess<double[][]>() {
 
             @Override
             public double[][] get(ColumnTable<?> table) {
@@ -259,15 +257,15 @@ public class ColumnTable<T> implements DataTable {
                 is.read(table.doublePointers[index], arrOffset, size);
             }
         };
-        Map<PrimitiveType<?>, PointerAccess<?>> pointerAccess = new HashMap<>();
-        pointerAccess.put(PrimitiveTypes.BYTE, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.BYTE.type()]);
-        pointerAccess.put(PrimitiveTypes.BOOLEAN, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.BOOLEAN.type()]);
-        pointerAccess.put(PrimitiveTypes.CHAR, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.CHAR.type()]);
-        pointerAccess.put(PrimitiveTypes.SHORT, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.SHORT.type()]);
-        pointerAccess.put(PrimitiveTypes.INT, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.INT.type()]);
-        pointerAccess.put(PrimitiveTypes.LONG, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.LONG.type()]);
-        pointerAccess.put(PrimitiveTypes.FLOAT, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.FLOAT.type()]);
-        pointerAccess.put(PrimitiveTypes.DOUBLE, POINTER_ACCESSORS_BY_TYPE[PrimitiveTypes.DOUBLE.type()]);
+        Map<ElementType<?>, PointerAccess<?>> pointerAccess = new HashMap<>();
+        pointerAccess.put(ElementType.BYTE, POINTER_ACCESSORS_BY_TYPE[ElementType.BYTE.type()]);
+        pointerAccess.put(ElementType.BOOLEAN, POINTER_ACCESSORS_BY_TYPE[ElementType.BOOLEAN.type()]);
+        pointerAccess.put(ElementType.CHAR, POINTER_ACCESSORS_BY_TYPE[ElementType.CHAR.type()]);
+        pointerAccess.put(ElementType.SHORT, POINTER_ACCESSORS_BY_TYPE[ElementType.SHORT.type()]);
+        pointerAccess.put(ElementType.INT, POINTER_ACCESSORS_BY_TYPE[ElementType.INT.type()]);
+        pointerAccess.put(ElementType.LONG, POINTER_ACCESSORS_BY_TYPE[ElementType.LONG.type()]);
+        pointerAccess.put(ElementType.FLOAT, POINTER_ACCESSORS_BY_TYPE[ElementType.FLOAT.type()]);
+        pointerAccess.put(ElementType.DOUBLE, POINTER_ACCESSORS_BY_TYPE[ElementType.DOUBLE.type()]);
         POINTER_ACCESSORS = Collections.unmodifiableMap(pointerAccess);
     }
 
@@ -386,7 +384,7 @@ public class ColumnTable<T> implements DataTable {
 
     @SuppressWarnings("unchecked")
     private PointerAccess<Object> selectPointerAccessor(Object data) {
-        return (PointerAccess<Object>) POINTER_ACCESSORS.get(PrimitiveTypeHandler.valueOf(data.getClass().getComponentType()));
+        return (PointerAccess<Object>) POINTER_ACCESSORS.get(ElementType.forClass(data.getClass().getComponentType()));
     }
 
     @SuppressWarnings("unchecked")
@@ -728,14 +726,14 @@ public class ColumnTable<T> implements DataTable {
         }
         // Allocate the pointer arrays. Note that many will be
         // zero-length.
-        this.bytePointers = new byte[columnIndex[PrimitiveTypes.BYTE.type()]][];
-        this.shortPointers = new short[columnIndex[PrimitiveTypes.SHORT.type()]][];
-        this.intPointers = new int[columnIndex[PrimitiveTypes.INT.type()]][];
-        this.longPointers = new long[columnIndex[PrimitiveTypes.LONG.type()]][];
-        this.floatPointers = new float[columnIndex[PrimitiveTypes.FLOAT.type()]][];
-        this.doublePointers = new double[columnIndex[PrimitiveTypes.DOUBLE.type()]][];
-        this.charPointers = new char[columnIndex[PrimitiveTypes.CHAR.type()]][];
-        this.booleanPointers = new boolean[columnIndex[PrimitiveTypes.BOOLEAN.type()]][];
+        this.bytePointers = new byte[columnIndex[ElementType.BYTE.type()]][];
+        this.shortPointers = new short[columnIndex[ElementType.SHORT.type()]][];
+        this.intPointers = new int[columnIndex[ElementType.INT.type()]][];
+        this.longPointers = new long[columnIndex[ElementType.LONG.type()]][];
+        this.floatPointers = new float[columnIndex[ElementType.FLOAT.type()]][];
+        this.doublePointers = new double[columnIndex[ElementType.DOUBLE.type()]][];
+        this.charPointers = new char[columnIndex[ElementType.CHAR.type()]][];
+        this.booleanPointers = new boolean[columnIndex[ElementType.BOOLEAN.type()]][];
         // Now set the pointers.
         Arrays.fill(columnIndex, 0);
         for (int col = 0; col < this.arrays.length; col += 1) {

--- a/src/main/java/nom/tam/util/ColumnTable.java
+++ b/src/main/java/nom/tam/util/ColumnTable.java
@@ -622,7 +622,22 @@ public class ColumnTable<T> implements DataTable {
     }
 
     /**
-     * Get a particular column.
+     * <p>
+     * Gets a particular column in the format that it is stored in the FITS. For most column types
+     * the storage format matches the Java type, but there are exceptions:
+     * </p>
+     * <ul>
+     * <li>Character arrays in FITS are stored as <code>byte[]</code> or <code>short[]</code>, depending
+     * on the {@link nom.tam.fits.FitsFactory#setUseUnicodeChars(boolean)} setting, not unicode Java <code>char[]</code>.
+     * Therefore, this call will return <code>byte[]</code> or <code>short[]</code>, the same as for a byte or 16-bit 
+     * integer array. As a result if a new table is created with the returned data, the new table column will change 
+     * its FITS column type from <code>A</code> to <code>B</code> or <code>I</code>.</li>
+     * <li>Complex values in FITS are stored as <code>float[2]</code> or <code>double[2]</code>, not as a 
+     * {@link ComplexValue} type. Therefore, this call will return <code>float[]</code> or <code>double[]</code>, the 
+     * same as for a float array. As a result if a new table is created with the returned data, the new table column 
+     * will change it's FITS column type from <code>C</code> to <code>F</code>, or from <code>M</code> to 
+     * <code>D</code>,.</li>
+     * </ul>
      * 
      * @param col
      *            The column desired.
@@ -633,7 +648,7 @@ public class ColumnTable<T> implements DataTable {
     public Object getColumn(int col) {
         return this.arrays[col];
     }
-
+    
     /**
      * @return the actual data arrays
      */

--- a/src/main/java/nom/tam/util/ComplexValue.java
+++ b/src/main/java/nom/tam/util/ComplexValue.java
@@ -38,14 +38,22 @@ import nom.tam.fits.FitsFactory;
 import nom.tam.fits.LongValueException;
 
 /**
- * A no-frills complex value, mainly just for representing complex numbers in FITS headers.
- * Its a non-mutable object that is created with a real and imaginary parts, which can be
+ * <p>
+ * A no-frills complex value, for representing complex numbers in FITS headers.
+ * It is a non-mutable object that is created with a real and imaginary parts, which can be
  * retrieved thereafter, and provides string formatting that is suited specifically for
  * representation in FITS headers.
+ * </p>
+ * 
+ * <p>
+ * Note that binary tables handle complex data differently, with elements of `float[2]` or
+ * `double[2]`.
+ * </p>
  * 
  * @author Attila Kovacs
  *
  * @since 1.16
+ * 
  */
 public class ComplexValue {
     
@@ -79,6 +87,92 @@ public class ComplexValue {
         this.re = re;
         this.im = im;
     }
+    
+    
+    /**
+     * Returns the real part of this complex value.
+     * 
+     * @return      the real part
+     * 
+     * @see #im()
+     */
+    public final double re() {
+        return re;
+    }
+
+    /**
+     * Returns the imaginary part of this complex value.
+     * 
+     * @return      the imaginary part
+     * 
+     * @see #re()
+     */
+    public final double im() {
+        return im;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Double.hashCode(re()) ^ Double.hashCode(im());
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        
+        if (!(o instanceof ComplexValue)) {
+            return false;
+        }
+        
+        ComplexValue z = (ComplexValue) o;
+        return z.re() == re() && z.im() == im();        
+    }
+    
+    /**
+     * Checks if the complex value is zero. That is, if both the real or imaginary parts
+     * are zero.
+     * 
+     * @return      <code>true</code>if both the real or imaginary parts are zero.
+     *              Otherwise <code>false</code>.
+     */
+    public final boolean isZero() {
+        return re() == 0.0 && im() == 0.0;
+    }
+    
+    /**
+     * Checks if the complex value is finite. That is, if neither the real or imaginary parts
+     * are NaN or Infinite.
+     * 
+     * @return      <code>true</code>if neither the real or imaginary parts are NaN or Infinite.
+     *              Otherwise <code>false</code>.
+     */
+    public final boolean isFinite() {
+        return Double.isFinite(re()) && Double.isFinite(im());
+    }
+    
+    @Override
+    public String toString() {
+        return "(" + re() + "," + im() + ")";
+    }
+    
+    /**
+     * Converts this complex value to its string representation with up to the specified 
+     * number of decimal places showing after the leading figure, for both the
+     * real and imaginary parts. 
+     * 
+     * @param decimals  the maximum number of decimal places to show.
+     * @return          the string representation with the specified precision, which
+     *                  may be used in a FITS header.
+     *                  
+     * @see FlexFormat
+     */
+    public String toString(int decimals) {
+        FlexFormat f = new FlexFormat().setPrecision(decimals); 
+        return "(" + f.format(re()) + "," + f.format(im()) + ")";
+    }
+    
 
     /**
      * <p>
@@ -143,91 +237,6 @@ public class ComplexValue {
         }
     }
     
-    
-    @Override
-    public int hashCode() {
-        return Double.hashCode(re) ^ Double.hashCode(im);
-    }
-    
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        }
-        
-        if (!(o instanceof ComplexValue)) {
-            return false;
-        }
-        
-        ComplexValue z = (ComplexValue) o;
-        return z.re() == re() && z.im() == im();        
-    }
-    
-    
-    /**
-     * Checks if the complex value is zero. That is, if both the real or imaginary parts
-     * are zero.
-     * 
-     * @return      <code>true</code>if both the real or imaginary parts are zero.
-     *              Otherwise <code>false</code>.
-     */
-    public final boolean isZero() {
-        return re() == 0.0 && im() == 0.0;
-    }
-    
-    /**
-     * Checks if the complex value is finite. That is, if neither the real or imaginary parts
-     * are NaN or Infinite.
-     * 
-     * @return      <code>true</code>if neither the real or imaginary parts are NaN or Infinite.
-     *              Otherwise <code>false</code>.
-     */
-    public final boolean isFinite() {
-        return Double.isFinite(re) && Double.isFinite(im);
-    }
-    
-    /**
-     * Returns the real part of this complex value.
-     * 
-     * @return      the real part
-     * 
-     * @see #im()
-     */
-    public final double re() {
-        return re;
-    }
-    
-    /**
-     * Returns the imaginary part of this complex value.
-     * 
-     * @return      the imaginary part
-     * 
-     * @see #re()
-     */
-    public final double im() {
-        return im;
-    }
-    
-    @Override
-    public String toString() {
-        return "(" + re + "," + im + ")";
-    }
-    
-    /**
-     * Converts this complex value to its string representation with up to the specified 
-     * number of decimal places showing after the leading figure, for both the
-     * real and imaginary parts. 
-     * 
-     * @param decimals  the maximum number of decimal places to show.
-     * @return          the string representation with the specified precision, which
-     *                  may be used in a FITS header.
-     *                  
-     * @see FlexFormat
-     */
-    public String toString(int decimals) {
-        FlexFormat f = new FlexFormat().setPrecision(decimals); 
-        return "(" + f.format(re) + "," + f.format(im) + ")";
-    }
     
     /**
      * Converts this comlex value to its string representation using up to the

--- a/src/main/java/nom/tam/util/type/BooleanType.java
+++ b/src/main/java/nom/tam/util/type/BooleanType.java
@@ -33,7 +33,7 @@ package nom.tam.util.type;
 
 import java.nio.Buffer;
 
-class BooleanType extends PrimitiveTypeBase<Buffer> {
+class BooleanType extends ElementType<Buffer> {
 
     protected BooleanType() {
         super(1, false, boolean.class, Boolean.class, null, 'Z', 0);

--- a/src/main/java/nom/tam/util/type/ByteType.java
+++ b/src/main/java/nom/tam/util/type/ByteType.java
@@ -33,12 +33,13 @@ package nom.tam.util.type;
 
 import java.nio.ByteBuffer;
 
-class ByteType extends PrimitiveTypeBase<ByteBuffer> {
+import nom.tam.fits.header.Bitpix;
 
-    private static final int BIT_PIX = 8;
+class ByteType extends ElementType<ByteBuffer> {
+
 
     protected ByteType() {
-        super(1, false, byte.class, Byte.class, ByteBuffer.class, 'B', BIT_PIX);
+        super(1, false, byte.class, Byte.class, ByteBuffer.class, 'B', Bitpix.BITPIX_BYTE);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/ByteType.java
+++ b/src/main/java/nom/tam/util/type/ByteType.java
@@ -39,7 +39,7 @@ class ByteType extends ElementType<ByteBuffer> {
 
 
     protected ByteType() {
-        super(1, false, byte.class, Byte.class, ByteBuffer.class, 'B', Bitpix.BITPIX_BYTE);
+        super(1, false, byte.class, Byte.class, ByteBuffer.class, 'B', Bitpix.VALUE_FOR_BYTE);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/CharType.java
+++ b/src/main/java/nom/tam/util/type/CharType.java
@@ -33,7 +33,7 @@ package nom.tam.util.type;
 
 import java.nio.CharBuffer;
 
-class CharType extends PrimitiveTypeBase<CharBuffer> {
+class CharType extends ElementType<CharBuffer> {
 
     protected CharType() {
         super(2, false, char.class, Character.class, CharBuffer.class, 'C', 0);

--- a/src/main/java/nom/tam/util/type/CharType.java
+++ b/src/main/java/nom/tam/util/type/CharType.java
@@ -31,11 +31,18 @@ package nom.tam.util.type;
  * #L%
  */
 
-import java.nio.CharBuffer;
+import java.nio.ByteBuffer;
 
-class CharType extends ElementType<CharBuffer> {
+import nom.tam.fits.FitsFactory;
+
+class CharType extends ElementType<ByteBuffer> {
 
     protected CharType() {
-        super(2, false, char.class, Character.class, CharBuffer.class, 'C', 0);
+        super(0, false, char.class, Character.class, null, 'C', 0);
+    }   
+    
+    @Override
+    public int size() {
+        return FitsFactory.isUseUnicodeChars() ? ElementType.SHORT.size() : ElementType.BYTE.size();
     }
 }

--- a/src/main/java/nom/tam/util/type/DoubleType.java
+++ b/src/main/java/nom/tam/util/type/DoubleType.java
@@ -41,7 +41,7 @@ class DoubleType extends ElementType<DoubleBuffer> {
     private static final int SIZE = 8;
 
     protected DoubleType() {
-        super(SIZE, false, double.class, Double.class, DoubleBuffer.class, 'D', Bitpix.BITPIX_DOUBLE);
+        super(SIZE, false, double.class, Double.class, DoubleBuffer.class, 'D', Bitpix.VALUE_FOR_DOUBLE);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/DoubleType.java
+++ b/src/main/java/nom/tam/util/type/DoubleType.java
@@ -34,14 +34,14 @@ package nom.tam.util.type;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 
-class DoubleType extends PrimitiveTypeBase<DoubleBuffer> {
+import nom.tam.fits.header.Bitpix;
 
-    private static final int BIT_PIX = -64;
+class DoubleType extends ElementType<DoubleBuffer> {
 
     private static final int SIZE = 8;
 
     protected DoubleType() {
-        super(SIZE, false, double.class, Double.class, DoubleBuffer.class, 'D', BIT_PIX);
+        super(SIZE, false, double.class, Double.class, DoubleBuffer.class, 'D', Bitpix.BITPIX_DOUBLE);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/ElementType.java
+++ b/src/main/java/nom/tam/util/type/ElementType.java
@@ -1,0 +1,298 @@
+package nom.tam.util.type;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 2004 - 2015 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import java.lang.reflect.Array;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import nom.tam.fits.FitsException;
+import nom.tam.fits.header.Bitpix;
+
+/**
+ * A base data element type in a FITS image or table column, with associated functions.
+ *
+ * @param <B>   the generic type of data buffer
+ */
+public abstract class ElementType<B extends Buffer> {
+
+    public static final int COPY_BLOCK_SIZE = 1024;
+
+    private final int bitPix;
+
+    private final Class<B> bufferClass;
+
+    private final boolean individualSize;
+
+    private final Class<?> primitiveClass;
+
+    private final int size;
+
+    private final char type;
+
+    private final Class<?> wrapperClass;
+
+    protected ElementType(int size, boolean individualSize, Class<?> primitiveClass, Class<?> wrapperClass, Class<B> bufferClass, char type, int bitPix) {
+        this.size = size;
+        this.individualSize = individualSize;
+        this.primitiveClass = primitiveClass;
+        this.wrapperClass = wrapperClass;
+        this.bufferClass = bufferClass;
+        this.type = type;
+        this.bitPix = bitPix;
+    }
+
+
+    public void appendBuffer(B buffer, B dataToAppend) {
+        throw new UnsupportedOperationException("no primitive type");
+    }
+
+ 
+    public void appendToByteBuffer(ByteBuffer byteBuffer, B dataToAppend) {
+        byte[] temp = new byte[Math.min(COPY_BLOCK_SIZE * this.size, dataToAppend.remaining() * this.size)];
+        B typedBuffer = asTypedBuffer(ByteBuffer.wrap(temp));
+        Object array = newArray(Math.min(COPY_BLOCK_SIZE, dataToAppend.remaining()));
+        while (dataToAppend.hasRemaining()) {
+            int part = Math.min(COPY_BLOCK_SIZE, dataToAppend.remaining());
+            getArray(dataToAppend, array, part);
+            putArray(typedBuffer, array, part);
+            byteBuffer.put(temp, 0, part * this.size);
+        }
+    }
+
+    public B asTypedBuffer(ByteBuffer buffer) {
+        throw new UnsupportedOperationException("no primitive buffer available");
+    }
+
+    public int bitPix() {
+        return this.bitPix;
+    }
+
+    public Class<B> bufferClass() {
+        return this.bufferClass;
+    }
+
+    public ByteBuffer convertToByteBuffer(Object array) {
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[Array.getLength(array) * this.size]);
+        putArray(asTypedBuffer(buffer), array);
+        buffer.rewind();
+        return buffer;
+    }
+
+    public final void getArray(B buffer, Object array) {
+        getArray(buffer, array, Array.getLength(array));
+    }
+
+    public final void getArray(B buffer, Object array, int length) {
+        getArray(buffer, array, 0, length);
+    }
+
+    public void getArray(B buffer, Object array, int offset, int length) {
+        throw new UnsupportedOperationException("no primitive type");
+    }
+
+    public boolean individualSize() {
+        return this.individualSize;
+    }
+
+    public boolean is(ElementType<? extends Buffer> other) {
+        return this.bitPix == other.bitPix();
+    }
+
+    public Object newArray(int length) {
+        return null;
+    }
+
+    public final B newBuffer(int length) {
+        return wrap(newArray(length));
+    }
+
+    public final B newBuffer(long length) {
+        // TODO handle big arrays differently by using memory mapped files.
+        return wrap(newArray((int) length));
+    }
+
+    public Class<?> primitiveClass() {
+        return this.primitiveClass;
+    }
+
+    public final void putArray(B buffer, Object array) {
+        putArray(buffer, array, Array.getLength(array));
+    }
+
+    public void putArray(B buffer, Object array, int length) {
+        throw new UnsupportedOperationException("no primitive type");
+    }
+
+    public int size() {
+        return this.size;
+    }
+
+    /**
+     * currently the only individual size primitive so, keep it simple
+     *
+     * @param instance
+     *            the object to calculate the size
+     * @return the size in bytes of the object instance
+     */
+    public int size(Object instance) {
+        if (instance == null) {
+            return 0;
+        }
+        return this.size;
+    }
+
+    public B sliceBuffer(B buffer) {
+        return null;
+    }
+
+    public char type() {
+        return this.type;
+    }
+
+    public B wrap(Object array) {
+        return null;
+    }
+
+    public Class<?> wrapperClass() {
+        return this.wrapperClass;
+    }
+    
+    public static final ElementType<Buffer> BOOLEAN = new BooleanType();
+
+    public static final ElementType<ByteBuffer> BYTE = new ByteType();
+
+    public static final ElementType<CharBuffer> CHAR = new CharType();
+
+    public static final ElementType<DoubleBuffer> DOUBLE = new DoubleType();
+
+    public static final ElementType<FloatBuffer> FLOAT = new FloatType();
+
+    public static final ElementType<IntBuffer> INT = new IntType();
+
+    public static final ElementType<LongBuffer> LONG = new LongType();
+
+    public static final ElementType<ShortBuffer> SHORT = new ShortType();
+
+    public static final ElementType<Buffer> STRING = new StringType();
+
+    public static final ElementType<Buffer> UNKNOWN = new UnknownType();
+
+    
+    private static Map<Class<?>, ElementType<?>> byClass;
+    
+    private static Map<Character, ElementType<?>> byType;
+    
+    static {
+        Map<Class<?>, ElementType<?>> initialByClass = new HashMap<>();
+        Map<Character, ElementType<?>> initialByType = new HashMap<>();
+        for (ElementType<?> type : values()) {
+            initialByType.put(type.type(), type);
+            initialByClass.put(type.primitiveClass(), type);
+            initialByClass.put(type.wrapperClass(), type);
+            if (type.bufferClass() != null) {
+                initialByClass.put(type.bufferClass(), type);
+            }
+        }
+        byClass = Collections.unmodifiableMap(initialByClass);
+        byType = Collections.unmodifiableMap(initialByType);
+    }
+
+
+    public static ElementType<Buffer> forDataID(char type) {
+        return cast(byType.get(type));
+    }
+    
+    public static <B extends Buffer> ElementType<B> forClass(Class<?> clazz) {
+        ElementType<?> primitiveType = byClass.get(clazz);
+        if (primitiveType == null) {
+            for (Class<?> interf : clazz.getInterfaces()) {
+                primitiveType = byClass.get(interf);
+                if (primitiveType != null) {
+                    return cast(primitiveType);
+                }
+            }
+            return forClass(clazz.getSuperclass());
+        }
+        return cast(primitiveType);
+    }
+
+    public static <B extends Buffer> ElementType<B> forBuffer(B b) {
+        return forClass(b.getClass());
+    }
+    
+    public static ElementType<Buffer> forBitpix(int bitPix) {
+        try {
+            return cast(Bitpix.forValue(bitPix).getElementType());
+        } catch (FitsException e) {
+            return null;
+        }
+    }
+    
+    public static ElementType<Buffer> forNearestBitpix(int bitPix) {
+        try {
+            return cast(Bitpix.forValue(bitPix, true).getElementType());
+        } catch (FitsException e) {
+            return UNKNOWN;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <B extends Buffer> ElementType<B> cast(ElementType<?> primitiveType) {
+        return (ElementType<B>) primitiveType;
+    }
+
+    private static ElementType<?>[] values() {
+        return new ElementType[]{
+            BOOLEAN,
+            BYTE,
+            CHAR,
+            DOUBLE,
+            FLOAT,
+            INT,
+            LONG,
+            SHORT,
+            STRING,
+            UNKNOWN
+        };
+    }
+
+}

--- a/src/main/java/nom/tam/util/type/ElementType.java
+++ b/src/main/java/nom/tam/util/type/ElementType.java
@@ -71,10 +71,10 @@ public abstract class ElementType<B extends Buffer> {
     private final Class<?> wrapperClass;
 
     /**
+     * Instantiates a new FITS data element type.
      * 
-     * 
-     * @param size
-     * @param varSize
+     * @param size              the number of bytes in the FITS representation of that type.
+     * @param varSize           <code>true</code> if the element has a size that varies from object to object.
      * @param primitiveClass    The primitive data type, e.g. `int.class`, or <code>null</code> if no primitive type is associated.
      * @param wrapperClass      The boxed data type, e.g. `Integer.class`, or <code>null</code> if no boxed type is associated.
      * @param bufferClass       The type of underlying buffer (in FITS), or <code>null</code> if arrays of this type 

--- a/src/main/java/nom/tam/util/type/FloatType.java
+++ b/src/main/java/nom/tam/util/type/FloatType.java
@@ -41,7 +41,7 @@ class FloatType extends ElementType<FloatBuffer> {
     private static final int SIZE = 4;
 
     protected FloatType() {
-        super(SIZE, false, float.class, Float.class, FloatBuffer.class, 'F', Bitpix.BITPIX_FLOAT);
+        super(SIZE, false, float.class, Float.class, FloatBuffer.class, 'F', Bitpix.VALUE_FOR_FLOAT);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/FloatType.java
+++ b/src/main/java/nom/tam/util/type/FloatType.java
@@ -34,14 +34,14 @@ package nom.tam.util.type;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
-class FloatType extends PrimitiveTypeBase<FloatBuffer> {
+import nom.tam.fits.header.Bitpix;
 
-    private static final int BIT_PIX = -32;
+class FloatType extends ElementType<FloatBuffer> {
 
     private static final int SIZE = 4;
 
     protected FloatType() {
-        super(SIZE, false, float.class, Float.class, FloatBuffer.class, 'F', BIT_PIX);
+        super(SIZE, false, float.class, Float.class, FloatBuffer.class, 'F', Bitpix.BITPIX_FLOAT);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/IntType.java
+++ b/src/main/java/nom/tam/util/type/IntType.java
@@ -41,7 +41,7 @@ class IntType extends ElementType<IntBuffer> {
     private static final int SIZE = 4;
 
     protected IntType() {
-        super(SIZE, false, int.class, Integer.class, IntBuffer.class, 'I', Bitpix.BITPIX_INT);
+        super(SIZE, false, int.class, Integer.class, IntBuffer.class, 'I', Bitpix.VALUE_FOR_INT);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/IntType.java
+++ b/src/main/java/nom/tam/util/type/IntType.java
@@ -34,14 +34,14 @@ package nom.tam.util.type;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
-class IntType extends PrimitiveTypeBase<IntBuffer> {
+import nom.tam.fits.header.Bitpix;
 
-    private static final int BIT_PIX = 32;
+class IntType extends ElementType<IntBuffer> {
 
     private static final int SIZE = 4;
 
     protected IntType() {
-        super(SIZE, false, int.class, Integer.class, IntBuffer.class, 'I', BIT_PIX);
+        super(SIZE, false, int.class, Integer.class, IntBuffer.class, 'I', Bitpix.BITPIX_INT);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/LongType.java
+++ b/src/main/java/nom/tam/util/type/LongType.java
@@ -34,14 +34,14 @@ package nom.tam.util.type;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 
-class LongType extends PrimitiveTypeBase<LongBuffer> {
+import nom.tam.fits.header.Bitpix;
 
-    private static final int BIT_PIX = 64;
+class LongType extends ElementType<LongBuffer> {
 
     private static final int SIZE = 8;
 
     protected LongType() {
-        super(SIZE, false, long.class, Long.class, LongBuffer.class, 'J', BIT_PIX);
+        super(SIZE, false, long.class, Long.class, LongBuffer.class, 'J', Bitpix.BITPIX_LONG);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/LongType.java
+++ b/src/main/java/nom/tam/util/type/LongType.java
@@ -41,7 +41,7 @@ class LongType extends ElementType<LongBuffer> {
     private static final int SIZE = 8;
 
     protected LongType() {
-        super(SIZE, false, long.class, Long.class, LongBuffer.class, 'J', Bitpix.BITPIX_LONG);
+        super(SIZE, false, long.class, Long.class, LongBuffer.class, 'J', Bitpix.VALUE_FOR_LONG);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/PrimitiveType.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2015 nom-tam-fits
+ * Copyright (C) 1996 - 2021 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 
@@ -31,54 +31,21 @@ package nom.tam.util.type;
  * #L%
  */
 
+
 import java.nio.Buffer;
-import java.nio.ByteBuffer;
 
-public interface PrimitiveType<B extends Buffer> {
+/**
+ * @deprecated Use {@link ElementType} instead.
+ *
+ * @param <B>       the generic type of data buffer
+ */
+@Deprecated
+public abstract class PrimitiveType<B extends Buffer> extends ElementType<B> {
 
-    void appendBuffer(B buffer, B dataToAppend);
+    @Deprecated
+    protected PrimitiveType(int size, boolean individualSize, Class<?> primitiveClass, Class<?> wrapperClass,
+            Class<B> bufferClass, char type, int bitPix) {
+        super(size, individualSize, primitiveClass, wrapperClass, bufferClass, type, bitPix);
+    }
 
-    void appendToByteBuffer(ByteBuffer byteBuffer, B dataToAppend);
-
-    B asTypedBuffer(ByteBuffer buffer);
-
-    int bitPix();
-
-    Class<? extends B> bufferClass();
-
-    ByteBuffer convertToByteBuffer(Object array);
-
-    void getArray(B buffer, Object array);
-
-    void getArray(B buffer, Object array, int length);
-
-    void getArray(B buffer, Object array, int offset, int length);
-
-    boolean individualSize();
-
-    boolean is(PrimitiveType<? extends Buffer> d);
-
-    Object newArray(int length);
-
-    B newBuffer(int length);
-
-    B newBuffer(long length);
-
-    Class<?> primitiveClass();
-
-    void putArray(B buffer, Object array);
-
-    void putArray(B buffer, Object array, int length);
-
-    int size();
-
-    int size(Object instance);
-
-    B sliceBuffer(B buffer);
-
-    char type();
-
-    B wrap(Object array);
-
-    Class<?> wrapperClass();
 }

--- a/src/main/java/nom/tam/util/type/PrimitiveTypeBase.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveTypeBase.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2015 nom-tam-fits
+ * Copyright (C) 1996 - 2021 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 
@@ -31,172 +31,20 @@ package nom.tam.util.type;
  * #L%
  */
 
-import java.lang.reflect.Array;
 import java.nio.Buffer;
-import java.nio.ByteBuffer;
 
-abstract class PrimitiveTypeBase<B extends Buffer> implements PrimitiveType<B> {
+/**
+ * @deprecated Use {@link ElementType} instead.
+ *
+ * @param <B>       the generic type of data buffer
+ */
+@Deprecated
+public abstract class PrimitiveTypeBase<B extends Buffer> extends PrimitiveType<B> {
 
-    public static final int COPY_BLOCK_SIZE = 1024;
-
-    private final int bitPix;
-
-    private final Class<B> bufferClass;
-
-    private final boolean individualSize;
-
-    private final Class<?> primitiveClass;
-
-    private final int size;
-
-    private final char type;
-
-    private final Class<?> wrapperClass;
-
-    protected PrimitiveTypeBase(int size, boolean individualSize, Class<?> primitiveClass, Class<?> wrapperClass, Class<B> bufferClass, char type, int bitPix) {
-        this.size = size;
-        this.individualSize = individualSize;
-        this.primitiveClass = primitiveClass;
-        this.wrapperClass = wrapperClass;
-        this.bufferClass = bufferClass;
-        this.type = type;
-        this.bitPix = bitPix;
+    @Deprecated
+    protected PrimitiveTypeBase(int size, boolean individualSize, Class<?> primitiveClass, Class<?> wrapperClass,
+            Class<B> bufferClass, char type, int bitPix) {
+        super(size, individualSize, primitiveClass, wrapperClass, bufferClass, type, bitPix);
     }
 
-    @Override
-    public void appendBuffer(B buffer, B dataToAppend) {
-        throw new UnsupportedOperationException("no primitive type");
-    }
-
-    @Override
-    public void appendToByteBuffer(ByteBuffer byteBuffer, B dataToAppend) {
-        byte[] temp = new byte[Math.min(COPY_BLOCK_SIZE * this.size, dataToAppend.remaining() * this.size)];
-        B typedBuffer = asTypedBuffer(ByteBuffer.wrap(temp));
-        Object array = newArray(Math.min(COPY_BLOCK_SIZE, dataToAppend.remaining()));
-        while (dataToAppend.hasRemaining()) {
-            int part = Math.min(COPY_BLOCK_SIZE, dataToAppend.remaining());
-            getArray(dataToAppend, array, part);
-            putArray(typedBuffer, array, part);
-            byteBuffer.put(temp, 0, part * this.size);
-        }
-    }
-
-    @Override
-    public B asTypedBuffer(ByteBuffer buffer) {
-        throw new UnsupportedOperationException("no primitive buffer available");
-    }
-
-    @Override
-    public int bitPix() {
-        return this.bitPix;
-    }
-
-    @Override
-    public Class<B> bufferClass() {
-        return this.bufferClass;
-    }
-
-    @Override
-    public ByteBuffer convertToByteBuffer(Object array) {
-        ByteBuffer buffer = ByteBuffer.wrap(new byte[Array.getLength(array) * this.size]);
-        putArray(asTypedBuffer(buffer), array);
-        buffer.rewind();
-        return buffer;
-    }
-
-    @Override
-    public final void getArray(B buffer, Object array) {
-        getArray(buffer, array, Array.getLength(array));
-    }
-
-    @Override
-    public final void getArray(B buffer, Object array, int length) {
-        getArray(buffer, array, 0, length);
-    }
-
-    @Override
-    public void getArray(B buffer, Object array, int offset, int length) {
-        throw new UnsupportedOperationException("no primitive type");
-    }
-
-    @Override
-    public boolean individualSize() {
-        return this.individualSize;
-    }
-
-    @Override
-    public boolean is(PrimitiveType<? extends Buffer> other) {
-        return this.bitPix == other.bitPix();
-    }
-
-    @Override
-    public Object newArray(int length) {
-        return null;
-    }
-
-    @Override
-    public final B newBuffer(int length) {
-        return wrap(newArray(length));
-    }
-
-    @Override
-    public final B newBuffer(long length) {
-        // TODO handle big arrays differently by using memory mapped files.
-        return wrap(newArray((int) length));
-    }
-
-    @Override
-    public Class<?> primitiveClass() {
-        return this.primitiveClass;
-    }
-
-    @Override
-    public final void putArray(B buffer, Object array) {
-        putArray(buffer, array, Array.getLength(array));
-    }
-
-    @Override
-    public void putArray(B buffer, Object array, int length) {
-        throw new UnsupportedOperationException("no primitive type");
-    }
-
-    @Override
-    public int size() {
-        return this.size;
-    }
-
-    /**
-     * currently the only individual size primitive so, keep it simple
-     *
-     * @param instance
-     *            the object to calculate the size
-     * @return the size in bytes of the object instance
-     */
-    @Override
-    public int size(Object instance) {
-        if (instance == null) {
-            return 0;
-        }
-        return this.size;
-    }
-
-    @Override
-    public B sliceBuffer(B buffer) {
-        return null;
-    }
-
-    @Override
-    public char type() {
-        return this.type;
-    }
-
-    @Override
-    public B wrap(Object array) {
-        return null;
-    }
-
-    @Override
-    public Class<?> wrapperClass() {
-        return this.wrapperClass;
-    }
 }

--- a/src/main/java/nom/tam/util/type/PrimitiveTypeHandler.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveTypeHandler.java
@@ -32,97 +32,40 @@ package nom.tam.util.type;
  */
 
 import java.nio.Buffer;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
+/**
+ * @deprecated  Use equivalent static methods of {@link ElementType} instead.
+ * 
+ */
+@Deprecated
 public final class PrimitiveTypeHandler {
 
-    private static final int MAX_TYPE_VALUE = 256;
-
-    private static final int BIT_PIX_OFFSET = 64;
-
-    private static PrimitiveType<?>[] byBitPix;
-
-    private static PrimitiveType<?>[] byType;
-
-    private static Map<Class<?>, PrimitiveType<? extends Buffer>> byClass;
-
-    static {
-        byBitPix = new PrimitiveType[BIT_PIX_OFFSET * 2 + 1];
-        byType = new PrimitiveType[MAX_TYPE_VALUE];
-        Map<Class<?>, PrimitiveType<?>> initialByClass = new HashMap<>();
-        for (PrimitiveType<?> type : values()) {
-            if (type.bitPix() != 0) {
-                byBitPix[type.bitPix() + BIT_PIX_OFFSET] = type;
-            }
-            byType[type.type()] = type;
-            initialByClass.put(type.primitiveClass(), type);
-            initialByClass.put(type.wrapperClass(), type);
-            if (type.bufferClass() != null) {
-                initialByClass.put(type.bufferClass(), type);
-            }
-        }
-        byClass = Collections.unmodifiableMap(initialByClass);
+    /**
+     * @deprecated Use {@link ElementType#forDataID(char)} instead.
+     */
+    public static ElementType<Buffer> valueOf(char type) {
+        return ElementType.forDataID(type);
     }
 
-    public static PrimitiveType<?> nearestValueOf(int bitPix) {
-        if (bitPix >= PrimitiveTypes.FLOAT.bitPix() && bitPix < 0) {
-            return PrimitiveTypes.FLOAT;
-        } else if (bitPix >= PrimitiveTypes.DOUBLE.bitPix() && bitPix < PrimitiveTypes.FLOAT.bitPix()) {
-            return PrimitiveTypes.DOUBLE;
-        } else if (bitPix > 0 && bitPix <= PrimitiveTypes.BYTE.bitPix()) {
-            return PrimitiveTypes.BYTE;
-        } else if (bitPix > PrimitiveTypes.BYTE.bitPix() && bitPix <= PrimitiveTypes.SHORT.bitPix()) {
-            return PrimitiveTypes.SHORT;
-        } else if (bitPix > PrimitiveTypes.SHORT.bitPix() && bitPix <= PrimitiveTypes.INT.bitPix()) {
-            return PrimitiveTypes.INT;
-        } else if (bitPix > PrimitiveTypes.INT.bitPix() && bitPix <= PrimitiveTypes.LONG.bitPix()) {
-            return PrimitiveTypes.LONG;
-        }
-        return PrimitiveTypes.UNKNOWN;
+    /**
+     * @deprecated Use {@link ElementType#forClass(Class)} instead.
+     */
+    public static <B extends Buffer> ElementType<B> valueOf(Class<?> clazz) {
+        return ElementType.forClass(clazz);
     }
 
-    public static PrimitiveType<Buffer> valueOf(char type) {
-        return cast(byType[type]);
+    /**
+     * @deprecated Use {@link ElementType#forBitpix(int)} instead.
+     */
+    public static ElementType<Buffer> valueOf(int bitPix) {
+        return ElementType.forBitpix(bitPix);
     }
-
-    public static <B extends Buffer> PrimitiveType<B> valueOf(Class<?> clazz) {
-        PrimitiveType<?> primitiveType = byClass.get(clazz);
-        if (primitiveType == null) {
-            for (Class<?> interf : clazz.getInterfaces()) {
-                primitiveType = byClass.get(interf);
-                if (primitiveType != null) {
-                    return cast(primitiveType);
-                }
-            }
-            return valueOf(clazz.getSuperclass());
-        }
-        return cast(primitiveType);
-    }
-
-    public static PrimitiveType<Buffer> valueOf(int bitPix) {
-        return cast(byBitPix[bitPix + BIT_PIX_OFFSET]);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <B extends Buffer> PrimitiveType<B> cast(PrimitiveType<?> primitiveType) {
-        return (PrimitiveType<B>) primitiveType;
-    }
-
-    private static PrimitiveType<?>[] values() {
-        return new PrimitiveType[]{
-            PrimitiveTypes.BOOLEAN,
-            PrimitiveTypes.BYTE,
-            PrimitiveTypes.CHAR,
-            PrimitiveTypes.DOUBLE,
-            PrimitiveTypes.FLOAT,
-            PrimitiveTypes.INT,
-            PrimitiveTypes.LONG,
-            PrimitiveTypes.SHORT,
-            PrimitiveTypes.STRING,
-            PrimitiveTypes.UNKNOWN
-        };
+    
+    /**
+     * @deprecated Use {@link ElementType#forNearestBitpix(int)} instead.
+     */
+    public static ElementType<Buffer> nearestValueOf(int bitPix) {
+        return ElementType.forNearestBitpix(bitPix);
     }
 
     private PrimitiveTypeHandler() {

--- a/src/main/java/nom/tam/util/type/PrimitiveTypes.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveTypes.java
@@ -40,28 +40,43 @@ import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
 
+/**
+ * @deprecated  Use identical static fields of {@link ElementType} instead.
+ * 
+ */
+@Deprecated
 public final class PrimitiveTypes {
 
-    public static final PrimitiveType<Buffer> BOOLEAN = new BooleanType();
+    /** @deprecated Use {@link ElementType#BOOLEAN} instead */
+    public static final ElementType<Buffer> BOOLEAN = ElementType.BOOLEAN;
 
-    public static final PrimitiveType<ByteBuffer> BYTE = new ByteType();
+    /** @deprecated Use {@link ElementType#BYTE} instead */
+    public static final ElementType<ByteBuffer> BYTE = ElementType.BYTE;
 
-    public static final PrimitiveType<CharBuffer> CHAR = new CharType();
+    /** @deprecated Use {@link ElementType#CHAR} instead */
+    public static final ElementType<CharBuffer> CHAR = ElementType.CHAR;
 
-    public static final PrimitiveType<DoubleBuffer> DOUBLE = new DoubleType();
+    /** @deprecated Use {@link ElementType#DOUBLE} instead */
+    public static final ElementType<DoubleBuffer> DOUBLE = ElementType.DOUBLE;
 
-    public static final PrimitiveType<FloatBuffer> FLOAT = new FloatType();
+    /** @deprecated Use {@link ElementType#FLOAT} instead */
+    public static final ElementType<FloatBuffer> FLOAT = ElementType.FLOAT;
 
-    public static final PrimitiveType<IntBuffer> INT = new IntType();
+    /** @deprecated Use {@link ElementType#INT} instead */
+    public static final ElementType<IntBuffer> INT = ElementType.INT;
 
-    public static final PrimitiveType<LongBuffer> LONG = new LongType();
+    /** @deprecated Use {@link ElementType#LONG} instead */
+    public static final ElementType<LongBuffer> LONG = ElementType.LONG;
 
-    public static final PrimitiveType<ShortBuffer> SHORT = new ShortType();
+    /** @deprecated Use {@link ElementType#SHORT} instead */
+    public static final ElementType<ShortBuffer> SHORT = ElementType.SHORT;
 
-    public static final PrimitiveType<Buffer> STRING = new StringType();
+    /** @deprecated Use {@link ElementType#STRING} instead */
+    public static final ElementType<Buffer> STRING = ElementType.STRING;
 
-    public static final PrimitiveType<Buffer> UNKNOWN = new UnknownType();
-
+    /** @deprecated Use {@link ElementType#UNKNOWN} instead */
+    public static final ElementType<Buffer> UNKNOWN = ElementType.UNKNOWN;
+    
     private PrimitiveTypes() {
         // TODO Auto-generated constructor stub
     }

--- a/src/main/java/nom/tam/util/type/PrimitiveTypes.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveTypes.java
@@ -33,7 +33,6 @@ package nom.tam.util.type;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -54,7 +53,7 @@ public final class PrimitiveTypes {
     public static final ElementType<ByteBuffer> BYTE = ElementType.BYTE;
 
     /** @deprecated Use {@link ElementType#CHAR} instead */
-    public static final ElementType<CharBuffer> CHAR = ElementType.CHAR;
+    public static final ElementType<ByteBuffer> CHAR = ElementType.CHAR;
 
     /** @deprecated Use {@link ElementType#DOUBLE} instead */
     public static final ElementType<DoubleBuffer> DOUBLE = ElementType.DOUBLE;

--- a/src/main/java/nom/tam/util/type/ShortType.java
+++ b/src/main/java/nom/tam/util/type/ShortType.java
@@ -39,7 +39,7 @@ import nom.tam.fits.header.Bitpix;
 class ShortType extends ElementType<ShortBuffer> {
 
     protected ShortType() {
-        super(2, false, short.class, Short.class, ShortBuffer.class, 'S', Bitpix.BITPIX_SHORT);
+        super(2, false, short.class, Short.class, ShortBuffer.class, 'S', Bitpix.VALUE_FOR_SHORT);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/ShortType.java
+++ b/src/main/java/nom/tam/util/type/ShortType.java
@@ -34,12 +34,12 @@ package nom.tam.util.type;
 import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
-class ShortType extends PrimitiveTypeBase<ShortBuffer> {
+import nom.tam.fits.header.Bitpix;
 
-    private static final int BIT_PIX = 16;
+class ShortType extends ElementType<ShortBuffer> {
 
     protected ShortType() {
-        super(2, false, short.class, Short.class, ShortBuffer.class, 'S', BIT_PIX);
+        super(2, false, short.class, Short.class, ShortBuffer.class, 'S', Bitpix.BITPIX_SHORT);
     }
 
     @Override

--- a/src/main/java/nom/tam/util/type/StringType.java
+++ b/src/main/java/nom/tam/util/type/StringType.java
@@ -33,7 +33,7 @@ package nom.tam.util.type;
 
 import java.nio.Buffer;
 
-class StringType extends PrimitiveTypeBase<Buffer> {
+class StringType extends ElementType<Buffer> {
 
     protected StringType() {
         super(0, true, CharSequence.class, String.class, null, 'L', 0);

--- a/src/main/java/nom/tam/util/type/UnknownType.java
+++ b/src/main/java/nom/tam/util/type/UnknownType.java
@@ -33,7 +33,7 @@ package nom.tam.util.type;
 
 import java.nio.Buffer;
 
-class UnknownType extends PrimitiveTypeBase<Buffer> {
+class UnknownType extends ElementType<Buffer> {
 
     protected UnknownType() {
         super(0, true, Object.class, Object.class, null, 'L', 0);

--- a/src/test/java/nom/tam/fits/BitpixTest.java
+++ b/src/test/java/nom/tam/fits/BitpixTest.java
@@ -1,0 +1,159 @@
+package nom.tam.fits;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+import nom.tam.fits.header.Bitpix;
+
+public class BitpixTest {
+
+    
+    @Test
+    public void testByteID() throws Exception {
+        assertEquals('B', Bitpix.BYTE.getArrayID());
+    }
+    
+    @Test
+    public void testShortID() throws Exception {
+        assertEquals('S', Bitpix.SHORT.getArrayID());
+    }
+    
+    @Test
+    public void testIntID() throws Exception {
+        assertEquals('I', Bitpix.INTEGER.getArrayID());
+    }
+    
+    @Test
+    public void testLongID() throws Exception {
+        assertEquals('J', Bitpix.LONG.getArrayID());
+    }
+    
+    @Test
+    public void testFloatID() throws Exception {
+        assertEquals('F', Bitpix.FLOAT.getArrayID());
+    }
+    
+    @Test
+    public void testDoubleID() throws Exception {
+        assertEquals('D', Bitpix.DOUBLE.getArrayID());
+    }
+    
+    @Test
+    public void testByteDescription() throws Exception {
+        assertNotNull(Bitpix.BYTE.getDescription());
+        assertEquals(Bitpix.BYTE.getDescription(), HeaderCard.sanitize(Bitpix.BYTE.getDescription()));
+    }
+    
+    @Test
+    public void testShortDescription() throws Exception {
+        assertNotNull(Bitpix.SHORT.getDescription());
+        assertEquals(Bitpix.SHORT.getDescription(), HeaderCard.sanitize(Bitpix.SHORT.getDescription()));
+    }
+    
+    @Test
+    public void testIntDescription() throws Exception {
+        assertNotNull(Bitpix.INTEGER.getDescription());
+        assertEquals(Bitpix.INTEGER.getDescription(), HeaderCard.sanitize(Bitpix.INTEGER.getDescription()));
+    }
+    
+    @Test
+    public void testLongDescription() throws Exception {
+        assertNotNull(Bitpix.LONG.getDescription());
+        assertEquals(Bitpix.LONG.getDescription(), HeaderCard.sanitize(Bitpix.LONG.getDescription()));
+    }
+    
+    @Test
+    public void testFloatDescription() throws Exception {
+        assertNotNull(Bitpix.FLOAT.getDescription());
+        assertEquals(Bitpix.FLOAT.getDescription(), HeaderCard.sanitize(Bitpix.FLOAT.getDescription()));
+    }
+    
+    @Test
+    public void testDoubleDescription() throws Exception {
+        assertNotNull(Bitpix.DOUBLE.getDescription());
+        assertEquals(Bitpix.DOUBLE.getDescription(), HeaderCard.sanitize(Bitpix.DOUBLE.getDescription()));
+    }
+    
+    @Test
+    public void testByteObject() throws Exception {
+        assertEquals(Bitpix.BYTE, Bitpix.forNumberType(Byte.class));
+    }
+    
+    @Test
+    public void testShortObject() throws Exception {
+        assertEquals(Bitpix.SHORT, Bitpix.forNumberType(Short.class));
+    }
+    
+    @Test
+    public void testIntObject() throws Exception {
+        assertEquals(Bitpix.INTEGER, Bitpix.forNumberType(Integer.class));
+    }
+    
+    @Test
+    public void testLongObject() throws Exception {
+        assertEquals(Bitpix.LONG, Bitpix.forNumberType(Long.class));
+    }
+    
+    @Test
+    public void testFloatObject() throws Exception {
+        assertEquals(Bitpix.FLOAT, Bitpix.forNumberType(Float.class));
+    }
+    
+    @Test
+    public void testDoubleObject() throws Exception {
+        assertEquals(Bitpix.DOUBLE, Bitpix.forNumberType(Double.class));
+    }
+        
+    @Test(expected = FitsException.class)
+    public void testInvalidPrimitiveType() throws Exception {
+        FitsFactory.setAllowHeaderRepairs(false);
+        Bitpix.forPrimitiveType(Object.class);
+    }
+    
+    @Test(expected = FitsException.class)
+    public void testInvalidNumberType1() throws Exception {
+        Bitpix.forNumberType(BigInteger.class);
+    }
+    
+    @Test(expected = FitsException.class)
+    public void testInvalidNumberType2() throws Exception {
+        Bitpix.forNumberType(BigDecimal.class);
+    }
+    
+}

--- a/src/test/java/nom/tam/fits/DeprecatedTest.java
+++ b/src/test/java/nom/tam/fits/DeprecatedTest.java
@@ -1,0 +1,44 @@
+package nom.tam.fits;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import org.junit.Test;
+
+@SuppressWarnings("deprecation")
+public class DeprecatedTest {
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testHeaderSetInvalidBitpix() throws Exception {
+        Header h = new Header();
+        h.setBitpix(20);
+    }
+}

--- a/src/test/java/nom/tam/fits/HeaderOrderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderOrderTest.java
@@ -78,7 +78,7 @@ public class HeaderOrderTest {
         
         header.addValue(BLOCKED, 1);
         header.addValue(SIMPLE, true);
-        header.addValue(BITPIX, 1);
+        header.addValue(BITPIX, 8);
         header.addValue(THEAP, 1);  
         header.addValue(NAXIS, 0);
         header.addValue(END, true);
@@ -97,7 +97,7 @@ public class HeaderOrderTest {
         Assert.assertEquals(THEAP.key(), header.iterator(4).next().getKey());
         header = new Header();
         header.addValue(SIMPLE, true);
-        header.addValue(BITPIX, 1);
+        header.addValue(BITPIX, 8);
         header.addValue(NAXIS, 0);
         header.addValue(END, true);
         header.addValue(THEAP, 1);

--- a/src/test/java/nom/tam/fits/ProtectedFitsTest.java
+++ b/src/test/java/nom/tam/fits/ProtectedFitsTest.java
@@ -166,6 +166,6 @@ public class ProtectedFitsTest {
             actual = e;
         }
         Assert.assertNotNull(actual);
-        Assert.assertTrue(actual.getMessage().toLowerCase().contains("string not supported"));
+        Assert.assertTrue(actual.getMessage().toLowerCase().contains("string"));
     }
 }

--- a/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
+++ b/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
@@ -61,6 +61,7 @@ import org.junit.Test;
 import nom.tam.fits.BasicHDU;
 import nom.tam.fits.Fits;
 import nom.tam.fits.FitsException;
+import nom.tam.fits.FitsFactory;
 import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
 import nom.tam.fits.ImageData;
@@ -1216,11 +1217,25 @@ public class ReadWriteProvidedCompressedImageTest {
 
     @Test
     public void testImagePlusCompressedImage1() throws Exception {
+        FitsFactory.setAllowHeaderRepairs(true);
         testImagePlusCompressedImage(resolveLocalOrRemoteFileName("03h-80dec--C_CVT_2013-12-29-MW1-03h_Light_600SecISO200_000042.fit"));
     }
 
     @Test
     public void testImagePlusCompressedImage2() throws Exception {
+        FitsFactory.setAllowHeaderRepairs(true);
+        testImagePlusCompressedImage(resolveLocalOrRemoteFileName("17h-75dec--BINT_C_CVT_2014-06-25-MW1-17h_Light_600SecISO200_000031.fit"));
+    }
+    
+    @Test(expected = FitsException.class)
+    public void testImagePlusCompressedImage1A() throws Exception {
+        FitsFactory.setAllowHeaderRepairs(false);
+        testImagePlusCompressedImage(resolveLocalOrRemoteFileName("03h-80dec--C_CVT_2013-12-29-MW1-03h_Light_600SecISO200_000042.fit"));
+    }
+
+    @Test(expected = FitsException.class)
+    public void testImagePlusCompressedImage2A() throws Exception {
+        FitsFactory.setAllowHeaderRepairs(false);
         testImagePlusCompressedImage(resolveLocalOrRemoteFileName("17h-75dec--BINT_C_CVT_2014-06-25-MW1-17h_Light_600SecISO200_000031.fit"));
     }
 

--- a/src/test/java/nom/tam/fits/test/HeaderCardStaticTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardStaticTest.java
@@ -46,8 +46,8 @@ import org.junit.Test;
 import nom.tam.fits.HeaderCard;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.IFitsHeader.VALUE;
-import nom.tam.fits.header.Standard;
 import nom.tam.util.ComplexValue;
+import nom.tam.fits.header.Standard;
 
 
 public class HeaderCardStaticTest {

--- a/src/test/java/nom/tam/fits/test/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderTest.java
@@ -1028,7 +1028,7 @@ public class HeaderTest {
         }, 80);
         Header header = new Header();
         header.addValue(SIMPLE, true);
-        header.addValue(BITPIX, 1);
+        header.addValue(BITPIX, 8);
         header.addValue(NAXIS, 0);
         header.addValue(END, true);
 

--- a/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
+++ b/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
@@ -164,7 +164,7 @@ public class RandomGroupsTest {
     }
 
     @Test
-    public void typedRandomGroup() throws FitsException {
+    public void typedRandomGroup() throws Exception {
         testGroupCreationAndRecreationByType(new byte[20][20], new byte[3], 8, "byte");
         testGroupCreationAndRecreationByType(new short[20][20], new short[3], 16, "short");
         testGroupCreationAndRecreationByType(new int[20][20], new int[3], 32, "int");
@@ -174,7 +174,7 @@ public class RandomGroupsTest {
     }
 
     @Test(expected = FitsException.class)
-    public void illegalTypedRandomGroup() throws FitsException {
+    public void illegalTypedRandomGroup() throws Exception {
         testGroupCreationAndRecreationByType(new Double[20][20], new Double[3], -64, "Double");
     }
 
@@ -212,7 +212,7 @@ public class RandomGroupsTest {
         }
     }
 
-    private void testGroupCreationAndRecreationByType(Object fa, Object pa, int bipix, String typeName) throws FitsException {
+    private void testGroupCreationAndRecreationByType(Object fa, Object pa, int bipix, String typeName) throws Exception {
         Object[][] data = new Object[1][2];
         data[0][0] = pa;
         data[0][1] = fa;

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
@@ -67,7 +67,7 @@ import nom.tam.image.tile.operation.TileArea;
 import nom.tam.image.tile.operation.buffer.TileBuffer;
 import nom.tam.image.tile.operation.buffer.TileBufferFactory;
 import nom.tam.util.test.ThrowAnyException;
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 import nom.tam.util.type.PrimitiveTypes;
 
 import org.junit.Assert;
@@ -299,7 +299,7 @@ public class TileCompressorProviderTest {
                 return control.option();
             }
         };
-        final TileBuffer tileBuffer = TileBufferFactory.createTileBuffer((PrimitiveType) PrimitiveTypes.BYTE, 0, 10, 10, 10);
+        final TileBuffer tileBuffer = TileBufferFactory.createTileBuffer((ElementType) PrimitiveTypes.BYTE, 0, 10, 10, 10);
         TileDecompressor tileDecompressor = new TileDecompressor(image, 1, new TileArea()) {
 
             @Override

--- a/src/test/java/nom/tam/image/compression/tile/mask/ImageMaskTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/mask/ImageMaskTest.java
@@ -46,7 +46,7 @@ import java.util.Arrays;
 
 import nom.tam.image.tile.operation.buffer.TileBuffer;
 import nom.tam.image.tile.operation.buffer.TileBufferFactory;
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 import nom.tam.util.type.PrimitiveTypes;
 
 import org.junit.Assert;
@@ -338,18 +338,18 @@ public class ImageMaskTest {
         constrs[0].newInstance();
     }
 
-    protected TileBuffer createTileBuffer(Buffer buffer, PrimitiveType type) {
+    protected TileBuffer createTileBuffer(Buffer buffer, ElementType type) {
         TileBuffer tileBuffer = TileBufferFactory.createTileBuffer(type, 0, 10, 10, 1);
         tileBuffer.setData(buffer);
         return tileBuffer;
     }
 
-    protected void createTilePreserver(Buffer buffer, ImageNullPixelMask mask, PrimitiveType type, int tileIndex) {
+    protected void createTilePreserver(Buffer buffer, ImageNullPixelMask mask, ElementType type, int tileIndex) {
         TileBuffer tileBuffer = createTileBuffer(buffer, type);
         mask.createTilePreserver(tileBuffer, tileIndex).preserveNull();
     }
 
-    protected NullPixelMaskRestorer createTileRestorer(Buffer buffer, ImageNullPixelMask mask, PrimitiveType type, int tileIndex) {
+    protected NullPixelMaskRestorer createTileRestorer(Buffer buffer, ImageNullPixelMask mask, ElementType type, int tileIndex) {
         TileBuffer tileBuffer = createTileBuffer(buffer, type);
         return mask.createTileRestorer(tileBuffer, tileIndex);
     }

--- a/src/test/java/nom/tam/util/BufferedFileTest.java
+++ b/src/test/java/nom/tam/util/BufferedFileTest.java
@@ -36,8 +36,18 @@ import java.io.IOException;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+
+import nom.tam.fits.FitsFactory;
 
 public class BufferedFileTest {
+    
+    @Before
+    @After
+    public void setDefaults() {
+        FitsFactory.setDefaults();
+    }
 
     @Test
     public void testCheckEof() throws IOException {
@@ -62,12 +72,29 @@ public class BufferedFileTest {
     }
 
     @Test
-    public void testReadWrite() throws IOException {
-        BufferedFile file = new BufferedFile("target/BufferedFileReadWrite", "rw");
+    public void testReadWriteAscii() throws IOException {
+        FitsFactory.setUseUnicodeChars(false);
+        BufferedFile file = new BufferedFile("target/BufferedFileReadWriteAscii", "rw");
         file.write(new byte[10]);
         Assert.assertTrue(file.getChannel().isOpen());
         file.close();
-        file = new BufferedFile("target/BufferedFileReadWrite", "rw");
+        file = new BufferedFile("target/BufferedFileReadWriteAscii", "rw");
+        try {
+            file.write(new char[2]);
+            Assert.assertEquals(3, file.read(new char[3]));
+        } finally {
+            file.close();
+        }
+    }
+    
+    @Test
+    public void testReadWriteUnicode() throws IOException {
+        FitsFactory.setUseUnicodeChars(true);
+        BufferedFile file = new BufferedFile("target/BufferedFileReadWriteUnicode", "rw");
+        file.write(new byte[10]);
+        Assert.assertTrue(file.getChannel().isOpen());
+        file.close();
+        file = new BufferedFile("target/BufferedFileReadWriteUnicode", "rw");
         try {
             file.write(new char[2]);
             Assert.assertEquals(6, file.read(new char[3]));

--- a/src/test/java/nom/tam/util/PrimitiveTypeTest.java
+++ b/src/test/java/nom/tam/util/PrimitiveTypeTest.java
@@ -45,7 +45,7 @@ import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
 
-import nom.tam.util.type.PrimitiveType;
+import nom.tam.util.type.ElementType;
 import nom.tam.util.type.PrimitiveTypeHandler;
 import nom.tam.util.type.PrimitiveTypes;
 
@@ -54,7 +54,7 @@ import org.junit.Test;
 
 public class PrimitiveTypeTest {
 
-    private <T extends Buffer> Buffer bufferAtPosition(PrimitiveType<T> type, int length, int position) {
+    private <T extends Buffer> Buffer bufferAtPosition(ElementType<T> type, int length, int position) {
         T result = type.newBuffer(length);
         result.position(position);
         return type.sliceBuffer(result);
@@ -78,7 +78,7 @@ public class PrimitiveTypeTest {
         testAppedBuffer(PrimitiveTypes.BYTE, expectedValue);
     }
 
-    private <T extends Buffer> void testGetPutArray(PrimitiveType<T> type, Object value, Object other) {
+    private <T extends Buffer> void testGetPutArray(ElementType<T> type, Object value, Object other) {
         Object array = type.newArray(1);
         Array.set(array, 0, value);
         T buffer = type.newBuffer(1);
@@ -186,7 +186,7 @@ public class PrimitiveTypeTest {
         testAppedBuffer(PrimitiveTypes.SHORT, expectedValue);
     }
 
-    private <T extends Buffer> void testAppedBuffer(PrimitiveType<T> type, Object expectedValue) {
+    private <T extends Buffer> void testAppedBuffer(ElementType<T> type, Object expectedValue) {
         Object oneArray = type.newArray(1);
         Array.set(oneArray, 0, expectedValue);
         T buffer = type.wrap(oneArray);
@@ -249,14 +249,15 @@ public class PrimitiveTypeTest {
 
     @Test
     public void testPrimitiveTypeNearest() throws Exception {
+        assertSame(PrimitiveTypes.UNKNOWN, PrimitiveTypeHandler.nearestValueOf(0));
         assertSame(PrimitiveTypes.BYTE, PrimitiveTypeHandler.nearestValueOf(2));
         assertSame(PrimitiveTypes.FLOAT, PrimitiveTypeHandler.nearestValueOf(-2));
         assertSame(PrimitiveTypes.FLOAT, PrimitiveTypeHandler.nearestValueOf(-17));
         assertSame(PrimitiveTypes.DOUBLE, PrimitiveTypeHandler.nearestValueOf(-40));
-        assertSame(PrimitiveTypes.UNKNOWN, PrimitiveTypeHandler.nearestValueOf(-80));
+        assertSame(PrimitiveTypes.DOUBLE, PrimitiveTypeHandler.nearestValueOf(-80));
         assertSame(PrimitiveTypes.SHORT, PrimitiveTypeHandler.nearestValueOf(9));
         assertSame(PrimitiveTypes.INT, PrimitiveTypeHandler.nearestValueOf(20));
         assertSame(PrimitiveTypes.LONG, PrimitiveTypeHandler.nearestValueOf(40));
-        assertSame(PrimitiveTypes.UNKNOWN, PrimitiveTypeHandler.nearestValueOf(80));
+        assertSame(PrimitiveTypes.LONG, PrimitiveTypeHandler.nearestValueOf(80));
     }
 }

--- a/src/test/java/nom/tam/util/test/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/test/ArrayFuncsTest.java
@@ -43,6 +43,7 @@ import java.lang.reflect.Constructor;
 import nom.tam.util.ArrayFuncs;
 import nom.tam.util.AsciiFuncs;
 import nom.tam.util.TestArrayFuncs;
+import nom.tam.util.type.ElementType;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -539,14 +540,13 @@ public class ArrayFuncsTest {
     @Test
     public void testGetBaseLength() {
 
-        assertEquals(ArrayFuncs.getBaseLength(new int[2][3]), 4);
-        assertEquals(ArrayFuncs.getBaseLength(new double[2][3]), 8);
-        assertEquals(ArrayFuncs.getBaseLength(new byte[2][3]), 1);
-        assertEquals(ArrayFuncs.getBaseLength(new short[2][3]), 2);
-        assertEquals(ArrayFuncs.getBaseLength(new int[2][3]), 4);
-        assertEquals(ArrayFuncs.getBaseLength(new char[2][3]), 2);
-        assertEquals(ArrayFuncs.getBaseLength(new float[2][3]), 4);
-        assertEquals(ArrayFuncs.getBaseLength(new boolean[2][3]), 1);
+        assertEquals(ArrayFuncs.getBaseLength(new int[2][3]), ElementType.INT.size());
+        assertEquals(ArrayFuncs.getBaseLength(new double[2][3]), ElementType.DOUBLE.size());
+        assertEquals(ArrayFuncs.getBaseLength(new byte[2][3]), ElementType.BYTE.size());
+        assertEquals(ArrayFuncs.getBaseLength(new short[2][3]), ElementType.SHORT.size());
+        assertEquals(ArrayFuncs.getBaseLength(new char[2][3]), ElementType.CHAR.size());
+        assertEquals(ArrayFuncs.getBaseLength(new float[2][3]), ElementType.FLOAT.size());
+        assertEquals(ArrayFuncs.getBaseLength(new boolean[2][3]), ElementType.BOOLEAN.size());
         assertEquals(ArrayFuncs.getBaseLength(new Object[2][3]), -1);
     }
 

--- a/src/test/java/nom/tam/util/test/BufferedFileTest.java
+++ b/src/test/java/nom/tam/util/test/BufferedFileTest.java
@@ -51,7 +51,10 @@ import java.io.RandomAccessFile;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
 
+import nom.tam.fits.FitsFactory;
 import nom.tam.fits.compress.CloseIS;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayFuncs;
@@ -59,8 +62,10 @@ import nom.tam.util.AsciiFuncs;
 import nom.tam.util.BufferedDataInputStream;
 import nom.tam.util.BufferedDataOutputStream;
 import nom.tam.util.BufferedFile;
+import nom.tam.util.FitsIO;
 import nom.tam.util.SafeClose;
 import nom.tam.util.TestArrayFuncs;
+import nom.tam.util.type.ElementType;
 
 /**
  * This class provides runs tests of the BufferedI/O classes: BufferedFile,
@@ -222,7 +227,9 @@ public class BufferedFileTest {
         long ls2;
         short ss = (short) (60000 * (Math.random() - 30000));
         short ss2;
-        char cs = (char) (60000 * Math.random());
+        // AK: FITS only support ASCII characters, not unicode
+        // so we should not write outside of ASCII range.
+        char cs = (char) (256 * Math.random());
         char cs2;
         byte bs = (byte) (256 * Math.random() - 128);
         byte bs2;
@@ -238,35 +245,35 @@ public class BufferedFileTest {
         for (int i = 0; i < iter; i += 1) {
             f.writeArray(db);
         }
-        System.out.println("  BF  Dbl write: " + 8 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Dbl write: " + ElementType.DOUBLE.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.writeArray(fl);
         }
-        System.out.println("  BF  Flt write: " + 4 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Flt write: " + ElementType.FLOAT.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.writeArray(in);
         }
-        System.out.println("  BF  Int write: " + 4 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Int write: " + ElementType.INT.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.writeArray(ln);
         }
-        System.out.println("  BF  Lng write: " + 8 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Lng write: " + ElementType.LONG.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.writeArray(sh);
         }
-        System.out.println("  BF  Sht write: " + 2 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Sht write: " + ElementType.SHORT.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.writeArray(ch);
         }
-        System.out.println("  BF  Chr write: " + 2 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Chr write: " + ElementType.CHAR.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.writeArray(by);
         }
-        System.out.println("  BF  Byt write: " + 1 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Byt write: " + ElementType.BYTE.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.writeArray(bl);
         }
-        System.out.println("  BF  Boo write: " + 1 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Boo write: " + ElementType.BOOLEAN.size() * dim * iter / (1000 * deltaTime()));
 
         f.writeByte(bs);
         f.writeChar(cs);
@@ -279,41 +286,41 @@ public class BufferedFileTest {
 
         f.writeArray(multi);
         f.seek(0);
-
+        
         resetTime();
         for (int i = 0; i < iter; i += 1) {
             f.readLArray(db2);
         }
-        System.out.println("  BF  Dbl read:  " + 8 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Dbl read:  " + ElementType.DOUBLE.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.readLArray(fl2);
         }
-        System.out.println("  BF  Flt read:  " + 4 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Flt read:  " + ElementType.FLOAT.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.readLArray(in2);
         }
-        System.out.println("  BF  Int read:  " + 4 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Int read:  " + ElementType.INT.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.readLArray(ln2);
         }
-        System.out.println("  BF  Lng read:  " + 8 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Lng read:  " + ElementType.LONG.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.readLArray(sh2);
         }
-        System.out.println("  BF  Sht read:  " + 2 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Sht read:  " + ElementType.SHORT.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.readLArray(ch2);
         }
-        System.out.println("  BF  Chr read:  " + 2 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Chr read:  " + ElementType.CHAR.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.readLArray(by2);
         }
-        System.out.println("  BF  Byt read:  " + 1 * dim * iter / (1000 * deltaTime()));
+        System.out.println("  BF  Byt read:  " + ElementType.BYTE.size() * dim * iter / (1000 * deltaTime()));
         for (int i = 0; i < iter; i += 1) {
             f.readLArray(bl2);
         }
-        System.out.println("  BF  Boo read:  " + 1 * dim * iter / (1000 * deltaTime()));
-
+        System.out.println("  BF  Boo read:  " + ElementType.BOOLEAN.size() * dim * iter / (1000 * deltaTime()));
+        
         bs2 = f.readByte();
         cs2 = f.readChar();
         ss2 = f.readShort();
@@ -344,7 +351,7 @@ public class BufferedFileTest {
             assertFalse("Int error at " + i, in[i] != in2[i]);
             assertFalse("Long error at " + i, ln[i] != ln2[i]);
             assertFalse("Short error at " + i, sh[i] != sh2[i]);
-            assertFalse("Char error at " + i, ch[i] != ch2[i]);
+            assertFalse("Char error at " + i + ":" + (short) ch[i] + "|" + (short) ch2[i], ch[i] != ch2[i]);
             assertFalse("Byte error at " + i, by[i] != by2[i]);
             assertFalse("Bool error at " + i, bl[i] != bl2[i]);
         }
@@ -387,7 +394,9 @@ public class BufferedFileTest {
         long ls2;
         short ss = (short) (60000 * (Math.random() - 30000));
         short ss2;
-        char cs = (char) (60000 * Math.random());
+        // AK: FITS only support ASCII characters, not unicode
+        // so we should not write outside of ASCII range.
+        char cs = (char) (256 * Math.random());
         char cs2;
         byte bs = (byte) (256 * Math.random() - 128);
         byte bs2;
@@ -403,35 +412,35 @@ public class BufferedFileTest {
             for (int i = 0; i < iter; i += 1) {
                 f.writeArray(db);
             }
-            System.out.println("  BDS Dbl write: " + 8 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Dbl write: " + ElementType.DOUBLE.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.writeArray(fl);
             }
-            System.out.println("  BDS Flt write: " + 4 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Flt write: " + ElementType.FLOAT.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.writeArray(in);
             }
-            System.out.println("  BDS Int write: " + 4 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Int write: " + ElementType.INT.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.writeArray(ln);
             }
-            System.out.println("  BDS Lng write: " + 8 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Lng write: " + ElementType.LONG.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.writeArray(sh);
             }
-            System.out.println("  BDS Sht write: " + 2 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Sht write: " + ElementType.SHORT.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.writeArray(ch);
             }
-            System.out.println("  BDS Chr write: " + 2 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Chr write: " + ElementType.CHAR.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.writeArray(by);
             }
-            System.out.println("  BDS Byt write: " + 1 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Byt write: " + ElementType.BYTE.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.writeArray(bl);
             }
-            System.out.println("  BDS Boo write: " + 1 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Boo write: " + ElementType.BOOLEAN.size() * dim * iter / (1000 * deltaTime()));
 
             f.writeByte(bs);
             f.writeChar(cs);
@@ -454,35 +463,35 @@ public class BufferedFileTest {
             for (int i = 0; i < iter; i += 1) {
                 f.readLArray(db2);
             }
-            System.out.println("  BDS Dbl read:  " + 8 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Dbl read:  " + ElementType.DOUBLE.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.readLArray(fl2);
             }
-            System.out.println("  BDS Flt read:  " + 4 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Flt read:  " + ElementType.FLOAT.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.readLArray(in2);
             }
-            System.out.println("  BDS Int read:  " + 4 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Int read:  " + ElementType.INT.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.readLArray(ln2);
             }
-            System.out.println("  BDS Lng read:  " + 8 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Lng read:  " + ElementType.LONG.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.readLArray(sh2);
             }
-            System.out.println("  BDS Sht read:  " + 2 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Sht read:  " + ElementType.SHORT.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.readLArray(ch2);
             }
-            System.out.println("  BDS Chr read:  " + 2 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Chr read:  " + ElementType.CHAR.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.readLArray(by2);
             }
-            System.out.println("  BDS Byt read:  " + 1 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Byt read:  " + ElementType.BYTE.size() * dim * iter / (1000 * deltaTime()));
             for (int i = 0; i < iter; i += 1) {
                 f.readLArray(bl2);
             }
-            System.out.println("  BDS Boo read:  " + 1 * dim * iter / (1000 * deltaTime()));
+            System.out.println("  BDS Boo read:  " + ElementType.BOOLEAN.size() * dim * iter / (1000 * deltaTime()));
 
             bs2 = f.readByte();
             cs2 = f.readChar();
@@ -578,15 +587,35 @@ public class BufferedFileTest {
         lastTime = new java.util.Date().getTime();
         return (lastTime - time) / 1000.;
     }
+    
+    @Before
+    @After
+    public void setDefaults() {
+        FitsFactory.setDefaults();
+    }
 
     @Test
-    public void datailTest() throws Exception {
+    public void datailTestAscii() throws Exception {
+        FitsFactory.setUseUnicodeChars(false);
         doTest("target/bufferedFile.test", 1000, 1);
     }
 
     @Test
-    public void datailTest2() throws Exception {
+    public void datailTest2Ascii() throws Exception {
+        FitsFactory.setUseUnicodeChars(false);
         doTest("target/bufferedFile2.test", 2000, 4);
+    }
+    
+    @Test
+    public void datailTestUnicode() throws Exception {
+        FitsFactory.setUseUnicodeChars(true);
+        doTest("target/bufferedFileU.test", 1000, 1);
+    }
+
+    @Test
+    public void datailTest2Unicode() throws Exception {
+        FitsFactory.setUseUnicodeChars(true);
+        doTest("target/bufferedFile2U.test", 2000, 4);
     }
 
     /**
@@ -613,19 +642,16 @@ public class BufferedFileTest {
         int sign = 1;
         for (int i = 0; i < dim; i += 1) {
 
-            double x = sign * Math.pow(10., 20 * Math.random() - 10);
+            double x = sign * Math.pow(10., 20 * Math.random());
             db[i] = x;
             fl[i] = (float) x;
-
-            if (Math.abs(x) < 1) {
-                x = 1 / x;
-            }
-
             in[i] = (int) x;
             ln[i] = (long) x;
             sh[i] = (short) x;
             by[i] = (byte) x;
-            ch[i] = (char) x;
+            // AK: FITS only support ASCII characters, not unicode
+            // so we should not test roundtrips outside of ASCII range.
+            ch[i] = FitsFactory.isUseUnicodeChars() ? (char) sh[i] : (char) (sh[i] & 0xFF);
             bl[i] = x > 0;
 
             sign = -sign;
@@ -636,8 +662,8 @@ public class BufferedFileTest {
         by[0] = Byte.MIN_VALUE;
         by[1] = Byte.MAX_VALUE;
         by[2] = 0;
-        ch[0] = Character.MIN_VALUE;
-        ch[1] = Character.MAX_VALUE;
+        ch[0] = FitsFactory.isUseUnicodeChars() ? Character.MIN_VALUE : 0x0;
+        ch[1] = FitsFactory.isUseUnicodeChars() ? Character.MAX_VALUE : 0xFF;
         ch[2] = 0;
         sh[0] = Short.MAX_VALUE;
         sh[1] = Short.MIN_VALUE;
@@ -996,9 +1022,13 @@ public class BufferedFileTest {
         };
         bf.write(testStrings);
         bf.write(testStrings, 1, 3);
+        FitsFactory.setUseUnicodeChars(true);
         bf.writeChars("abc");
+        FitsFactory.setUseUnicodeChars(false);
+        bf.writeChars("def");
         bf.writeBytes("test\n");
-        assertEquals(77, bf.length());
+        assertEquals(80, bf.length());
+        
         bf.close();
 
         bf = new BufferedFile("target/bufferedFilePrim.test");
@@ -1013,9 +1043,16 @@ public class BufferedFileTest {
         bf.read(bytes2);
         assertEquals("string 2string 3string 4", AsciiFuncs.asciiString(bytes2));
 
+        FitsFactory.setUseUnicodeChars(true);
         assertEquals('a', bf.readChar());
         assertEquals('b', bf.readChar());
         assertEquals('c', bf.readChar());
+        
+        FitsFactory.setUseUnicodeChars(false);
+        assertEquals('d', bf.readChar());
+        assertEquals('e', bf.readChar());
+        assertEquals('f', bf.readChar());
+        
         assertEquals("test", bf.readLine());
 
         bf.close();

--- a/src/test/java/nom/tam/util/test/StreamTest.java
+++ b/src/test/java/nom/tam/util/test/StreamTest.java
@@ -42,9 +42,12 @@ import java.io.PipedOutputStream;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
 
 import nom.tam.fits.Fits;
 import nom.tam.fits.FitsException;
+import nom.tam.fits.FitsFactory;
 import nom.tam.util.AsciiFuncs;
 import nom.tam.util.BufferedDataInputStream;
 import nom.tam.util.BufferedDataOutputStream;
@@ -56,6 +59,12 @@ public class StreamTest {
 
     private static BufferedDataInputStream in;
 
+    @Before
+    @After
+    public void setDefaults() {
+        FitsFactory.setDefaults();
+    }
+    
     @BeforeClass
     public static void setup() throws Exception {
         PipedInputStream pipeInput = new PipedInputStream(10240);
@@ -91,7 +100,34 @@ public class StreamTest {
     }
 
     @Test
-    public void testCharArray() throws Exception {
+    public void testCharArrayAscii() throws Exception {
+        FitsFactory.setUseUnicodeChars(false);
+        
+        char[] chars = new char[10];
+        char[] expectedChars = new char[10];
+        for (int index = 0; index < expectedChars.length; index++) {
+            expectedChars[index] = (char) ('A' + index);
+        }
+        ou.writePrimitiveArray(expectedChars);
+        ou.write(expectedChars);
+        ou.flush();
+        in.read(chars);
+        Assert.assertEquals(expectedChars.length, chars.length);
+        for (int index = 0; index < expectedChars.length; index++) {
+            Assert.assertEquals("char[" + index + "]", expectedChars[index], chars[index]);
+            chars[index] = ' ';
+        }
+        in.readPrimitiveArray(chars);
+        for (int index = 0; index < expectedChars.length; index++) {
+            Assert.assertEquals("char[" + index + "]", expectedChars[index], chars[index]);
+        }
+        Assert.assertEquals(0, in.available());
+    }
+    
+    @Test
+    public void testCharArrayUnicode() throws Exception {
+        FitsFactory.setUseUnicodeChars(true);
+        
         char[] chars = new char[10];
         char[] expectedChars = new char[10];
         for (int index = 0; index < expectedChars.length; index++) {
@@ -353,7 +389,30 @@ public class StreamTest {
     }
 
     @Test
-    public void testChar() throws Exception {
+    public void testCharAscii() throws Exception {
+        FitsFactory.setUseUnicodeChars(false);
+        
+        char[] value = new char[10];
+        char[] expectedValue = new char[10];
+        for (int index = 0; index < expectedValue.length; index++) {
+            expectedValue[index] = (char) ('A' + index);
+            ou.writeChar(expectedValue[index]);
+        }
+        ou.flush();
+        for (int index = 0; index < expectedValue.length; index++) {
+            value[index] = in.readChar();
+        }
+        Assert.assertEquals(expectedValue.length, value.length);
+        for (int index = 0; index < expectedValue.length; index++) {
+            Assert.assertEquals("boolean[" + index + "]", expectedValue[index], value[index]);
+        }
+        Assert.assertEquals(0, in.available());
+    }
+    
+    @Test
+    public void testCharUnicode() throws Exception {
+        FitsFactory.setUseUnicodeChars(true);
+        
         char[] value = new char[10];
         char[] expectedValue = new char[10];
         for (int index = 0; index < expectedValue.length; index++) {

--- a/src/test/java/nom/tam/util/type/DeprecatedTest.java
+++ b/src/test/java/nom/tam/util/type/DeprecatedTest.java
@@ -1,0 +1,63 @@
+package nom.tam.util.type;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.nio.IntBuffer;
+
+import org.junit.Test;
+
+import nom.tam.fits.header.Bitpix;
+
+@SuppressWarnings("deprecation")
+public class DeprecatedTest {
+    
+    @Test
+    public void testPrimitiveTypeConstructor() throws Exception {
+        PrimitiveType<?> i = new PrimitiveType<IntBuffer>(4, false, int.class, Integer.class, IntBuffer.class, 'I', Bitpix.VALUE_FOR_INT) {
+            
+        };
+        assertEquals("size", 4, i.size());
+        assertFalse("isVariableSize", i.individualSize());
+        assertEquals("primitive", int.class, i.primitiveClass());
+        assertEquals("wrapped", Integer.class, i.wrapperClass());
+        assertEquals("bufclass", IntBuffer.class, i.bufferClass());
+        assertEquals("ID", 'I', i.type());
+        assertEquals("BITPIX", Bitpix.INTEGER.getHeaderValue(), i.bitPix());
+    }
+    
+    public void testElementTypeForID() throws Exception {
+        assertEquals(ElementType.forDataID('J'), PrimitiveTypeHandler.valueOf('J'));
+    }
+}


### PR DESCRIPTION
A few more fixes:

- Typesafe use of BITPIX, with restricted set of values recognised by the FITS standard.
- Handling of FITS boolean and character arrays more consistently. (For now the old behaviour of 2-byte characters is maintained even though there is NO standard for it in FITS -- but a switch is created to enable standard compliance)
- `PrimitiveType` renamed to `ElementType` since it does not only deal with primitives, and simplified hierarchy. The old hierarchy is also replicated albeit in deprecated form, for back compatibility. 