### PR TITLE
Report dupes consistently via header parser's logger.

### DIFF
--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -2035,7 +2035,7 @@ public class Header implements FitsElement {
             return;
         }
 
-        getParserLogger().log(Level.WARNING, "Multiple occurrences of key:" + dup.getKey());
+        HeaderCardParser.getLogger().log(Level.WARNING, "Multiple occurrences of key:" + dup.getKey());
         
         if (this.duplicates == null) {
             this.duplicates = new ArrayList<>();
@@ -2370,7 +2370,7 @@ public class Header implements FitsElement {
      */
     public static void setParserWarningsEnabled(boolean value) {
         Level level = value ? Level.WARNING : Level.SEVERE;
-        getParserLogger().setLevel(level);
+        HeaderCardParser.getLogger().setLevel(level);
         Logger.getLogger(ComplexValue.class.getName()).setLevel(level);
     }
     
@@ -2386,22 +2386,7 @@ public class Header implements FitsElement {
      * @since 1.16
      */
     public static boolean isParserWarningsEnabled() {        
-        return !getParserLogger().getLevel().equals(Level.SEVERE);
-    }
-    
-    /**
-     * Returns the logger for the header parser. This logger logs specifically FITS standard
-     * violations during parsing of (3rd party) headers. It is managed independently of the 
-     * verbosity of the Header's own logging.
-     * 
-     * @return      The logger instance used for reporting FITS standard violations when parsing
-     *              headers.
-     *              
-     * @see #setParserWarningsEnabled(boolean)
-     * @see #isParserWarningsEnabled()
-     */
-    private static Logger getParserLogger() {
-        return Logger.getLogger(HeaderCardParser.class.getName());
+        return !HeaderCardParser.getLogger().getLevel().equals(Level.SEVERE);
     }
     
     /**

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -2363,6 +2363,8 @@ public class Header implements FitsElement {
      * @param value     <code>true</code> if parser warnings about FITS standard violations when reading in
      *                  existing FITS headers are to be logged, otherwise <code>false</code>
      * 
+     * @see #isParserWarningsEnabled()
+     * @see #getParserLogger()
      * @see FitsFactory#setAllowHeaderRepairs(boolean)
      * 
      * @since 1.16
@@ -2381,6 +2383,7 @@ public class Header implements FitsElement {
      *              existing FITS headers are enabled and logged, otherwise <code>false</code>
      *              
      * @see #setParserWarningsEnabled(boolean)
+     * @see #getParserLogger()
      * 
      * @since 1.16
      */
@@ -2395,6 +2398,9 @@ public class Header implements FitsElement {
      * 
      * @return      The logger instance used for reporting FITS standard violations when parsing
      *              headers.
+     *              
+     * @see #setParserWarningsEnabled(boolean)
+     * @see #isParserWarningsEnabled()
      */
     public static Logger getParserLogger() {
         return Logger.getLogger(HeaderCardParser.class.getName());

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -2364,7 +2364,6 @@ public class Header implements FitsElement {
      *                  existing FITS headers are to be logged, otherwise <code>false</code>
      * 
      * @see #isParserWarningsEnabled()
-     * @see #getParserLogger()
      * @see FitsFactory#setAllowHeaderRepairs(boolean)
      * 
      * @since 1.16
@@ -2383,7 +2382,6 @@ public class Header implements FitsElement {
      *              existing FITS headers are enabled and logged, otherwise <code>false</code>
      *              
      * @see #setParserWarningsEnabled(boolean)
-     * @see #getParserLogger()
      * 
      * @since 1.16
      */
@@ -2402,7 +2400,7 @@ public class Header implements FitsElement {
      * @see #setParserWarningsEnabled(boolean)
      * @see #isParserWarningsEnabled()
      */
-    public static Logger getParserLogger() {
+    private static Logger getParserLogger() {
         return Logger.getLogger(HeaderCardParser.class.getName());
     }
     

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -71,7 +71,6 @@ import nom.tam.util.ComplexValue;
 import nom.tam.util.Cursor;
 import nom.tam.util.FitsIO;
 import nom.tam.util.HashedList;
-import nom.tam.util.LoggerHelper;
 import nom.tam.util.RandomAccess;
 
 /**
@@ -2035,9 +2034,9 @@ public class Header implements FitsElement {
         if (dup.isCommentStyleCard() || CONTINUE.key().equals(dup.getKey())) {
             return;
         }
-        if (isParserWarningsEnabled()) {
-            LOG.log(Level.WARNING, "Multiple occurrences of key:" + dup.getKey());
-        }
+
+        getParserLogger().log(Level.WARNING, "Multiple occurrences of key:" + dup.getKey());
+        
         if (this.duplicates == null) {
             this.duplicates = new ArrayList<>();
         }
@@ -2370,8 +2369,8 @@ public class Header implements FitsElement {
      */
     public static void setParserWarningsEnabled(boolean value) {
         Level level = value ? Level.WARNING : Level.SEVERE;
-        LoggerHelper.getLogger(HeaderCardParser.class).setLevel(level);
-        LoggerHelper.getLogger(ComplexValue.class).setLevel(level);
+        getParserLogger().setLevel(level);
+        Logger.getLogger(ComplexValue.class.getName()).setLevel(level);
     }
     
     /**
@@ -2385,8 +2384,20 @@ public class Header implements FitsElement {
      * 
      * @since 1.16
      */
-    public static boolean isParserWarningsEnabled() {
-        return !Logger.getLogger(HeaderCardParser.class.getName()).getLevel().equals(Level.SEVERE);
+    public static boolean isParserWarningsEnabled() {        
+        return !getParserLogger().getLevel().equals(Level.SEVERE);
+    }
+    
+    /**
+     * Returns the logger for the header parser. This logger logs specifically FITS standard
+     * violations during parsing of (3rd party) headers. It is managed independently of the 
+     * verbosity of the Header's own logging.
+     * 
+     * @return      The logger instance used for reporting FITS standard violations when parsing
+     *              headers.
+     */
+    public static Logger getParserLogger() {
+        return Logger.getLogger(HeaderCardParser.class.getName());
     }
     
     /**

--- a/src/main/java/nom/tam/fits/HeaderCardParser.java
+++ b/src/main/java/nom/tam/fits/HeaderCardParser.java
@@ -66,7 +66,7 @@ import nom.tam.util.FlexFormat;
  */
 class HeaderCardParser {
 
-    private static final Logger LOG = Header.getParserLogger();
+    private static final Logger LOG = Logger.getLogger(HeaderCardParser.class.getName());
     
     static {
         // Do not log warnings by default.
@@ -644,6 +644,9 @@ class HeaderCardParser {
         return HeaderCard.sanitize(text);
     }
     
+    static Logger getLogger() {
+        return LOG;
+    }
     
     
 }

--- a/src/main/java/nom/tam/fits/HeaderCardParser.java
+++ b/src/main/java/nom/tam/fits/HeaderCardParser.java
@@ -66,7 +66,7 @@ import nom.tam.util.FlexFormat;
  */
 class HeaderCardParser {
 
-    private static final Logger LOG = Logger.getLogger(HeaderCardParser.class.getName());
+    private static final Logger LOG = Header.getParserLogger();
     
     static {
         // Do not log warnings by default.

--- a/src/test/java/nom/tam/fits/test/DupTest.java
+++ b/src/test/java/nom/tam/fits/test/DupTest.java
@@ -112,7 +112,7 @@ public class DupTest {
     
     @Test
     public void dupesWarningsOn() throws Exception {
-        Logger l = Logger.getLogger("nom.tam.fits.HeaderCardParser");
+        Logger l = Header.getParserLogger();
         l.setLevel(Level.WARNING);                      // Make sure we log warnings to Header
         
         LogCounter counter = new LogCounter();
@@ -132,7 +132,7 @@ public class DupTest {
     
     @Test
     public void dupesWarningsOff() throws Exception {
-        Logger l = Logger.getLogger("nom.tam.fits.HeaderCardParser");
+        Logger l = Header.getParserLogger();
         l.setLevel(Level.WARNING);                      // Make sure we log warnings to Header
         LogCounter counter = new LogCounter();
         l.addHandler(counter);

--- a/src/test/java/nom/tam/fits/test/DupTest.java
+++ b/src/test/java/nom/tam/fits/test/DupTest.java
@@ -79,10 +79,6 @@ public class DupTest {
         }
     };
     
-    public Logger getParserLogger() {
-        return Logger.getLogger("nom.tam.fits.HeaderCardParser");
-    }
-    
     @Test
     public void test() throws Exception {
 
@@ -112,6 +108,10 @@ public class DupTest {
         assertTrue("Now rewriteable", hdr.rewriteable());
         assertFalse("No duplicates", hdr.hadDuplicates());
         assertTrue("Dups is null", hdr.getDuplicates() == null);
+    }
+    
+    private Logger getParserLogger() {
+        return Logger.getLogger("nom.tam.fits.HeaderCardParser");
     }
     
     @Test

--- a/src/test/java/nom/tam/fits/test/DupTest.java
+++ b/src/test/java/nom/tam/fits/test/DupTest.java
@@ -79,6 +79,10 @@ public class DupTest {
         }
     };
     
+    public Logger getParserLogger() {
+        return Logger.getLogger("nom.tam.fits.HeaderCardParser");
+    }
+    
     @Test
     public void test() throws Exception {
 
@@ -112,7 +116,7 @@ public class DupTest {
     
     @Test
     public void dupesWarningsOn() throws Exception {
-        Logger l = Header.getParserLogger();
+        Logger l = getParserLogger();
         l.setLevel(Level.WARNING);                      // Make sure we log warnings to Header
         
         LogCounter counter = new LogCounter();
@@ -132,7 +136,7 @@ public class DupTest {
     
     @Test
     public void dupesWarningsOff() throws Exception {
-        Logger l = Header.getParserLogger();
+        Logger l = getParserLogger();
         l.setLevel(Level.WARNING);                      // Make sure we log warnings to Header
         LogCounter counter = new LogCounter();
         l.addHandler(counter);

--- a/src/test/java/nom/tam/fits/test/DupTest.java
+++ b/src/test/java/nom/tam/fits/test/DupTest.java
@@ -68,13 +68,12 @@ public class DupTest {
         public void flush() {}
 
         @Override
-        public void publish(LogRecord arg0) { 
+        public synchronized void publish(LogRecord arg0) { 
             count++; 
             System.err.println("### MESSAGE: " + arg0.getMessage());
         }
         
-        public int getCount() { 
-            
+        public synchronized int getCount() { 
             return count; 
             
         }

--- a/src/test/java/nom/tam/fits/test/DupTest.java
+++ b/src/test/java/nom/tam/fits/test/DupTest.java
@@ -112,7 +112,7 @@ public class DupTest {
     
     @Test
     public void dupesWarningsOn() throws Exception {
-        Logger l = Logger.getLogger(Header.class.getName());
+        Logger l = Logger.getLogger("nom.tam.fits.HeaderCardParser");
         l.setLevel(Level.WARNING);                      // Make sure we log warnings to Header
         
         LogCounter counter = new LogCounter();
@@ -132,7 +132,7 @@ public class DupTest {
     
     @Test
     public void dupesWarningsOff() throws Exception {
-        Logger l = Logger.getLogger(Header.class.getName());
+        Logger l = Logger.getLogger("nom.tam.fits.HeaderCardParser");
         l.setLevel(Level.WARNING);                      // Make sure we log warnings to Header
         LogCounter counter = new LogCounter();
         l.addHandler(counter);

--- a/src/test/java/nom/tam/fits/test/JunkTest.java
+++ b/src/test/java/nom/tam/fits/test/JunkTest.java
@@ -32,8 +32,13 @@ package nom.tam.fits.test;
  */
 
 import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+
 import nom.tam.fits.Fits;
 import nom.tam.fits.FitsFactory;
+import nom.tam.fits.Header;
 import nom.tam.util.FitsFile;
 import nom.tam.util.SafeClose;
 
@@ -46,6 +51,17 @@ import org.junit.Test;
  * succeed after FitsFactory.setAllowTerminalJunk(true).
  */
 public class JunkTest {
+    
+    @Before
+    public void before() {
+        FitsFactory.setDefaults();
+    }
+
+    @After
+    public void after() {
+        FitsFactory.setDefaults();
+        Header.setCommentAlignPosition(Header.DEFAULT_COMMENT_ALIGN);
+    }
 
     boolean readSuccess(String file) {
         Fits f = null;


### PR DESCRIPTION
Dupes found when parsing (3rd party) headers,  used to be reported to `Header`'s `Logger`, but should be parsing specific, and thus be reported through `HeaderCardParser`'s separate logger instead to allow for distinct verbosity control through `Header.setParserWarningsEnabled()`.