### PR TITLE
Header checks (part 2)

### DIFF
--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -42,9 +42,7 @@ import static nom.tam.fits.header.Standard.DATE;
 import static nom.tam.fits.header.Standard.DATE_OBS;
 import static nom.tam.fits.header.Standard.EPOCH;
 import static nom.tam.fits.header.Standard.EQUINOX;
-import static nom.tam.fits.header.Standard.EXTEND;
 import static nom.tam.fits.header.Standard.GCOUNT;
-import static nom.tam.fits.header.Standard.GROUPS;
 import static nom.tam.fits.header.Standard.INSTRUME;
 import static nom.tam.fits.header.Standard.NAXIS;
 import static nom.tam.fits.header.Standard.NAXISn;
@@ -582,54 +580,12 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
      *             if the operation failed
      */
     void setPrimaryHDU(boolean newPrimary) throws FitsException {
-
         if (newPrimary && !canBePrimary()) {
             throw new FitsException("Invalid attempt to make HDU of type:" + this.getClass().getName() + " primary.");
         } 
         
+        myHeader.editRequiredKeys(newPrimary);
         this.isPrimary = newPrimary;
-       
-        // Some FITS readers don't like the PCOUNT and GCOUNT keywords
-        // in a primary array or they EXTEND keyword in extensions.
-
-        if (this.isPrimary && !this.myHeader.getBooleanValue(GROUPS, false)) {
-            this.myHeader.deleteKey(PCOUNT);
-            this.myHeader.deleteKey(GCOUNT);
-        }
-
-        if (this.isPrimary) {
-            HeaderCard card = this.myHeader.findCard(EXTEND);
-            if (card == null) {
-                getAxes(); // Leaves the iterator pointing to the last NAXISn
-                           // card.
-                this.myHeader.nextCard();
-                this.myHeader.addValue(EXTEND, true);
-            }
-        }
-
-        if (!this.isPrimary) {
-
-            this.myHeader.iterator();
-
-            int pcount = this.myHeader.getIntValue(PCOUNT, 0);
-            int gcount = this.myHeader.getIntValue(GCOUNT, 1);
-            int naxis = this.myHeader.getIntValue(NAXIS, 0);
-            this.myHeader.deleteKey(EXTEND);
-            HeaderCard pcard = this.myHeader.findCard(PCOUNT);
-            HeaderCard gcard = this.myHeader.findCard(GCOUNT);
-
-            //this.myHeader.getCard(2 + naxis);
-            this.myHeader.findCard(NAXIS.key() + naxis);
-            
-            if (pcard == null) {
-                this.myHeader.addValue(PCOUNT, pcount);
-            }
-            if (gcard == null) {
-                this.myHeader.addValue(GCOUNT, gcount);
-            }
-            this.myHeader.iterator();
-        }
-
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -527,11 +527,7 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
      *         stripped.
      */
     public String getTrimmedString(IFitsHeader keyword) {
-        String s = this.myHeader.getStringValue(keyword);
-        if (s != null) {
-            s = s.trim();
-        }
-        return s;
+        return getTrimmedString(keyword.key());
     }
 
     /**
@@ -590,13 +586,17 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
 
     @Override
     public void write(ArrayDataOutput stream) throws FitsException {
+        if (myHeader == null) {
+            myHeader = new Header();
+        }
+        
         if (stream instanceof FitsOutput) {
             boolean isFirst = ((FitsOutput) stream).isAtStart();
             setPrimaryHDU(canBePrimary() && isFirst);
         }
-        if (this.myHeader != null) {
-            this.myHeader.write(stream);
-        }
+        
+        this.myHeader.write(stream);
+        
         if (this.myData != null) {
             this.myData.write(stream);
         }

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -2029,7 +2029,7 @@ public class Header implements FitsElement {
      * 
      * @since 1.17
      * 
-     * @see #validateFor(FitsOutput)
+     * @see #validate(FitsOutput)
      */
     void editRequiredKeys(boolean isPrimary) throws FitsException {
        
@@ -2077,20 +2077,18 @@ public class Header implements FitsElement {
     
     /**
      * <p>
-     * Validates this header immediately before writing it to a FITS output. If the header is
-     * to be written to the beginning of the output it will be edited as necessary for a primary header.
-     * Othwreise it will be edited as needed for an extension header. In both cases it means adding
+     * Validates this header by making it a proper primary or extension header. In both cases it means adding
      * required keywords if missing, and removing conflicting cards. Then ordering is checked and
      * corrected as necessary and ensures that the <code>END</code> card is at the tail. 
      * 
      * 
-     * @param out               The output (file or stream) to which this header is about to be written next
+     * @param asPrimary         <code>true</code> if this header is to be a primary FITS header
      * @throws FitsException    If there was an issue getting the header into proper form.
      * 
      * @since 1.17
      */
-    public void validateFor(FitsOutput out) throws FitsException {
-        editRequiredKeys(out.isAtStart());
+    public void validate(boolean asPrimary) throws FitsException {
+        editRequiredKeys(asPrimary);
         validate();
     }   
         

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -199,7 +199,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         }
 
     }
-   
+    
     /**
      * Creates a new card with a number value. The card will be created either in the integer, fixed-decimal, or
      * format, with the native precision. If the native precision cannot be fitted in the available card space,
@@ -583,7 +583,6 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         this.value = aValue;
     }
 
-    
     @Override
     protected HeaderCard clone() {
         try { 
@@ -1389,12 +1388,23 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @param key       The standard or conventional FITS keyword
      * @param type      The type we want to use with that key
      * 
+     * @throws IllegalArgumentException if the keyword does not support the given value type.
+     * 
      * @since 1.16
      */
-    private static void checkType(IFitsHeader key, VALUE type) {
-        if (key.valueType() != VALUE.ANY && key.valueType() != type) {
-            LOG.log(Level.WARNING, "[" + key + "] created with unexpected value type.", new IllegalArgumentException("Expected " + type + ", got " + key.valueType()));
+    private static boolean checkType(IFitsHeader key, VALUE type) throws IllegalArgumentException {
+        if (key.valueType() == type || key.valueType() == VALUE.ANY) {
+            return true;
         }
+        if (key.valueType() == VALUE.COMPLEX && (type == VALUE.REAL || type == VALUE.INTEGER)) {
+            return true;
+        }
+        if (key.valueType() == VALUE.REAL && type == VALUE.INTEGER) {
+            return true;
+        }
+
+        LOG.log(Level.WARNING, "[" + key + "] created with unexpected value type.", new IllegalArgumentException("Expected " + type + ", got " + key.valueType()));
+        return false;
     }
     
     /**
@@ -1421,7 +1431,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         try {
             return new HeaderCard(key.key(), value, key.comment());
         } catch (HeaderCardException e) {
-            throw new IllegalArgumentException("Invalid standard key [" + key.key() + "]", e);
+            throw new IllegalArgumentException("Invalid sconventional key [" + key.key() + "]", e);
         }
     }
     
@@ -1440,10 +1450,10 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @throws IllegalArgumentException     
      *                  if the standard key was ill-defined.
      *                  
-     * @since 1.6
+     * @since 1.16
      */
     public static HeaderCard create(IFitsHeader key, Number value)  throws IllegalArgumentException  {
-        if (value instanceof Float || value instanceof Double || value instanceof BigInteger) {
+        if (value instanceof Float || value instanceof Double || value instanceof BigDecimal) {
             checkType(key, VALUE.REAL);
         } else {       
             checkType(key, VALUE.INTEGER);
@@ -1452,7 +1462,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         try {
             return new HeaderCard(key.key(), value, key.comment());
         } catch (HeaderCardException e) {
-            throw new IllegalArgumentException("Invalid standard key [" + key.key() + "]", e);
+            throw new IllegalArgumentException("Invalid conventional key [" + key.key() + "]", e);
         }
     }
     
@@ -1471,7 +1481,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @throws IllegalArgumentException     
      *                  if the standard key was ill-defined.
      *                  
-     * @since 1.6
+     * @since 1.16
      */
     public static HeaderCard create(IFitsHeader key, ComplexValue value)  throws IllegalArgumentException  {
         checkType(key, VALUE.COMPLEX);
@@ -1479,7 +1489,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         try {
             return new HeaderCard(key.key(), value, key.comment());
         } catch (HeaderCardException e) {
-            throw new IllegalArgumentException("Invalid standard key [" + key.key() + "]", e);
+            throw new IllegalArgumentException("Invalid conventional key [" + key.key() + "]", e);
         }
     }
     
@@ -1509,7 +1519,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         try {
             return new HeaderCard(key.key(), value, key.comment());
         } catch (HeaderCardException e) {
-            throw new IllegalArgumentException("Invalid standard key [" + key.key() + "]", e);
+            throw new IllegalArgumentException("Invalid conventional key [" + key.key() + "]", e);
         }
     }
     

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -1403,7 +1403,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         if (key.valueType() == VALUE.REAL && type == VALUE.INTEGER) {
             return true;
         }
-
+        
         LOG.log(Level.WARNING, "[" + key + "] with unexpected value type.", new IllegalArgumentException("Expected " + type + ", got " + key.valueType()));
         return false;
     }

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -110,6 +110,6 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
      * @since 1.17
      */
     public static boolean isCommentStyleKey(String key) {
-        return commentStyleKeys.contains(key) || key.isEmpty();
+        return commentStyleKeys.contains(key) || key.trim().isEmpty();
     }
 }

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -1,6 +1,7 @@
 package nom.tam.fits.header;
 
 import java.io.Serializable;
+import java.util.HashSet;
 
 /*
  * #%L
@@ -48,6 +49,8 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
     private final SOURCE status;
 
     private final VALUE valueType;
+    
+    private static HashSet<String> commentStyleKeys = new HashSet<>();
 
     public FitsHeaderImpl(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
         this.key = headerName;
@@ -55,6 +58,9 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
         this.hdu = hdu;
         this.valueType = valueType;
         this.comment = comment;
+        if (valueType == VALUE.NONE) {
+            commentStyleKeys.add(headerName);
+        }
     }
 
     @Override
@@ -90,5 +96,20 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
     @Override
     public VALUE valueType() {
         return this.valueType;
+    }
+    
+    /**
+     * Checks if a keywords is known to be a comment-style keyword. That is, it checks if the <code>key</code> argument matches 
+     * any {@link IFitsHeader} constructed via this implementation with a <code>valueType</code> argument that was
+     * <code>null</code>, or if the key is empty.
+     * 
+     * @param key       the keyword to check
+     * @return          <code>true</code> if the key is empty or if it matches any known {@link IFitsHeader} keywords
+     *                  implemented through this class that have valueType of <code>null</code>. Otherwise <code>false</code>.
+     *                  
+     * @since 1.17
+     */
+    public static boolean isCommentStyleKey(String key) {
+        return commentStyleKeys.contains(key) || key.isEmpty();
     }
 }

--- a/src/main/java/nom/tam/util/HashedList.java
+++ b/src/main/java/nom/tam/util/HashedList.java
@@ -198,7 +198,7 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
      */
     private void add(int pos, VALUE entry) {     
         String key = entry.getKey();
-        if (this.keyed.containsKey(key) && !unkeyedKey(key)) {
+        if (this.keyed.containsKey(key) && !FitsHeaderImpl.isCommentStyleKey(key)) {
             int oldPos = indexOf(entry);
             internalRemove(oldPos, entry);
             if (oldPos < pos) {
@@ -229,10 +229,6 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
         }
     }
 
-    private static boolean unkeyedKey(String key) {
-        return FitsHeaderImpl.isCommentStyleKey(key) || key.trim().isEmpty();
-    }
-
     @Override
     public boolean add(VALUE e) {
         add(this.ordered.size(), e);
@@ -250,7 +246,7 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
      *            The element to add to the list.
      */
     public void update(String key, VALUE entry) {
-        if (this.keyed.containsKey(key) && !unkeyedKey(key)) {
+        if (this.keyed.containsKey(key) && !FitsHeaderImpl.isCommentStyleKey(key)) {
             int index = indexOf(get(key));
             remove(index);
             add(index, entry);

--- a/src/main/java/nom/tam/util/HashedList.java
+++ b/src/main/java/nom/tam/util/HashedList.java
@@ -57,6 +57,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import nom.tam.fits.header.FitsHeaderImpl;
+
 /**
  * a ordered hash map implementation.
  *
@@ -228,7 +230,7 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
     }
 
     private static boolean unkeyedKey(String key) {
-        return "COMMENT".equals(key) || "HISTORY".equals(key) || key.trim().isEmpty();
+        return FitsHeaderImpl.isCommentStyleKey(key) || key.trim().isEmpty();
     }
 
     @Override

--- a/src/test/java/nom/tam/fits/BasicHduFailureTest.java
+++ b/src/test/java/nom/tam/fits/BasicHduFailureTest.java
@@ -168,30 +168,16 @@ public class BasicHduFailureTest {
         Assert.assertNull(dummyHDU.getObservationDate());
     }
 
-    @Test
+    @Test(expected = FitsException.class)
     public void testRewriteFailuer() throws Exception {
-        FitsException actual = null;
-        try {
-            BasicHDU<?> dummyHDU = BasicHDU.getDummyHDU();
-            dummyHDU.rewrite();
-        } catch (FitsException e) {
-            actual = e;
-        }
-        Assert.assertNotNull(actual);
-        Assert.assertTrue(actual.getMessage().contains("rewrite"));
+        BasicHDU<?> dummyHDU = BasicHDU.getDummyHDU();
+        dummyHDU.rewrite();
     }
 
-    @Test
+    @Test(expected = FitsException.class)
     public void testSetPrimaryFailuer() throws Exception {
         UndefinedData data = new UndefinedData(new long[10]);
         BasicHDU<?> dummyHDU = new UndefinedHDU(UndefinedHDU.manufactureHeader(data), data);
-        FitsException actual = null;
-        try {
-            dummyHDU.setPrimaryHDU(true);
-        } catch (FitsException e) {
-            actual = e;
-        }
-        Assert.assertNotNull(actual);
-        Assert.assertTrue(actual.getMessage().contains("primary"));
+        dummyHDU.setPrimaryHDU(true);
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderOrderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderOrderTest.java
@@ -76,12 +76,12 @@ public class HeaderOrderTest {
         ArrayDataOutput dos = new FitsOutputStream(new ByteArrayOutputStream(), 80);
         Header header = new Header();
         
-        header.addValue(BLOCKED, 1);
+        header.addValue(BLOCKED, true);
         header.addValue(SIMPLE, true);
         header.addValue(BITPIX, 8);
         header.addValue(THEAP, 1);  
         header.addValue(NAXIS, 0);
-        header.addValue(END, true);
+        header.insertCommentStyle(END.key(), null);
        
         
         // Check that the order is what we expect...
@@ -99,9 +99,9 @@ public class HeaderOrderTest {
         header.addValue(SIMPLE, true);
         header.addValue(BITPIX, 8);
         header.addValue(NAXIS, 0);
-        header.addValue(END, true);
+        header.insertCommentStyle(END.key(), null);
         header.addValue(THEAP, 1);
-        header.addValue(BLOCKED, 1);
+        header.addValue(BLOCKED, true);
         Assert.assertEquals(END.key(), header.iterator(3).next().getKey());
         header.write(dos);
         Assert.assertEquals(THEAP.key(), header.iterator(4).next().getKey());

--- a/src/test/java/nom/tam/fits/HeaderOrderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderOrderTest.java
@@ -113,4 +113,28 @@ public class HeaderOrderTest {
     public void testSaveNewCard() {
         HeaderCard.saveNewHeaderCard("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "", false);
     }
+    
+    @Test
+    public void testBadNaxis1() {
+        assertEquals(1, new HeaderOrder().compare("NAXIS-1", "THEAP"));
+    }
+    
+    @Test
+    public void testBadNaxis2() {
+        assertEquals(1, new HeaderOrder().compare("NAXIS1000", "THEAP"));
+    }
+    
+    @Test
+    public void testBadNaxis3() {
+        assertEquals(1, new HeaderOrder().compare("NAXISA", "THEAP"));
+    }
+    
+    @Test
+    public void testNullOrder() {
+        assertEquals(1, new HeaderOrder().compare(null, "THEAP"));
+        assertEquals(0, new HeaderOrder().compare(null, "WHATEVER"));
+        assertEquals(-1, new HeaderOrder().compare(null, "END"));
+    }
 }
+
+

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1570,4 +1570,12 @@ public class HeaderTest {
         h.updateLine("", HeaderCard.createCommentCard("new comment"));
         assertEquals(2, h.getNumberOfCards());
     }
+    
+    @Test
+    public void updateKey() throws Exception {
+        Header h = new Header();
+        h.addValue("TEST1", 1, "comment");
+        h.updateLine("TEST1", new HeaderCard("TEST2", 2, "comment"));
+        assertEquals(1, h.getNumberOfCards());
+    }
 }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1566,8 +1566,8 @@ public class HeaderTest {
     @Test
     public void updateEmptyKey() throws Exception {
         Header h = new Header();
-        h.insertCommentStyle("", "existing comment");
-        h.updateLine("", HeaderCard.createCommentCard("new comment"));
+        h.insertCommentStyle("  ", "existing comment");
+        h.updateLine("  ", HeaderCard.createCommentCard("new comment"));
         assertEquals(2, h.getNumberOfCards());
     }
     

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1491,6 +1491,53 @@ public class HeaderTest {
         // No exception
     }
     
+    private void checkPrimary(Header h) throws Exception {
+        Cursor<String, HeaderCard> c = h.iterator();
+        assertEquals("SIMPLE", "SIMPLE", c.next().getKey());
+        assertEquals("BITPIX", "BITPIX", c.next().getKey());
+        assertEquals("NAXIS", "NAXIS", c.next().getKey());
+        assertEquals("EXTEND", "EXTEND", c.next().getKey());
+        assertFalse("!XTENSION", h.containsKey("XTENSION"));
+    }
     
+    private void checkXtension(Header h) throws Exception {
+        Cursor<String, HeaderCard> c = h.iterator();
+        assertEquals("XTENSION", "XTENSION", c.next().getKey());
+        assertEquals("BITPIX", "BITPIX", c.next().getKey());
+        assertEquals("NAXIS", "NAXIS", c.next().getKey());
+        assertEquals("PCOUNT", "PCOUNT", c.next().getKey());
+        assertEquals("GCOUNT", "GCOUNT", c.next().getKey());
+        assertFalse("!SIMPLE", h.containsKey("SIMPLE"));
+        assertFalse("!EXTEND", h.containsKey("EXTEND"));
+    }
     
+    @Test
+    public void testValidateForPrimary() throws Exception {
+        Header h = new Header();
+        h.validate(true);
+        checkPrimary(h);
+    }
+    
+    @Test
+    public void testValidateForXtension() throws Exception {
+        Header h = new Header();
+        h.validate(false);
+        checkXtension(h);
+    }
+    
+    @Test
+    public void testRevalidateForPrimary() throws Exception {
+        Header h = new Header();
+        h.validate(false);
+        h.validate(true);
+        checkPrimary(h);
+    }
+    
+    @Test
+    public void testRevalidateForXtension() throws Exception {
+        Header h = new Header();
+        h.validate(true);
+        h.validate(false);
+        checkXtension(h);
+    }
 }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -32,6 +32,7 @@ package nom.tam.fits;
  */
 
 import static nom.tam.fits.header.Standard.BITPIX;
+import static nom.tam.fits.header.Standard.BLOCKED;
 import static nom.tam.fits.header.Standard.END;
 import static nom.tam.fits.header.Standard.EXTEND;
 import static nom.tam.fits.header.Standard.NAXIS;
@@ -719,10 +720,10 @@ public class HeaderTest {
             assertEquals(hdr.getBooleanValue(CTYPE1.name()), false);
             assertEquals(hdr.getBooleanValue(CTYPE1), false);
 
-            hdu.addValue(CTYPE1.name(), 5, "bla");
-            assertEquals(hdr.getIntValue(CTYPE1.name()), 5);
-            assertEquals(hdr.getIntValue(CTYPE1), 5);
-            assertEquals(hdr.getIntValue(CTYPE1, -1), 5);
+            hdu.addValue(NAXISn.n(1).key(), 5, "bla");
+            assertEquals(hdr.getIntValue(NAXISn.n(1).key()), 5);
+            assertEquals(hdr.getIntValue(NAXISn.n(1)), 5);
+            assertEquals(hdr.getIntValue(NAXISn.n(1), -1), 5);
             assertEquals(hdr.getIntValue("ZZZ", -1), -1);
 
             hdu.addValue(CTYPE1.name(), "XX", "bla");
@@ -732,45 +733,45 @@ public class HeaderTest {
             assertEquals(hdr.getStringValue(CTYPE1, "yy"), "XX");
             assertEquals(hdr.getStringValue("ZZZ", "yy"), "yy");
        
-            hdr.addValue(CTYPE2, true);
-            assertEquals(hdr.getBooleanValue(CTYPE2.name()), true);
-            assertEquals(hdr.getBooleanValue(CTYPE2), true);
+            hdr.addValue(BLOCKED, true);
+            assertEquals(hdr.getBooleanValue(BLOCKED.name()), true);
+            assertEquals(hdr.getBooleanValue(BLOCKED), true);
             assertEquals(hdr.getBooleanValue("ZZZ", true), true);
 
-            hdr.addValue(CTYPE2, 5.0);
-            assertEquals(hdr.getDoubleValue(CTYPE2.name()), 5.0, 0.000001);
-            assertEquals(hdr.getDoubleValue(CTYPE2), 5.0, 0.000001);
+            hdr.addValue(CRVAL2, 5.0);
+            assertEquals(hdr.getDoubleValue(CRVAL2.name()), 5.0, 0.000001);
+            assertEquals(hdr.getDoubleValue(CRVAL2), 5.0, 0.000001);
             assertEquals(hdr.getDoubleValue("ZZZ", -1.0), -1.0, 0.000001);
 
-            hdr.addValue(CTYPE2.key(), 5.0, 6, "precision control.");
-            assertEquals(hdr.getDoubleValue(CTYPE2.name()), 5.0, 0.000001);
-            assertEquals(hdr.getDoubleValue(CTYPE2), 5.0, 0.000001);
+            hdr.addValue(CRVAL2.key(), 5.0, 6, "precision control.");
+            assertEquals(hdr.getDoubleValue(CRVAL2.name()), 5.0, 0.000001);
+            assertEquals(hdr.getDoubleValue(CRVAL2), 5.0, 0.000001);
             assertEquals(hdr.getDoubleValue("ZZZ", -1.0), -1.0, 0.000001);
 
-            hdr.addValue(CTYPE2.name(), BigDecimal.valueOf(5.0), "nothing special");
-            assertEquals(hdr.getDoubleValue(CTYPE2.name()), 5.0, 0.000001);
-            assertEquals(hdr.getDoubleValue(CTYPE2, -1d), 5.0, 0.000001);
-            assertEquals(hdr.getDoubleValue(CTYPE2), 5.0, 0.000001);
-            assertEquals(hdr.getBigDecimalValue(CTYPE2.name()), BigDecimal.valueOf(5.0));
-            assertEquals(hdr.getBigDecimalValue(CTYPE2), BigDecimal.valueOf(5.0));
-            assertEquals(hdr.getBigDecimalValue(CTYPE2, BigDecimal.ZERO), BigDecimal.valueOf(5.0));
+            hdr.addValue(CRVAL2.name(), BigDecimal.valueOf(5.0), "nothing special");
+            assertEquals(hdr.getDoubleValue(CRVAL2.name()), 5.0, 0.000001);
+            assertEquals(hdr.getDoubleValue(CRVAL2, -1d), 5.0, 0.000001);
+            assertEquals(hdr.getDoubleValue(CRVAL2), 5.0, 0.000001);
+            assertEquals(hdr.getBigDecimalValue(CRVAL2.name()), BigDecimal.valueOf(5.0));
+            assertEquals(hdr.getBigDecimalValue(CRVAL2), BigDecimal.valueOf(5.0));
+            assertEquals(hdr.getBigDecimalValue(CRVAL2, BigDecimal.ZERO), BigDecimal.valueOf(5.0));
             assertEquals(hdr.getBigDecimalValue("ZZZ", BigDecimal.valueOf(-1.0)), BigDecimal.valueOf(-1.0));
 
-            hdr.addValue(CTYPE2.name(), 5.0f, "nothing special");
-            assertEquals(hdr.getFloatValue(CTYPE2.name()), 5.0f, 0.000001);
-            assertEquals(hdr.getFloatValue(CTYPE2), 5.0f, 0.000001);
-            assertEquals(hdr.getFloatValue(CTYPE2.name(), -1f), 5.0f, 0.000001);
-            assertEquals(hdr.getFloatValue(CTYPE2, -1f), 5.0f, 0.000001);
+            hdr.addValue(CRVAL2.name(), 5.0f, "nothing special");
+            assertEquals(hdr.getFloatValue(CRVAL2.name()), 5.0f, 0.000001);
+            assertEquals(hdr.getFloatValue(CRVAL2), 5.0f, 0.000001);
+            assertEquals(hdr.getFloatValue(CRVAL2.name(), -1f), 5.0f, 0.000001);
+            assertEquals(hdr.getFloatValue(CRVAL2, -1f), 5.0f, 0.000001);
             assertEquals(hdr.getFloatValue("ZZZ", -1f), -1f, 0.000001);
 
-            hdr.addValue(CTYPE2.name(), BigInteger.valueOf(5), "nothing special");
-            assertEquals(hdr.getIntValue(CTYPE2.name()), 5);
-            assertEquals(hdr.getIntValue(CTYPE2), 5);
+            hdr.addValue(NAXISn.n(2).key(), BigInteger.valueOf(5), "nothing special");
+            assertEquals(hdr.getIntValue(NAXISn.n(2).key()), 5);
+            assertEquals(hdr.getIntValue(NAXISn.n(2)), 5);
             assertEquals(hdr.getIntValue("ZZZ", 0), 0);
-            assertEquals(hdr.getBigIntegerValue(CTYPE2.name()), BigInteger.valueOf(5));
-            assertEquals(hdr.getBigIntegerValue(CTYPE2.name(), BigInteger.valueOf(-1)), BigInteger.valueOf(5));
-            assertEquals(hdr.getBigIntegerValue(CTYPE2), BigInteger.valueOf(5));
-            assertEquals(hdr.getBigIntegerValue(CTYPE2, BigInteger.valueOf(-1)), BigInteger.valueOf(5));
+            assertEquals(hdr.getBigIntegerValue(NAXISn.n(2).key()), BigInteger.valueOf(5));
+            assertEquals(hdr.getBigIntegerValue(NAXISn.n(2).key(), BigInteger.valueOf(-1)), BigInteger.valueOf(5));
+            assertEquals(hdr.getBigIntegerValue(NAXISn.n(2).key()), BigInteger.valueOf(5));
+            assertEquals(hdr.getBigIntegerValue(NAXISn.n(2).key(), BigInteger.valueOf(-1)), BigInteger.valueOf(5));
             assertEquals(hdr.getBigIntegerValue("ZZZ", BigInteger.valueOf(-1)), BigInteger.valueOf(-1));
         } finally {
             SafeClose.close(in);
@@ -1029,7 +1030,7 @@ public class HeaderTest {
         header.addValue(SIMPLE, true);
         header.addValue(BITPIX, 8);
         header.addValue(NAXIS, 0);
-        header.addValue(END, true);
+        header.insertCommentStyle(END.key(), null);
 
         header.write(dos);
     }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -82,6 +82,8 @@ import nom.tam.fits.HeaderCommentsMap;
 import nom.tam.fits.HeaderOrder;
 import nom.tam.fits.ImageHDU;
 import nom.tam.fits.TruncatedFileException;
+import nom.tam.fits.header.GenericKey;
+import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.Standard;
 import nom.tam.fits.header.hierarch.BlanksDotHierarchKeyFormatter;
 import nom.tam.util.ArrayDataOutput;
@@ -779,6 +781,18 @@ public class HeaderTest {
         }
     }
 
+    @Test 
+    public void addIFitsComplexTest() throws Exception {
+        Header h = new Header();
+        IFitsHeader key = GenericKey.create("TEST");
+        ComplexValue z0 = new ComplexValue(1.0, 2.0);
+        h.addValue(key, z0);
+        assertTrue(h.containsKey(key));
+        assertTrue(h.containsKey(key.key()));
+        ComplexValue z = h.getComplexValue(key.key());
+        assertEquals(z0, z);
+    }
+    
     @Test
     public void dumpHeaderTests() throws Exception {
         Fits f = null;
@@ -1539,5 +1553,21 @@ public class HeaderTest {
         h.validate(true);
         h.validate(false);
         checkXtension(h);
+    }
+    
+    @Test
+    public void updateCommentKey() throws Exception {
+        Header h = new Header();
+        h.insertComment("existing comment");
+        h.updateLine(Standard.COMMENT, HeaderCard.createCommentCard("new comment"));
+        assertEquals(2, h.getNumberOfCards());
+    }
+    
+    @Test
+    public void updateEmptyKey() throws Exception {
+        Header h = new Header();
+        h.insertCommentStyle("", "existing comment");
+        h.updateLine("", HeaderCard.createCommentCard("new comment"));
+        assertEquals(2, h.getNumberOfCards());
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1578,4 +1578,12 @@ public class HeaderTest {
         h.updateLine("TEST1", new HeaderCard("TEST2", 2, "comment"));
         assertEquals(1, h.getNumberOfCards());
     }
+    
+    @Test
+    public void invalidHeaderSizeTest() throws Exception {
+        Header h = new Header();
+        h.addValue("TEST", 1.0, "Some value");
+        assertFalse(h.isValidHeader());
+        assertEquals(0, h.headerSize());
+    }
 }

--- a/src/test/java/nom/tam/fits/KeyTypeTest.java
+++ b/src/test/java/nom/tam/fits/KeyTypeTest.java
@@ -1,0 +1,326 @@
+package nom.tam.fits;
+
+/*-
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2022 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import nom.tam.fits.header.IFitsHeader;
+import nom.tam.fits.header.Standard;
+import nom.tam.util.ComplexValue;
+
+public class KeyTypeTest {
+    
+    private class ComplexKey implements IFitsHeader {
+        String name;
+        
+        ComplexKey(String name) {
+            this.name = name;
+        }
+        
+        @Override
+        public String comment() {
+            return "some complex valued keyword";
+        }
+
+        @Override
+        public HDU hdu() {
+            return HDU.ANY;
+        }
+
+        @Override
+        public String key() {
+            return name;
+        }
+
+        @Override
+        public IFitsHeader n(int... number) {
+            return null;
+        }
+
+        @Override
+        public SOURCE status() {
+            return SOURCE.UNKNOWN;
+        }
+
+        @Override
+        public VALUE valueType() {
+            return VALUE.COMPLEX;
+        }   
+    }
+    
+    
+    class LogCounter extends Handler {
+        private int count = 0;
+        
+        @Override
+        public void close() throws SecurityException {}
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public synchronized void publish(LogRecord arg0) { 
+            count++; 
+            System.err.println("### MESSAGE: " + arg0.getMessage());
+        }
+        
+        public synchronized int getCount() { 
+            return count; 
+        }
+    };
+
+    private LogCounter initLogCounter(Class<?> c) {
+        Logger l = Logger.getLogger(c.getName());
+        l.setLevel(Level.WARNING);                      // Make sure we log warnings to Header
+        LogCounter counter = new LogCounter();
+        l.addHandler(counter);
+        return counter;
+    }
+    
+    
+    @Test
+    public void replaceCommentStyleKeyWarning() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.SIMPLE, true);
+        LogCounter counter = initLogCounter(Header.class);
+        int i = counter.getCount();
+        h.replaceKey(Standard.SIMPLE, Standard.COMMENT);
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void replaceBooleanKey() throws Exception {
+        Header h = new Header();
+        HeaderCard c = h.addValue(Standard.SIMPLE, true);
+        h.replaceKey(Standard.SIMPLE, Standard.EXTEND);
+        assertEquals(Standard.EXTEND.key(), c.getKey());
+    }
+    
+    @Test
+    public void replaceBooleanKeyWarning() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.SIMPLE, true);
+        LogCounter counter = initLogCounter(Header.class);
+        int i = counter.getCount();
+        h.replaceKey(Standard.SIMPLE, Standard.BUNIT);
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void replaceRealKey() throws Exception {
+        Header h = new Header();
+        HeaderCard c = h.addValue(Standard.BSCALE, 1.0);
+        h.replaceKey(Standard.BSCALE, Standard.BZERO);
+        assertEquals(Standard.BZERO.key(), c.getKey());
+    }
+    
+    @Test
+    public void replaceRealKeyWarning() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.BSCALE, 1.0);
+        LogCounter counter = initLogCounter(Header.class);
+        int i = counter.getCount();
+        h.replaceKey(Standard.BSCALE, Standard.NAXIS);
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void replaceIntKey() throws Exception {
+        Header h = new Header();
+        HeaderCard c = h.addValue(Standard.NAXIS, -1);
+        h.replaceKey(Standard.NAXIS, Standard.BITPIX);
+        assertEquals(Standard.BITPIX.key(), c.getKey());
+    }
+    
+    @Test
+    public void replaceIntKeyReal() throws Exception {
+        Header h = new Header();
+        HeaderCard c = h.addValue(Standard.NAXIS, -1);
+        h.replaceKey(Standard.NAXIS, Standard.BZERO);
+        assertEquals(Standard.BZERO.key(), c.getKey());
+    }
+    
+    @Test
+    public void replaceIntKeyComplex() throws Exception {
+        Header h = new Header();
+        HeaderCard c = h.addValue(Standard.NAXIS, -1);
+        ComplexKey k = new ComplexKey("CKEY");
+        h.replaceKey(Standard.NAXIS, k);
+        assertEquals(k.key(), c.getKey());
+    }
+    
+    @Test
+    public void replaceIntKeyWarning() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, -1);
+        LogCounter counter = initLogCounter(Header.class);
+        int i = counter.getCount();
+        h.replaceKey(Standard.NAXIS, Standard.BUNIT);
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void replaceComplexKey() throws Exception {
+        Header h = new Header();
+        ComplexKey k1 = new ComplexKey("CVAL1");
+        ComplexKey k2  = new ComplexKey("CVAL2");
+        HeaderCard c = h.addValue(k1, new ComplexValue(1.0, -1.0));
+        h.replaceKey(k1, k2);
+        assertEquals(k2.key(), c.getKey());
+    }
+    
+    @Test
+    public void replaceComplexKeyWarning() throws Exception {
+        Header h = new Header();
+        ComplexKey k = new ComplexKey("CVAL");
+        h.addValue(k, new ComplexValue(1.0, -1.0));
+        LogCounter counter = initLogCounter(Header.class);
+        int i = counter.getCount();
+        h.replaceKey(k, Standard.BZERO);
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void replaceStringKey() throws Exception {
+        Header h = new Header();
+        HeaderCard c = h.addValue(Standard.TELESCOP, "CSO");
+        h.replaceKey(Standard.TELESCOP, Standard.INSTRUME);
+        assertEquals(Standard.INSTRUME.key(), c.getKey());
+    }
+    
+    @Test
+    public void replaceStringKeyWarning() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TELESCOP, "CSO");
+        LogCounter counter = initLogCounter(Header.class);
+        int i = counter.getCount();
+        h.replaceKey(Standard.TELESCOP, Standard.BZERO);
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void createBooleanKey() throws Exception {
+        HeaderCard c = HeaderCard.create(Standard.SIMPLE, true);
+        assertEquals(Standard.SIMPLE.key(), c.getKey());
+        assertTrue(c.getValue(Boolean.class, false));
+    }
+    
+    @Test
+    public void createBooleanKeyWarning() throws Exception {
+        LogCounter counter = initLogCounter(HeaderCard.class);
+        int i = counter.getCount();
+        HeaderCard.create(Standard.SIMPLE, 1.0);
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void createIntKey() throws Exception {
+        HeaderCard c = HeaderCard.create(Standard.NAXIS, 1);
+        assertEquals(Standard.NAXIS.key(), c.getKey());
+        assertEquals(1, c.getValue(Integer.class, -1).intValue());
+    }
+    
+    @Test
+    public void createIntKeyWarning() throws Exception {
+        LogCounter counter = initLogCounter(HeaderCard.class);
+        int i = counter.getCount();
+        HeaderCard.create(Standard.NAXIS, 1.0);
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void createRealKey() throws Exception {
+        HeaderCard c = HeaderCard.create(Standard.BZERO, 1.0);
+        assertEquals(Standard.BZERO.key(), c.getKey());
+        assertEquals(1.0, c.getValue(Double.class, Double.NaN).intValue(), 1e-12);
+    }
+    
+    @Test
+    public void createRealKeyInt() throws Exception {
+        HeaderCard c = HeaderCard.create(Standard.BZERO, new Integer(1));
+        assertEquals(Standard.BZERO.key(), c.getKey());
+        assertEquals(1.0, c.getValue(Double.class, Double.NaN).intValue(), 1e-12);
+    }
+    
+    @Test
+    public void createRealKeyWarning() throws Exception {
+        LogCounter counter = initLogCounter(HeaderCard.class);
+        int i = counter.getCount();
+        HeaderCard.create(Standard.BZERO, "string");
+        assertNotEquals(i, counter.getCount());
+    }
+    
+    @Test
+    public void createComplexKey() throws Exception {
+        ComplexKey k = new ComplexKey("CVAL");
+        ComplexValue z = new ComplexValue(1.0, -1.0);
+        HeaderCard c = HeaderCard.create(k, z);
+        assertEquals(k.key(), c.getKey());
+        assertEquals(z, c.getValue(ComplexValue.class, null));
+    }
+    
+    @Test
+    public void createComplexKeyReal() throws Exception {
+        ComplexKey k = new ComplexKey("CVAL");
+        ComplexValue z = new ComplexValue(1.0, 0.0);
+        HeaderCard c = HeaderCard.create(k, 1.0);
+        assertEquals(k.key(), c.getKey());
+        assertEquals(z, c.getValue(ComplexValue.class, null));
+    }
+    
+    @Test
+    public void createComplexKeyInt() throws Exception {
+        ComplexKey k = new ComplexKey("CVAL");
+        ComplexValue z = new ComplexValue(1.0, 0.0);
+        HeaderCard c = HeaderCard.create(k, new Integer(1));
+        assertEquals(k.key(), c.getKey());
+        assertEquals(z, c.getValue(ComplexValue.class, null));
+    }
+    
+    @Test
+    public void createComplexKeyWarning() throws Exception {
+        LogCounter counter = initLogCounter(HeaderCard.class);
+        int i = counter.getCount();
+        HeaderCard.create(new ComplexKey("CVAL"), "string");
+        assertNotEquals(i, counter.getCount());
+    }
+    
+}

--- a/src/test/java/nom/tam/fits/KeyTypeTest.java
+++ b/src/test/java/nom/tam/fits/KeyTypeTest.java
@@ -107,6 +107,10 @@ public class KeyTypeTest {
         }
     };
 
+    class ComplexDerived extends ComplexValue {
+        public ComplexDerived(double re, double im) { super(re, im); }
+    }
+    
     private LogCounter initLogCounter(Class<?> c) {
         Logger l = Logger.getLogger(c.getName());
         l.setLevel(Level.WARNING);                      // Make sure we log warnings to Header
@@ -202,7 +206,7 @@ public class KeyTypeTest {
         Header h = new Header();
         ComplexKey k1 = new ComplexKey("CVAL1");
         ComplexKey k2  = new ComplexKey("CVAL2");
-        HeaderCard c = h.addValue(k1, new ComplexValue(1.0, -1.0));
+        HeaderCard c = h.addValue(k1, new ComplexDerived(1.0, -1.0));
         h.replaceKey(k1, k2);
         assertEquals(k2.key(), c.getKey());
     }
@@ -211,7 +215,7 @@ public class KeyTypeTest {
     public void replaceComplexKeyWarning() throws Exception {
         Header h = new Header();
         ComplexKey k = new ComplexKey("CVAL");
-        h.addValue(k, new ComplexValue(1.0, -1.0));
+        h.addValue(k, new ComplexDerived(1.0, -1.0));
         LogCounter counter = initLogCounter(Header.class);
         int i = counter.getCount();
         h.replaceKey(k, Standard.BZERO);

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -76,6 +76,7 @@ import nom.tam.fits.header.Standard;
 import nom.tam.fits.utilities.FitsCheckSum;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayFuncs;
+import nom.tam.util.ByteBufferOutputStream;
 import nom.tam.util.FitsInputStream;
 import nom.tam.util.FitsOutputStream;
 import nom.tam.util.FitsFile;
@@ -1169,7 +1170,7 @@ public class BaseFitsTest {
         byte[] b = new byte[80];
         Exception ex = null;
         
-        FileInputStream in = new FileInputStream( new File("src/test/resources/nom/tam/fits/test/test.fits.gz"));
+        FileInputStream in = new FileInputStream(new File("src/test/resources/nom/tam/fits/test/test.fits.gz"));
         
         assertEquals(b.length, in.read(b));
         
@@ -1225,6 +1226,39 @@ public class BaseFitsTest {
         };
         new Fits().write((DataOutput) o);
         o.close();
+    }
+    
+    @Test
+    public void nAxisNullTest() throws Exception {
+        Header h = new Header();
+        h.setNaxes(0);
+        BasicHDU<?> hdu = new ImageHDU(h, null);
+        assertNull(hdu.getAxes());
+    }
+    
+    @Test
+    public void writeEmptyHDUTest() throws Exception {
+        byte[] preamble = new byte[100];
+        File f = new File(TMP_FITS_NAME);
+        FitsOutputStream o = new FitsOutputStream(new FileOutputStream(f));
+        BasicHDU<?> hdu = new ImageHDU(null, null);
+        hdu.write(o);
+        o.flush();
+        assertEquals(hdu.getHeader().getSize(), f.length());
+    }
+    
+    @Test
+    public void emptyHDUTest() throws Exception {
+        BasicHDU<?> hdu = new ImageHDU(null, null);
+        assertEquals(0, hdu.getSize());
+    }
+    
+    @Test
+    public void trimmedCommentStringTest() throws Exception {
+        Header h = new Header();
+        h.insertComment("comment");
+        BasicHDU<?> hdu = new ImageHDU(h, null);
+        assertNull(hdu.getTrimmedString(Standard.COMMENT));
     }
     
 }

--- a/src/test/java/nom/tam/fits/test/DupTest.java
+++ b/src/test/java/nom/tam/fits/test/DupTest.java
@@ -68,15 +68,13 @@ public class DupTest {
         public void flush() {}
 
         @Override
-        public void publish(LogRecord arg0) { 
+        public synchronized void publish(LogRecord arg0) { 
             count++; 
             System.err.println("### MESSAGE: " + arg0.getMessage());
         }
         
-        public int getCount() { 
-            
+        public synchronized int getCount() { 
             return count; 
-            
         }
     };
     

--- a/src/test/java/nom/tam/fits/test/JunkTest.java
+++ b/src/test/java/nom/tam/fits/test/JunkTest.java
@@ -118,6 +118,7 @@ public class JunkTest {
             SafeClose.close(f);
         }
     
+        FitsFactory.setDefaults();
         assertTrue("allow junk", FitsFactory.getAllowTerminalJunk());
 
         FitsFactory.setAllowTerminalJunk(true);


### PR DESCRIPTION
- Move implementation from `BasicHDU.setPrimary(boolean)` to new public `Header.validate(boolean)`, and deal with all required keywords, as well as order and END.
- Change `Header.addValue(IFitsHeader...)` to call `HeaderCard.create(IFitsHeader...)` with the checks they provide.
- Change `Header.create(IFitsHeader...)` to allow non-matching but compatible value types.
- Rewrite `HeaderOrder` to make it more algorithmic, and less case-by-case.
- Added a bunch of new tests as necessary 