### PR TITLE
Incremental HDU writing with automatic primary or extension HDU setting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>gov.nasa.gsfc.heasarc</groupId>
 	<artifactId>nom-tam-fits</artifactId>
-	<version>1.16.2-SNAPSHOT</version>
+	<version>1.17.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>nom.tam FITS library</name>
 	<description>Java library for reading and writing FITS files. FITS, the Flexible Image Transport System, is the format commonly used in the archiving and transport of astronomical data.</description>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -1,6 +1,13 @@
 <document xmlns="http://maven.apache.org/changes/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/xsd/changes-1.0.0.xsd">
 	<body>
 	
+	  <release version="1.17.0-SNAPSHOT" date="2022-04-14" description="Improved incremental output and other enhancements.">
+	    <action type="update" dev="attipaci" issue="266">
+				Safe incremental HDU writing via new FitsOutput interface, which is used to check whether HDUs should be set primary or not
+				depending on where it is located in the output.
+			</action>
+	  </release>
+	  
 	  <release version="1.16.1" date="2022-03-21" description="Maintenance release with bug fixes.">
 	    <action type="fix" dev="attipaci" issue="252">
 				Fixed broken Java 8 compatibility of 1.16.0 due to Java compiler flags in POM. Note, after the change the build itself will require Java 9 or later!

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -66,6 +66,7 @@ import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
+import nom.tam.util.FitsOutput;
 
 /**
  * This abstract class is the parent of all HDU types. It provides basic
@@ -633,6 +634,10 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
 
     @Override
     public void write(ArrayDataOutput stream) throws FitsException {
+        if (stream instanceof FitsOutput) {
+            boolean isFirst = ((FitsOutput) stream).isAtStart();
+            setPrimaryHDU(canBePrimary() && isFirst);
+        }
         if (this.myHeader != null) {
             this.myHeader.write(stream);
         }

--- a/src/main/java/nom/tam/util/ArrayDataOutput.java
+++ b/src/main/java/nom/tam/util/ArrayDataOutput.java
@@ -40,7 +40,7 @@ import java.io.IOException;
  * Interface for writing array data to outputs.
  */
 public interface ArrayDataOutput extends DataOutput, Closeable {
-
+    
     /**
      * Flush the output buffer
      * 

--- a/src/main/java/nom/tam/util/FitsEncoder.java
+++ b/src/main/java/nom/tam/util/FitsEncoder.java
@@ -65,7 +65,7 @@ public class FitsEncoder extends OutputEncoder {
     protected FitsEncoder() {
         super();
     }
-    
+
     /**
      * Instantiates a new FITS binary data encoder for converting Java arrays into
      * FITS data representations

--- a/src/main/java/nom/tam/util/FitsFile.java
+++ b/src/main/java/nom/tam/util/FitsFile.java
@@ -90,10 +90,10 @@ import java.util.logging.Logger;
  * @since 1.16
  */
 @SuppressWarnings("deprecation")
-public class FitsFile extends ArrayDataFile implements RandomAccess, ArrayDataOutput {
+public class FitsFile extends ArrayDataFile implements FitsOutput, RandomAccess {
 
     private static final Logger LOG = Logger.getLogger(FitsFile.class.getName());
-    
+
     /**
      * marker position
      */
@@ -200,6 +200,11 @@ public class FitsFile extends ArrayDataFile implements RandomAccess, ArrayDataOu
         return (FitsDecoder) super.getDecoder();
     }
   
+    @Override
+    public boolean isAtStart() {
+        return getFilePointer() == 0;
+    }
+    
     @Override
     public final synchronized int readUnsignedByte() throws IOException {
         return getDecoder().readUnsignedByte();
@@ -428,5 +433,4 @@ public class FitsFile extends ArrayDataFile implements RandomAccess, ArrayDataOu
     public synchronized void write(String[] s, int start, int length) throws IOException {
         getEncoder().write(s, start, length);
     }
-  
 }

--- a/src/main/java/nom/tam/util/FitsOutput.java
+++ b/src/main/java/nom/tam/util/FitsOutput.java
@@ -1,0 +1,59 @@
+package nom.tam.util;
+
+/*-
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2022 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+/**
+ * Interface for FITS-specific output. It mainly just provides an #isAtStart()
+ * method that can be used to determine whether or not we are at the head of the
+ * file or stream, in order to decide if an HDU here should be written as
+ * primary or as a FITS extension. The decision is made by
+ * {@link nom.tam.fits.BasicHDU#write(ArrayDataOutput)} and there is no need for
+ * any user interaction beyond it.
+ * 
+ * @author Attila Kovacs
+ * @since 1.17
+ */
+public interface FitsOutput extends ArrayDataOutput {
+
+    /**
+     * Checks whether we are currently at the start of this output file or
+     * stream.
+     * 
+     * @return <code>true</code> if we are currently at the start of stream
+     *         (where a primary HDU is to be written), or <code>false</code> if
+     *         we are further along, where HDUs should be written as extensions.
+     *         
+     * @see RandomAccess#position()
+     * @see FitsEncoder#getCount()
+     */
+    boolean isAtStart();
+}

--- a/src/main/java/nom/tam/util/FitsOutputStream.java
+++ b/src/main/java/nom/tam/util/FitsOutputStream.java
@@ -52,7 +52,7 @@ import java.io.OutputStream;
  * @see FitsFile
  */
 @SuppressWarnings("deprecation")
-public class FitsOutputStream extends ArrayOutputStream implements ArrayDataOutput {
+public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
 
     /** the output, as accessible via the <code>DataInput</code> interface */
     private final DataOutput data;
@@ -203,4 +203,10 @@ public class FitsOutputStream extends ArrayOutputStream implements ArrayDataOutp
     public final synchronized void writePrimitiveArray(Object o) throws IOException {
         writeArray(o);
     }
+
+    @Override
+    public boolean isAtStart() {
+        return getEncoder().getCount() == 0;
+    }
+
 }

--- a/src/main/java/nom/tam/util/OutputEncoder.java
+++ b/src/main/java/nom/tam/util/OutputEncoder.java
@@ -58,7 +58,10 @@ public abstract class OutputEncoder {
      * The output to which to write encoded data (directly or from the
      * conversion buffer)
      */
-    private OutputWriter out;
+    protected OutputWriter out;
+
+    /** Cumulative bytes written to the output, including over-writes */
+    private long count = 0;
 
     /**
      * A local buffer for efficient conversions before bulk writing to the
@@ -97,6 +100,19 @@ public abstract class OutputEncoder {
      */
     protected synchronized void setOutput(OutputWriter o) {
         this.out = o;
+    }
+
+    /**
+     * Returns the position in file or stream at which the next write will take
+     * place. For random access files, this is the current file pointer, while
+     * for streams it is the cumulative count of bytes previously written.
+     * 
+     * @return the byte offset in the file or stream at which the next write
+     *         will act.
+     * @see RandomAccess#getFilePointer()
+     */
+    public long getCount() {
+        return count;
     }
 
     /**
@@ -159,6 +175,7 @@ public abstract class OutputEncoder {
     protected synchronized void write(int b) throws IOException {
         flush();
         out.write(b);
+        count++;
     }
 
     /**
@@ -179,6 +196,7 @@ public abstract class OutputEncoder {
     protected synchronized void write(byte[] b, int start, int length) throws IOException {
         flush();
         out.write(b, start, length);
+        count += length;
     }
 
     /**

--- a/src/main/java/nom/tam/util/OutputWriter.java
+++ b/src/main/java/nom/tam/util/OutputWriter.java
@@ -90,7 +90,7 @@ public interface OutputWriter {
             @Override
             public void write(byte[] b, int from, int length) throws IOException {
                 o.write(b, from, length);
-            }            
+            }
         };
     }
 }


### PR DESCRIPTION
`BasicHDU.write()` now checks if the HDU is to be written to the start of the output (via the `FitsOutput` interface, implemented by both `FitsFile` and `FitsOutputStream`), and accordingly calls `setPrimaryHDU()` to create nearly fool-proof Fits files even if HDUs are written incrementally. 

However, `BasicHDU.write()` will allow writing a HDU to the head of stream, even if it cannot be made primary (such as a `BinaryTableHDU`), in order to better preserve compatibility with earlier behavior, and to allow writing incomplete Fits 'snipplets' if desired.