### PR TITLE
Tile compression of non-square images

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -1,10 +1,13 @@
 <document xmlns="http://maven.apache.org/changes/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/xsd/changes-1.0.0.xsd">
 	<body>
 
-    <release version="1.17.0-rc1" date="2022-08-18" description="Minor feature release.">
+    <release version="1.17.0-rc2" date="2022-08-18" description="Minor feature release.">
+      <action type="fix" dev="attipaci" issue="318">
+	      Fix broken tile compression of non-square images. 
+      </action>
     	<action type="add" dev="attipaci" issue="283">
 	      User adjustable header comment alignment position via Header.setCommentAlignPosition(int). 
-			</action>
+      </action>
     	<action type="add" dev="attipaci" issue="145">
 				New Fits.getHDU() methods to select HDU from Fits by name (and version).
 			</action>

--- a/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
@@ -94,25 +94,14 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
      */
     public void setTileAxes(int[] value) throws FitsException {
         this.tileAxes = Arrays.copyOf(value, value.length);
-        for (int index = 0; index < tileAxes.length; index++) {
-            if (tileAxes[index] <= 0) {
-                tileAxes[index] = axes[index];
-            }
-        }
     }
 
     protected boolean hasAxes() {
-        if (axes == null) {
-            return false;
-        }
-        return axes.length > 0;
+        return axes != null;
     }
 
     protected boolean hasTileAxes() {
-        if (tileAxes == null) {
-            return false;
-        }
-        return tileAxes.length > 0;
+        return tileAxes != null;
     }
 
     protected void createTiles(ITileOperationInitialisation<OPERATION> init) throws FitsException {

--- a/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
@@ -32,8 +32,6 @@ package nom.tam.image.tile.operation;
  */
 
 import java.lang.reflect.Array;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.nio.Buffer;
 import java.util.Arrays;
 
@@ -49,12 +47,13 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
      */
     private ElementType<Buffer> baseType;
 
+    /** Tile dimensions in Java array index order (x is last!) */
     private int[] tileAxes;
 
     private OPERATION[] tileOperations;
 
     private final Class<OPERATION> operationClass;
-
+    
     public AbstractTiledImageOperation(Class<OPERATION> operationClass) {
         this.operationClass = operationClass;
     }
@@ -66,7 +65,7 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
 
     public int getBufferSize() {
         int bufferSize = 1;
-        for (int axisValue : this.axes) {
+        for (int axisValue : axes) {
             bufferSize *= axisValue;
         }
         return bufferSize;
@@ -74,7 +73,7 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
 
     @Override
     public int getImageWidth() {
-        return this.axes[0];
+        return axes[axes.length - 1];
     }
 
     @Override
@@ -86,47 +85,59 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
         this.axes = Arrays.copyOf(axes, axes.length);
     }
 
+    /**
+     * Sets the tile dimension. Here the dimensions are in Java array index order, that is the
+     * x-dimension (width of tile) is last!
+     * 
+     * @param value     The tile dimensions in Java array index order (x is last!)
+     * @throws FitsException
+     */
     public void setTileAxes(int[] value) throws FitsException {
         this.tileAxes = Arrays.copyOf(value, value.length);
-        for (int index = 0; index < this.tileAxes.length; index++) {
-            if (this.tileAxes[index] <= 0) {
-                this.tileAxes[index] = this.axes[index];
+        for (int index = 0; index < tileAxes.length; index++) {
+            if (tileAxes[index] <= 0) {
+                tileAxes[index] = axes[index];
             }
         }
     }
 
-    protected boolean areAxesUndefined() {
-        return this.axes == null || this.axes.length == 0;
+    protected boolean hasAxes() {
+        if (axes == null) {
+            return false;
+        }
+        return axes.length > 0;
     }
 
-    protected boolean areTileAxesUndefined() {
-        return this.tileAxes == null || this.tileAxes.length == 0;
+    protected boolean hasTileAxes() {
+        if (tileAxes == null) {
+            return false;
+        }
+        return tileAxes.length > 0;
     }
 
     protected void createTiles(ITileOperationInitialisation<OPERATION> init) throws FitsException {
-        final int imageWidth = this.axes[0];
-        final int imageHeight = this.axes[1];
-        final int tileWidth = this.tileAxes[0];
-        final int tileHeight = this.tileAxes[1];
-        final int nrOfTilesOnXAxis = BigDecimal.valueOf((double) imageWidth / (double) tileWidth).setScale(0, RoundingMode.CEILING).intValue();
-        final int nrOfTilesOnYAxis = BigDecimal.valueOf((double) imageHeight / (double) tileHeight).setScale(0, RoundingMode.CEILING).intValue();
-        int lastTileWidth = imageWidth - (nrOfTilesOnXAxis - 1) * tileWidth;
-        int lastTileHeight = imageHeight - (nrOfTilesOnYAxis - 1) * tileHeight;
+        final int imageWidth = this.axes[1];
+        final int imageHeight = this.axes[0];
+        final int tileWidth = this.tileAxes[1];
+        final int tileHeight = this.tileAxes[0];
+        final int nx = (imageWidth + tileWidth - 1) / tileWidth;
+        final int ny = (imageHeight + tileHeight - 1) / tileHeight;
+  
         int tileIndex = 0;
         @SuppressWarnings("unchecked")
-        OPERATION[] operations = (OPERATION[]) Array.newInstance(this.operationClass, nrOfTilesOnXAxis * nrOfTilesOnYAxis);
+        OPERATION[] operations = (OPERATION[]) Array.newInstance(this.operationClass, ny * nx);
         this.tileOperations = operations;
         init.tileCount(this.tileOperations.length);
+
         for (int y = 0; y < imageHeight; y += tileHeight) {
-            boolean lastY = y + tileHeight >= imageHeight;
-            for (int x = 0; x < imageWidth; x += tileWidth) {
-                boolean lastX = x + tileWidth >= imageWidth;
+            int h = Math.min(tileHeight, imageHeight - y);
+            for (int x = 0; x < imageWidth; x += tileWidth, tileIndex++) {
+                int w = Math.min(tileWidth, imageWidth - x);
                 int dataOffset = y * imageWidth + x;
                 OPERATION tileOperation = init.createTileOperation(tileIndex, new TileArea().start(x, y));
-                tileOperation.setDimensions(dataOffset, lastX ? lastTileWidth : tileWidth, lastY ? lastTileHeight : tileHeight);
+                tileOperation.setDimensions(dataOffset, w, h);
                 this.tileOperations[tileIndex] = tileOperation;
                 init.init(tileOperation);
-                tileIndex++;
             }
         }
     }
@@ -139,6 +150,12 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
         return this.tileOperations.length;
     }
 
+    /**
+     * Returns the reference to the tile dimensions array. The dimensions are stored in Java array
+     * index order, i.e., the x-dimension (width) is last. 
+     * 
+     * @return      The tile dimensions in Java array index order (x is last!).
+     */
     protected int[] getTileAxes() {
         return this.tileAxes;
     }

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressionTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressionTest.java
@@ -1,0 +1,85 @@
+package nom.tam.image.compression.tile;
+
+/*-
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2022 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import nom.tam.fits.Fits;
+import nom.tam.fits.FitsFactory;
+import nom.tam.fits.ImageHDU;
+import nom.tam.fits.header.Compression;
+import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
+import nom.tam.image.compression.hdu.CompressedImageHDU;
+
+
+public class TileCompressionTest {
+
+    public int[][] getRectangularImage(int nx, int ny) {
+        int[][] im = new int[ny][nx];
+
+        for (int y = 0; y < im.length; y++) for (int x = 0; x < im[y].length; x++) {
+            im[y][x] = x + y;
+        }
+
+        return im;
+    }
+    
+    @Test
+    public void rectangularRiceCompressTest() throws Exception {
+        int[][] im = getRectangularImage(32, 80);
+        String fileName = "target/rect_comp.fits.fz";
+
+        ImageHDU hdu = (ImageHDU) FitsFactory.hduFactory(im);
+        CompressedImageHDU cHDU = CompressedImageHDU.fromImageHDU(hdu, -1, 1);
+
+        cHDU.setCompressAlgorithm(Compression.ZCMPTYPE_RICE_1)
+        .setQuantAlgorithm(null)
+        .getCompressOption(RiceCompressOption.class)
+        .setBlockSize(32);
+
+        cHDU.compress();
+
+        Fits f = new Fits();
+        f.addHDU(cHDU);
+        f.write(fileName);
+
+        f = new Fits(fileName);
+        cHDU = (CompressedImageHDU) f.read()[1];
+
+        hdu = cHDU.asImageHDU();
+        int[][] im2 = (int[][]) hdu.getKernel();
+        
+        Assert.assertArrayEquals(im, im2);
+    }
+
+}

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
@@ -395,7 +395,7 @@ public class TileCompressorProviderTest {
         }
     }
 
-    private void testTileSizes(int tileWidth, int tileHeigth) throws HeaderCardException, FitsException {
+    private void testTileSizes(int tileWidth, int tileHeight) throws HeaderCardException, FitsException {
         int imageSize = 100;
         TiledImageCompressionOperation operationsOfImage = new TiledImageCompressionOperation(null);
         Buffer buffer = IntBuffer.allocate(imageSize * imageSize);
@@ -405,7 +405,7 @@ public class TileCompressorProviderTest {
         header.addValue(ZNAXISn.n(1), imageSize);
         header.addValue(ZNAXISn.n(2), imageSize);
         header.addValue(ZTILEn.n(1), tileWidth);
-        header.addValue(ZTILEn.n(2), tileHeigth);
+        header.addValue(ZTILEn.n(2), tileHeight);
 
         operationsOfImage.readPrimaryHeaders(header);
         operationsOfImage.prepareUncompressedData(buffer);
@@ -416,7 +416,7 @@ public class TileCompressorProviderTest {
         for (TileCompressionOperation tileOperation : tiles) {
             if (tileWidth == imageSize) {
                 heigth += Access.getTileBuffer(tileOperation).getHeight();
-            } else if (tileHeigth == imageSize) {
+            } else if (tileHeight == imageSize) {
                 width += Access.getTileBuffer(tileOperation).getWidth();
             }
             pixels += Access.getTileBuffer(tileOperation).getHeight() * Access.getTileBuffer(tileOperation).getWidth();


### PR DESCRIPTION
Tile compression of non-square images never worked (see #129, #268). This was due to inverted tile size index ordering vs the the internal ordering used by `getAxes()`. The FITS conventiion uses Fortran style index order (with x being first), whereas java arrays have an inverted order (with x being last). The `getAxes()` method has always conformed to Java order (x being last), whereas tile sizes were in FITS order (x being first).

To reconcile, tile sizes are now stored in Java array indexing order internally s.t. the tile sizes coinform to the order returned by `getAxes()`.