### PR TITLE
1.16.0-rc3

### DIFF
--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -1016,12 +1016,12 @@ public class Fits implements Closeable {
      * @since 1.16
      */
     static boolean checkTruncated(ArrayDataInput in) throws IOException {
-        if (!(in instanceof ArrayDataFile)) {
+        if (!(in instanceof RandomAccess)) {
             // We cannot skip more than is available in an input stream.
             return false;
         }
         
-        ArrayDataFile f = (ArrayDataFile) in;
+        RandomAccess f = (RandomAccess) in;
         long pos = f.getFilePointer();
         long len = f.length();
         if (pos > len) {

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -50,7 +50,6 @@ import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import nom.tam.fits.compress.CompressionManager;
 import nom.tam.fits.utilities.FitsCheckSum;
-import nom.tam.util.ArrayDataFile;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.FitsInputStream;

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -50,6 +50,7 @@ import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import nom.tam.fits.compress.CompressionManager;
 import nom.tam.fits.utilities.FitsCheckSum;
+import nom.tam.util.ArrayDataFile;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.FitsInputStream;
@@ -661,7 +662,7 @@ public class Fits implements Closeable {
 
         // Check for truncation even if we successfully skipped to the expected end
         // since skip may allow going beyond the EOF.
-        if (this.dataStr.checkTruncated()) {
+        if (Fits.checkTruncated(this.dataStr)) {
             // File ends before required padding after data...
             // (files allow skipping beyond the end, which is why we don't
             // catch it above)
@@ -992,5 +993,41 @@ public class Fits implements Closeable {
     @Deprecated
     public static long checksum(final byte[] data) {
         return FitsCheckSum.checksum(data);
+    }
+    
+    
+    /**
+     * Checks if the file ends before the current read positon, and if so, it 
+     * may log a warning. This may happen with {@link FitsFile} where the 
+     * contract of {@link RandomAccess} allows for skipping ahead beyond the 
+     * end of file, since expanding the file is allowed when writing. Only a 
+     * subsequent read call would fail.
+     *
+     * @param in    the input from which the FITS content was read.
+     * @return      <code>true</code> if the current read position is beyond
+     *              the end-of-file, otherwise <code>false</code>.
+     * @throws IOException  if there was an IO error accessing the file or stream.
+     * 
+     * @see #skip(long)
+     * @see #skipBytes(int)
+     * @see #skipAllBytes(long)
+     * 
+     * 
+     * @since 1.16
+     */
+    static boolean checkTruncated(ArrayDataInput in) throws IOException {
+        if (!(in instanceof ArrayDataFile)) {
+            // We cannot skip more than is available in an input stream.
+            return false;
+        }
+        
+        ArrayDataFile f = (ArrayDataFile) in;
+        long pos = f.getFilePointer();
+        long len = f.length();
+        if (pos > len) {
+            LOG.log(Level.WARNING, "Premature file end at " + len + " (expected " + pos + ")", new Throwable());
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -1642,7 +1642,7 @@ public class Header implements FitsElement {
         }
       
         // AK: Log if the file ends before the expected end-of-header position.
-        if (dis.checkTruncated()) {
+        if (Fits.checkTruncated(dis)) {
             // No biggy. We got a complete header just fine, it's only that there was no
             // padding before EOF. We'll just log that, but otherwise keep going.
             LOG.warning("Premature end-of-file: no padding after header.");

--- a/src/main/java/nom/tam/util/ArrayDataInput.java
+++ b/src/main/java/nom/tam/util/ArrayDataInput.java
@@ -108,7 +108,7 @@ public interface ArrayDataInput extends InputReader, DataInput, FitsIO {
     int read(boolean[] buf, int offset, int size) throws IOException;
 
     /**
-     * Read an array of booleans, including legal <code>null</code> values. 
+     * Read an array of booleans, possibly including legal <code>null</code> values. 
      * 
      * @return number of bytes read.
      * @param buf
@@ -122,10 +122,11 @@ public interface ArrayDataInput extends InputReader, DataInput, FitsIO {
     }
 
     /**
-     * Reads into an array of booleans, including legal <code>null</code> values.
-     * The method has a default implementation, which calls {@link #readBoolean()}
+     * Reads into an array of booleans, possibly including legal <code>null</code> values.
+     * The method has a default implementation, calls {@link #readBoolean()}
      * element by element. Classes that implement this interface might want to
-     * replace that with a more efficient block read implementation.
+     * replace that with a more efficient block read implementation and/or
+     * to add the desired translation for <code>null</code> values.
      * 
      * @return number of bytes read.
      * @param buf

--- a/src/main/java/nom/tam/util/ArrayDataInput.java
+++ b/src/main/java/nom/tam/util/ArrayDataInput.java
@@ -397,26 +397,6 @@ public interface ArrayDataInput extends InputReader, DataInput, FitsIO {
      *             if the underlying stream failed
      */
     void skipAllBytes(int toSkip) throws IOException;
-
-    /**
-     * Checks if the file ends before the current read positon, and if so, it 
-     * may log a warning. This may happen with {@link FitsFile} where the 
-     * contract of {@link RandomAccess} allows for skipping ahead beyond the 
-     * end of file, since expanding the file is allowed when writing. Only a 
-     * subsequent read call would fail.
-     *
-     * @return      <code>true</code> if the current read position is beyond
-     *              the end-of-file, otherwise <code>false</code>.
-     * @throws IOException  if there was an IO error accessing the file or stream.
-     * 
-     * @see #skip(long)
-     * @see #skipBytes(int)
-     * @see #skipAllBytes(long)
-     * 
-     * 
-     * @since 1.16
-     */
-    boolean checkTruncated() throws IOException;
     
     /**
      * Read a buffer and signal an EOF if the requested elements cannot be read.

--- a/src/main/java/nom/tam/util/ArrayDataInput.java
+++ b/src/main/java/nom/tam/util/ArrayDataInput.java
@@ -61,7 +61,9 @@ public interface ArrayDataInput extends InputReader, DataInput, FitsIO {
      * @return  true if this stream instance supports the mark and
      *               reset methods; false otherwise.
      */
-    boolean markSupported();
+    default boolean markSupported() {
+        return false;
+    }
 
     /**
      * Read an array of byte's. The call generally follows the contract of

--- a/src/main/java/nom/tam/util/ArrayDataInput.java
+++ b/src/main/java/nom/tam/util/ArrayDataInput.java
@@ -63,7 +63,7 @@ public interface ArrayDataInput extends InputReader, DataInput, FitsIO {
      *               reset methods; false otherwise.
      */
     default boolean markSupported() {
-        return false;
+        return true;
     }
 
     /**

--- a/src/main/java/nom/tam/util/ArrayDataOutput.java
+++ b/src/main/java/nom/tam/util/ArrayDataOutput.java
@@ -50,31 +50,6 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     void flush() throws IOException;
 
     /**
-     * Writes a boolean value to the output, including support for legal 
-     * <code>null</code> values. The method's default implementation is
-     * to write <code>null</code> as the byte -1. Classes that implement
-     * this interface may want to override this behavior to represent
-     * <code>null</code> differently.
-     * 
-     * @param b
-     *            the boolean value. Subclass implementations may allow
-     *            <code>null</code> if it can be supported by the output data
-     *            format.
-     * @throws IOException
-     *             if there was an IO error writing the value to the output.
-     *             
-     * @since 1.16
-     */
-    default void writeBoolean(Boolean b) throws IOException {
-        if (b == null) {
-            write(-1);
-        } else {
-            writeBoolean(b.booleanValue());
-        }
-        
-    }
-
-    /**
      * Write an array of boolean's.
      * 
      * @param buf
@@ -113,11 +88,11 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     }
 
     /**
-     * Write a segment of an array of booleans, including legal
+     * Write a segment of an array of booleans, possibly including legal
      * <code>null</code> values.
-     * The method has a default implementation, which calls {@link #writeBoolean(Boolean)}
+     * The method has a default implementation, which calls {@link #writeBoolean(boolean)}
      * element by element. Classes that implement this interface might want to
-     * replace that with a more efficient block read implementation.
+     * replace that with a more efficient block read implementation/
      * 
      * @param buf
      *            array of booleans.
@@ -134,7 +109,7 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
        int to = offset + size;
 
        for (int i = offset; i < to; i++) {
-           writeBoolean(buf[i]);
+           writeBoolean(buf[i].booleanValue());
        }
     }
 

--- a/src/main/java/nom/tam/util/ArrayDataOutput.java
+++ b/src/main/java/nom/tam/util/ArrayDataOutput.java
@@ -50,7 +50,11 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     void flush() throws IOException;
 
     /**
-     * Writes a boolean value to the output.
+     * Writes a boolean value to the output, including support for legal 
+     * <code>null</code> values. The method's default implementation is
+     * to write <code>null</code> as the byte -1. Classes that implement
+     * this interface may want to override this behavior to represent
+     * <code>null</code> differently.
      * 
      * @param b
      *            the boolean value. Subclass implementations may allow
@@ -58,8 +62,17 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
      *            format.
      * @throws IOException
      *             if there was an IO error writing the value to the output.
+     *             
+     * @since 1.16
      */
-    void writeBoolean(Boolean b) throws IOException;
+    default void writeBoolean(Boolean b) throws IOException {
+        if (b == null) {
+            write(-1);
+        } else {
+            writeBoolean(b.booleanValue());
+        }
+        
+    }
 
     /**
      * Write an array of boolean's.
@@ -92,12 +105,19 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
      *            array of booleans.
      * @throws IOException
      *             if one of the underlying write operations failed
+     *             
+     * @since 1.16
      */
-    void write(Boolean[] buf) throws IOException;
+    default void write(Boolean[] buf) throws IOException {
+        write(buf, 0, buf.length);
+    }
 
     /**
      * Write a segment of an array of booleans, including legal
      * <code>null</code> values.
+     * The method has a default implementation, which calls {@link #writeBoolean(Boolean)}
+     * element by element. Classes that implement this interface might want to
+     * replace that with a more efficient block read implementation.
      * 
      * @param buf
      *            array of booleans.
@@ -107,8 +127,16 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
      *            number of array elements to write
      * @throws IOException
      *             if one of the underlying write operations failed
+     *             
+     * @since 1.16
      */
-    void write(Boolean[] buf, int offset, int size) throws IOException;
+    default void write(Boolean[] buf, int offset, int size) throws IOException {
+       int to = offset + size;
+
+       for (int i = offset; i < to; i++) {
+           writeBoolean(buf[i]);
+       }
+    }
 
     /**
      * Write an array of char's.

--- a/src/main/java/nom/tam/util/ArrayDecoder.java
+++ b/src/main/java/nom/tam/util/ArrayDecoder.java
@@ -188,7 +188,7 @@ public abstract class ArrayDecoder {
      */
     public void readArrayFully(Object o) throws IOException, IllegalArgumentException {
         if (readArray(o) != FitsEncoder.computeSize(o)) {
-            throw new EOFException("Incomplete array read.");
+            throw new EOFException("Incomplete array read (FITS encoding).");
         }
     }
 

--- a/src/main/java/nom/tam/util/FitsFile.java
+++ b/src/main/java/nom/tam/util/FitsFile.java
@@ -388,12 +388,7 @@ public class FitsFile extends ArrayDataFile implements RandomAccess, ArrayDataOu
     public synchronized void writeBoolean(boolean v) throws IOException {
         getEncoder().writeBoolean(v);
     }
-
-    @Override
-    public synchronized void writeBoolean(Boolean v) throws IOException {
-        getEncoder().writeBoolean(v);
-    }
-
+    
     @Override
     public synchronized void writeChar(int v) throws IOException {
         getEncoder().writeChar(v);

--- a/src/main/java/nom/tam/util/FitsFile.java
+++ b/src/main/java/nom/tam/util/FitsFile.java
@@ -264,7 +264,7 @@ public class FitsFile extends ArrayDataFile implements RandomAccess, ArrayDataOu
     public synchronized int read(boolean[] b, int start, int length) throws IOException {
         return getDecoder().read(b, start, length);
     }
-    
+
     @Override
     public final synchronized int read(Boolean[] buf) throws IOException {
         return read(buf, 0, buf.length);
@@ -522,16 +522,6 @@ public class FitsFile extends ArrayDataFile implements RandomAccess, ArrayDataOu
     @Override
     public synchronized void write(String[] s, int start, int length) throws IOException {
         getEncoder().write(s, start, length);
-    }
-
-    @Override
-    public final synchronized long position() {
-        return getFilePointer();
-    }
-
-    @Override
-    public final synchronized void position(long n) throws IOException {
-        seek(n);
     }
   
 }

--- a/src/main/java/nom/tam/util/FitsFile.java
+++ b/src/main/java/nom/tam/util/FitsFile.java
@@ -523,17 +523,6 @@ public class FitsFile extends ArrayDataFile implements RandomAccess, ArrayDataOu
     public synchronized void write(String[] s, int start, int length) throws IOException {
         getEncoder().write(s, start, length);
     }
-    
-    @Override
-    public synchronized boolean checkTruncated() throws IOException {
-        long pos = getFilePointer();
-        long len = length();
-        if (pos > len) {
-            LOG.log(Level.WARNING, "Premature file end at " + len + " (expected " + pos + ")", new Throwable());
-            return true;
-        }
-        return false;
-    }
 
     @Override
     public final synchronized long position() {

--- a/src/main/java/nom/tam/util/FitsInputStream.java
+++ b/src/main/java/nom/tam/util/FitsInputStream.java
@@ -355,11 +355,4 @@ public class FitsInputStream extends ArrayInputStream implements ArrayDataInput 
         return super.toString() + "[count=" + this.count + ",pos=" + this.pos + "]";
     }
     
-
-    @Override
-    public final boolean checkTruncated() throws IOException {
-        // We cannot skip more than is available in an input stream.
-        return false;
-    }
-
 }

--- a/src/main/java/nom/tam/util/FitsOutputStream.java
+++ b/src/main/java/nom/tam/util/FitsOutputStream.java
@@ -207,11 +207,6 @@ public class FitsOutputStream extends ArrayOutputStream implements ArrayDataOutp
     }
     
     @Override
-    public synchronized void writeBoolean(Boolean b) throws IOException {
-        getEncoder().writeBoolean(b);
-    }
-
-    @Override
     public synchronized void writeChar(int c) throws IOException {
         getEncoder().writeChar(c);
     }

--- a/src/main/java/nom/tam/util/RandomAccess.java
+++ b/src/main/java/nom/tam/util/RandomAccess.java
@@ -54,4 +54,15 @@ public interface RandomAccess extends ReadWriteAccess, ArrayDataInput {
      *             if the operation fails
      */
     void seek(long offsetFromStart) throws IOException;
+    
+    @Override
+    default long position() throws IOException {
+        return getFilePointer();
+    }
+    
+    @Override
+    default void position(long pos) throws IOException {
+        seek(pos);
+    }
+    
 }

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -109,7 +109,7 @@ These are represented as `float[2]` and `double[2]` arrays in the `nom.tam` libr
 
 As of version 1.16, we added a `ComplexValue` object for use in headers. At this point, 
 the new type is not being used with tables to maintain backward compatibility to the original behavior described above.
-This may change in a future release to make the use of `ComplexValue` more universally.
+This may change in a future release to use `ComplexValue` more universally.
 
 #### Strings
 

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1,4 +1,4 @@
-package nom.tam.fits.test;
+package nom.tam.fits;
 
 /*
  * #%L
@@ -1054,8 +1054,8 @@ public class HeaderTest {
         try {
             fits = new Fits("target/ht1_truncated.fits");
             ImageHDU hdu = (ImageHDU) fits.getHDU(0);
-            Header hdr = hdu.getHeader();
-            isTruncated = fits.getStream().checkTruncated();
+            hdu.getHeader();
+            isTruncated = Fits.checkTruncated(fits.getStream());
         } finally {
             SafeClose.close(fits);
         }

--- a/src/test/java/nom/tam/fits/ImageProtectedTest.java
+++ b/src/test/java/nom/tam/fits/ImageProtectedTest.java
@@ -127,7 +127,7 @@ public class ImageProtectedTest {
         // However, the contract of RandomAccess is to allow skipAllBytes() to move beyond
         // the file's end. But, we can check if the file pointer is beyond the current
         // end-of-file, so that's what we will check for from now on.
-        Assert.assertTrue(input.checkTruncated());
+        Assert.assertTrue(Fits.checkTruncated(input));
         input.close();
     }
 

--- a/src/test/java/nom/tam/fits/TruncatedFileExceptionTest.java
+++ b/src/test/java/nom/tam/fits/TruncatedFileExceptionTest.java
@@ -32,8 +32,12 @@ package nom.tam.fits;
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+
+import nom.tam.util.FitsFile;
 
 public class TruncatedFileExceptionTest {
 
@@ -41,5 +45,17 @@ public class TruncatedFileExceptionTest {
     public void testConstructorWithCause() {
         Exception e = new TruncatedFileException("test exception", new IllegalArgumentException("test cause"));
         assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+    }
+    
+    @Test
+    public void testTruncated() throws Exception {
+        try (FitsFile f = new FitsFile("fftest.bin", "rw", 100)) {
+            f.seek(10);
+            f.setLength(5);
+            assertEquals(5, f.getFilePointer());
+            assertFalse(Fits.checkTruncated(f));
+            f.seek(10);
+            assertTrue(Fits.checkTruncated(f));
+        }
     }
 }

--- a/src/test/java/nom/tam/util/DefaultMethodsTest.java
+++ b/src/test/java/nom/tam/util/DefaultMethodsTest.java
@@ -74,7 +74,7 @@ public class DefaultMethodsTest {
     @Test
     public void testWriteBooleanArray() throws Exception {
         Boolean[] b = new Boolean[] { null, Boolean.TRUE, Boolean.FALSE };
-        new DefaultOutput().write(b, 0, b.length);
+        new DefaultOutput().write(b);
         // No exception thrown...
     }
    

--- a/src/test/java/nom/tam/util/DefaultMethodsTest.java
+++ b/src/test/java/nom/tam/util/DefaultMethodsTest.java
@@ -1,0 +1,528 @@
+package nom.tam.util;
+
+/*-
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class DefaultMethodsTest {
+
+
+    @Test
+    public void testMarkSupported() throws Exception {
+        assertEquals(true, new DefaultInput().markSupported());
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadArrayFullyException() throws Exception {
+        int[] array = new int[2];
+        new DefaultInput().readArrayFully(array);
+        // throws EOFException since the test read() returns 0 always...
+    }
+    
+    @Test
+    public void testReadArrayFullySuccess() throws Exception {
+        int[] array = new int[2];
+        new DefaultInput() {
+            @Override
+            public long readLArray(Object o) throws IOException {
+                return 4L * array.length;
+            }
+        }.readArrayFully(array);
+    }
+    
+    @Test
+    public void testReadBooleanArray() throws Exception {
+        Boolean[] b = new Boolean[1];
+        assertEquals(b.length, new DefaultInput().read(b, 0, b.length));
+        assertEquals(false, b[0]);
+    }
+
+    @Test
+    public void testWriteBooleanArray() throws Exception {
+        Boolean[] b = new Boolean[] { null, Boolean.TRUE, Boolean.FALSE };
+        new DefaultOutput().write(b, 0, b.length);
+        // No exception thrown...
+    }
+   
+    
+    class DefaultInput implements ArrayDataInput {
+
+        @Override
+        public int read() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(byte[] b, int from, int length) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public boolean readBoolean() throws IOException {
+            // TODO Auto-generated method stub
+            return false;
+        }
+
+        @Override
+        public byte readByte() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public char readChar() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public double readDouble() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public float readFloat() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public void readFully(byte[] b) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public int readInt() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public String readLine() throws IOException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public long readLong() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public short readShort() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public String readUTF() throws IOException {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public int readUnsignedByte() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int readUnsignedShort() throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int skipBytes(int n) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public void close() throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void mark(int readlimit) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public int read(byte[] buf) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(boolean[] buf) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(boolean[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(char[] buf) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(char[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(double[] buf) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(double[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(float[] buf) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(float[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(int[] buf) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(int[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(long[] buf) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(long[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(short[] buf) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int read(short[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public int readArray(Object o) throws IOException, IllegalArgumentException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public long readLArray(Object o) throws IOException, IllegalArgumentException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public void reset() throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public long skip(long distance) throws IOException {
+            // TODO Auto-generated method stub
+            return 0;
+        }
+
+        @Override
+        public void skipAllBytes(long toSkip) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void skipAllBytes(int toSkip) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void readFully(byte[] b, int off, int len) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+    }
+
+
+    class DefaultOutput implements ArrayDataOutput {
+
+        @Override
+        public void write(int b) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeBoolean(boolean v) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeByte(int v) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeBytes(String s) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeChar(int v) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeChars(String s) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeDouble(double v) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeFloat(float v) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeInt(int v) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeLong(long v) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeShort(int v) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeUTF(String s) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void close() throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void flush() throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(boolean[] buf) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(boolean[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(char[] buf) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(char[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(double[] buf) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(double[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(float[] buf) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(float[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(int[] buf) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(int[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(long[] buf) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(long[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(short[] buf) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(short[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(String[] buf) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void write(String[] buf, int offset, int size) throws IOException {
+            // TODO Auto-generated method stub
+
+        }
+
+        @Override
+        public void writeArray(Object o) throws IOException, IllegalArgumentException {
+            // TODO Auto-generated method stub
+
+        }
+    }
+
+
+}

--- a/src/test/java/nom/tam/util/DefaultMethodsTest.java
+++ b/src/test/java/nom/tam/util/DefaultMethodsTest.java
@@ -67,7 +67,7 @@ public class DefaultMethodsTest {
     @Test
     public void testReadBooleanArray() throws Exception {
         Boolean[] b = new Boolean[1];
-        assertEquals(b.length, new DefaultInput().read(b, 0, b.length));
+        assertEquals(b.length, new DefaultInput().read(b));
         assertEquals(false, b[0]);
     }
 

--- a/src/test/java/nom/tam/util/DefaultMethodsTest.java
+++ b/src/test/java/nom/tam/util/DefaultMethodsTest.java
@@ -73,11 +73,17 @@ public class DefaultMethodsTest {
 
     @Test
     public void testWriteBooleanArray() throws Exception {
-        Boolean[] b = new Boolean[] { null, Boolean.TRUE, Boolean.FALSE };
+        Boolean[] b = new Boolean[] { Boolean.TRUE, Boolean.FALSE };
         new DefaultOutput().write(b);
         // No exception thrown...
     }
-   
+    
+    @Test(expected = NullPointerException.class)
+    public void testWriteBooleanNull() throws Exception {
+        Boolean[] b = new Boolean[] { Boolean.TRUE, Boolean.FALSE, null };
+        new DefaultOutput().write(b);
+        // A NullPointerException is thrown, because the deffault implementation does not handle null...
+    }
     
     class DefaultInput implements ArrayDataInput {
 

--- a/src/test/java/nom/tam/util/FitsFileTest.java
+++ b/src/test/java/nom/tam/util/FitsFileTest.java
@@ -96,17 +96,6 @@ public class FitsFileTest {
         }
     }
     
-    @Test
-    public void testTruncated() throws Exception {
-        try (FitsFile f = new FitsFile("fftest.bin", "rw", 100)) {
-            f.seek(10);
-            f.setLength(5);
-            assertEquals(5, f.getFilePointer());
-            assertFalse(f.checkTruncated());
-            f.seek(10);
-            assertTrue(f.checkTruncated());
-        }
-    }
     
     @Test
     public void testPosition() throws Exception {

--- a/src/test/java/nom/tam/util/FitsFileTest.java
+++ b/src/test/java/nom/tam/util/FitsFileTest.java
@@ -71,23 +71,6 @@ public class FitsFileTest {
         }
     }
     
-    @Test
-    public void testReadWriteBooleanObject() throws Exception {
-        try (FitsFile f = new FitsFile("fftest.bin", "rw", 100)) {
-            Boolean[] b = new Boolean[] { Boolean.TRUE, null, Boolean.FALSE };
-            for (int i=0; i<b.length; i++) {
-                f.writeBoolean(b[i]);
-            }
-            f.seek(0);
-            Boolean[] b2 = new Boolean[b.length];
-            f.read(b2);
-            f.close();
-            for (int i=0; i<b.length; i++) {
-                assertEquals("[" + i + "]", b[i], b2[i]);
-            }
-        }
-    }
-    
     @Test(expected = IOException.class)
     public void testSkipBeforeBeginninng() throws Exception {
         try (FitsFile f = new FitsFile("fftest.bin", "rw", 100)) {


### PR DESCRIPTION
- Move and hide `checkTruncated()` method to leave `ArrayDataInput` interface unperturbed. (Thanks to @mbtaylor for finding it as a potentially breaking change that was not necessary)