### PR TITLE
Suppress repeated duplicate warnings & improve checks

### DIFF
--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -2085,6 +2085,7 @@ public class Header implements FitsElement {
         HeaderCardParser.getLogger().log(Level.WARNING, "Multiple occurrences of key:" + dup.getKey());
 
         duplicates.add(dup);
+        dupKeys.add(dup.getKey());
     }
 
     /**

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -58,6 +58,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -970,14 +971,14 @@ public class Header implements FitsElement {
      * header.
      * 
      * @return  the set of header keywords that were assigned more than once in the
-     *          same header.
+     *          same header, or <code>null</code> if there were no duplicate assignments.
      *          
      * @see #hadDuplicates()
      * @see #getDuplicates()
      * 
      * @since 1.17
      */
-    public HashSet<String> getDuplicateKeySet() {
+    public Set<String> getDuplicateKeySet() {
         return dupKeys;
     }
     

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -34,7 +34,6 @@ package nom.tam.fits;
 import static nom.tam.fits.header.Standard.BITPIX;
 import static nom.tam.fits.header.Standard.BLANKS;
 import static nom.tam.fits.header.Standard.COMMENT;
-import static nom.tam.fits.header.Standard.CONTINUE;
 import static nom.tam.fits.header.Standard.END;
 import static nom.tam.fits.header.Standard.EXTEND;
 import static nom.tam.fits.header.Standard.GCOUNT;
@@ -57,6 +56,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -135,6 +135,8 @@ public class Header implements FitsElement {
     private long fileOffset;
 
     private List<HeaderCard> duplicates;
+    
+    private HashSet<String> dupKeys;
 
     /** Input descriptor last time header was read */
     private ArrayDataInput input;
@@ -930,17 +932,55 @@ public class Header implements FitsElement {
     }
 
     /**
+     * <p>
+     * Returns the list of duplicate cards in the order they appeared in the parsed header.
+     * You can access the first occurence of each of every duplicated FITS keyword 
+     * using the usual <code>Header.getValue()</code>, and find further occurrences
+     * in the list returned here.
+     * </p>
+     * <p>
+     * The FITS standared strongly discourages using the keywords multiple times with assigned
+     * values, and specifies that the values of such keywords are undefined by definitions.
+     * Our library is thus far more tolerant than the FITS standard, allowing you to access
+     * each and every value that was specified for the same keyword.
+     * </p>
+     * <p>
+     * On the other hand FITS does not limit how many times you can add comment-style
+     * keywords to a header. If you must used the same keyword multiple times in your
+     * header, you should consider using comment-style entries instead.
+     * </p>
+     * 
+     * 
      * @return the list of duplicate cards. Note that when the header is read
      *         in, only the last entry for a given keyword is retained in the
      *         active header. This method returns earlier cards that have been
      *         discarded in the order in which they were encountered in the
      *         header. It is possible for there to be many cards with the same
      *         keyword in this list.
+     *         
+     * @see #hadDuplicates()
+     * @see #getDuplicateKeySet()
      */
     public List<HeaderCard> getDuplicates() {
         return this.duplicates;
     }
 
+    /**
+     * Returns the set of keywords that had more than one value assignment in the parsed
+     * header.
+     * 
+     * @return  the set of header keywords that were assigned more than once in the
+     *          same header.
+     *          
+     * @see #hadDuplicates()
+     * @see #getDuplicates()
+     * 
+     * @since 1.17
+     */
+    public HashSet<String> getDuplicateKeySet() {
+        return dupKeys;
+    }
+    
     /**
      * @return Get the offset of this header
      */
@@ -1541,6 +1581,7 @@ public class Header implements FitsElement {
     private void clear() {
         cards.clear();
         duplicates = null;
+        dupKeys = null;
         readSize = 0;
         fileOffset = -1;
         minCards = 0;
@@ -2032,16 +2073,17 @@ public class Header implements FitsElement {
 
     private void addDuplicate(HeaderCard dup) { 
         // AK: Don't worry about duplicates for comment-style cards in general.
-        if (dup.isCommentStyleCard() || CONTINUE.key().equals(dup.getKey())) {
+        if (dup.isCommentStyleCard()) {
             return;
         }
-        if (isParserWarningsEnabled()) {
+        if (duplicates == null) {
+            duplicates = new ArrayList<>();
+            dupKeys = new HashSet<>();
+        }
+        if (dupKeys.add(dup.getKey()) && isParserWarningsEnabled()) {
             LOG.log(Level.WARNING, "Multiple occurrences of key:" + dup.getKey());
         }
-        if (this.duplicates == null) {
-            this.duplicates = new ArrayList<>();
-        }
-        this.duplicates.add(dup);
+        duplicates.add(dup);
     }
 
     /**

--- a/src/test/java/nom/tam/fits/test/DupTest.java
+++ b/src/test/java/nom/tam/fits/test/DupTest.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.DataOutputStream;
 import java.io.FileOutputStream;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -153,6 +154,15 @@ public class DupTest {
         assertEquals(initCount, counter.getCount());    // Check that logger was NOT called on them
         
         l.removeHandler(counter);
+    }
+    
+    @Test
+    public void dupesSetTest() throws Exception {
+        Fits f = new Fits("src/test/resources/nom/tam/fits/test/test_dup.fits");
+        Header h = f.readHDU().getHeader();
+        
+        Set<?> keys = h.getDuplicateKeySet(); 
+        assertTrue(keys.contains("CARD"));
     }
     
 }


### PR DESCRIPTION
The changes in this PR are:

 1. Warn only once for each keyword that has multiple assignments in the parse header.
 2. new method `Header.getDuplicateKeySet()`, which returns the set of keywords that had duplicate assignments, or `null` if there were no keyword was assigned more than once.