### PR TITLE
Deprecate unsafe / unneeded classes and methods

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "90...100"
+  range: "80...100"
   status:
     patch: off
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>gov.nasa.gsfc.heasarc</groupId>
 	<artifactId>nom-tam-fits</artifactId>
-	<version>1.17.0-SNAPSHOT</version>
+	<version>1.17.0-rc4</version>
 	<packaging>jar</packaging>
 	<name>nom.tam FITS library</name>
 	<description>Java library for reading and writing FITS files. FITS, the Flexible Image Transport System, is the format commonly used in the archiving and transport of astronomical data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -554,7 +554,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.18.0</version>
+				<version>3.19.0</version>
 				<configuration>
 					<linkXref>true</linkXref>
 					<sourceEncoding>UTF-8</sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>gov.nasa.gsfc.heasarc</groupId>
 	<artifactId>nom-tam-fits</artifactId>
-	<version>1.17.0-SNAPSHOT</version>
+	<version>1.17.0</version>
 	<packaging>jar</packaging>
 	<name>nom.tam FITS library</name>
 	<description>Java library for reading and writing FITS files. FITS, the Flexible Image Transport System, is the format commonly used in the archiving and transport of astronomical data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>gov.nasa.gsfc.heasarc</groupId>
 	<artifactId>nom-tam-fits</artifactId>
-	<version>1.17.0-rc4</version>
+	<version>1.17.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>nom.tam FITS library</name>
 	<description>Java library for reading and writing FITS files. FITS, the Flexible Image Transport System, is the format commonly used in the archiving and transport of astronomical data.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>gov.nasa.gsfc.heasarc</groupId>
 	<artifactId>nom-tam-fits</artifactId>
-	<version>1.17.0</version>
+	<version>1.17.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>nom.tam FITS library</name>
 	<description>Java library for reading and writing FITS files. FITS, the Flexible Image Transport System, is the format commonly used in the archiving and transport of astronomical data.</description>

--- a/release-HOWTO.md
+++ b/release-HOWTO.md
@@ -42,7 +42,7 @@ Once you are confident that everything is in perfect order for the next release,
  * Sleep on it. So far so good, but this is also you last chance to fix anything before the package really goes public, so don't rush it. Take some time to reflect on it, double or triple-check everything, before moving to the next step...
 
  * On Github, click on _Releases_, and create a new release:
-   - Name and tag the release with `nom-tam-fits-` followed by the version, such as `nom-tam-fits-1.17.0-rc1`.
+   - Name and tag the release with by the version, such as `1.17.0-rc1` (Note, before 1.17.0 the tag included a 'nom-tam-fits-' prefix as well, which resulted in source tarballs named as nom-tam-fits-nom-tam-fits-<version> -- therefore starting with 1.17.0 we'll omit that).
    - Link the release to the last master commit of the repo.
    - If it is not a final release, be sure to check the box for _pre-release_ near the bottom (when checked the CI will not publish a Github package for this release).
    - Write up a summary of what's in the release. It can be a digested version of the changes, or some other concise summary.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -1,7 +1,7 @@
 <document xmlns="http://maven.apache.org/changes/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/xsd/changes-1.0.0.xsd">
 	<body>
 
-    <release version="1.17.0-rc4" date="2022-09-04" description="Minor feature release.">
+    <release version="1.17.0" date="2022-09-11" description="Improved image compression, checksum support, and incremental writing">
       <action type="add" dev="attipaci" issue="319">
 	      Generalized tile compression for any-dimensional images based on the FITSIO convention. 
       </action>
@@ -30,8 +30,8 @@
         potentially huge data volumes in RAM when computing or updating checksums in an existing FITS file.
       </action>
       <action type="update" dev="attipaci" issue="323">
-        Fits.setChecksum() will now checksum all HDUs, including those not already loaded from disk without loading data into memory 
-        (in deferred read mode) if possible.
+        Fits.setChecksum() will now checksum all HDUs, including those not already loaded from disk -- 
+        keeping data in deferred read mode if possible.
       </action>
       <action type="add" dev="attipaci" issue="323">
         Added Fits.rewrite() to simplify re-writing the entire Fits objects, e.g. after updating checksums. The 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -1,12 +1,15 @@
 <document xmlns="http://maven.apache.org/changes/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/xsd/changes-1.0.0.xsd">
 	<body>
 
-    <release version="1.17.0-rc4" date="2022-08-31" description="Minor feature release.">
+    <release version="1.17.0-rc4" date="2022-09-04" description="Minor feature release.">
       <action type="add" dev="attipaci" issue="319">
 	      Generalized tile compression for any-dimensional images based on the FITSIO convention. 
       </action>
       <action type="fix" dev="attipaci" issue="318">
 	      Fixed broken tile compression of non-square images. 
+      </action>
+      <action type="fix" dev="attipaci" issue="318">
+	      CompressedImageHDU.fromInageHDU() now defaults to tiling by row if tile size is not explicitly specified, as per FITS specification and also for consistent behavior in higher dimensions.
       </action>
       <action type="update" dev="attipaci" issue="266">
 				Safe incremental HDU writing via new FitsOutput interface, which is used to check whether HDUs should be set 
@@ -15,25 +18,28 @@
       <action type="update" dev="attipaci" issue="323">
 	      Simpler, faster, and more versatile FitsChecksum class, with support for incremental checksum updates, checksum retrieval, and checksum computations directly from files.
       </action>
+      <action type="add" dev="attipaci" issue="323">
+	      New checksumming methods: BasicHDU.calcChecksum(), .setChecksum(), .getStoredChecksum(), and .getStoredDataSum(); Data.calcChecksum(); Fits.calcChecksum(int) and .setChecksum(int) -- as well as an extended static API for `FitsCheckSum`.
+      </action>
       <action type="update" dev="attipaci" issue="328">
 	      Checksum in-memory headers/data with less overhead through piped streams.
       </action>
       <action type="update" dev="attipaci" issue="323">
-        Fits.setChecksum() and calcChecksum(int) compute checksum directly from the file, if possible, for 
-        deferred read data (i.e. data not currently loaded into RAM). This eliminates the need to load 
-        potentially huge data volumes into RAM when computing or updating checksums in an existing FITS file.
+        Fits.setChecksum(), .setCheckSum(int), and .calcChecksum(int) compute checksum directly from the file, if possible, for 
+        deferred read data (i.e. data not currently loaded into RAM). This eliminates the need to keep 
+        potentially huge data volumes in RAM when computing or updating checksums in an existing FITS file.
       </action>
       <action type="update" dev="attipaci" issue="323">
-        Fits.setChecksum() will now checksum any HDUs not already loaded from disk without loading data into memory 
+        Fits.setChecksum() will now checksum all HDUs, including those not already loaded from disk without loading data into memory 
         (in deferred read mode) if possible.
       </action>
       <action type="add" dev="attipaci" issue="323">
         Added Fits.rewrite() to simplify re-writing the entire Fits objects, e.g. after updating checksums. The 
-        implementation is efficient by not processing any data segments in deferred read mode. BasicHDU.rewrite() 
+        implementation is efficient in that it skips data segments in deferred read mode. BasicHDU.rewrite()
         is modified to make it efficient also.
       </action>
     	<action type="add" dev="attipaci" issue="283">
-	      User adjustable header comment alignment position via Header.setCommentAlignPosition(int). 
+	      User adjustable header comment alignment position via Header.setCommentAlignPosition(int) and checking via .getCommentAlignPosition(). 
       </action>
     	<action type="add" dev="attipaci" issue="145">
 				New Fits.getHDU() methods to select HDU from Fits by name (and version).
@@ -43,7 +49,7 @@
         controlled via Header.setParserWarningsEnabled(boolean). 
       </action>
       <action type="update" dev="attipaci" issue="292">
-        Suppress repeated duplicate keyword warnings when parsing and improve checks for FITS standard violations.
+        Suppress repeated duplicate keyword warnings when parsing and improve checks for FITS standard violations. Added Header.getDuplicateKeySet() method to check which keywords have duplicates. 
       </action>
       <action type="update" dev="attipaci" issue="292">
         Replacing header keys logs a warning when existing value type is incompatible wth the newly associated 

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -122,7 +122,12 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
     /** The associated data unit. */
     protected DataClass myData = null;
 
-    /** Is this the first HDU in a FITS file? */
+    /**
+     * @deprecated Unused internally, and it should be a dynamic property not a static one.
+     *  
+     * Is this the first HDU in a FITS file? 
+     */
+    @Deprecated
     protected boolean isPrimary = false;
 
     protected BasicHDU(Header myHeader, DataClass myData) {
@@ -329,10 +334,12 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
     }
 
     /**
+     * Returns the data component of this HDU.
+     * 
      * @return the associated Data object
      */
     public DataClass getData() {
-        return this.myData;
+        return myData;
     }
 
     /**
@@ -591,7 +598,7 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
      *         stripped.
      */
     public String getTrimmedString(String keyword) {
-        String s = this.myHeader.getStringValue(keyword);
+        String s = myHeader.getStringValue(keyword);
         if (s != null) {
             s = s.trim();
         }
@@ -621,9 +628,9 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
     @SuppressWarnings("unchecked")
     @Override
     public void read(ArrayDataInput stream) throws FitsException, IOException {
-        this.myHeader = Header.readHeader(stream);
-        this.myData = (DataClass) this.myHeader.makeData();
-        this.myData.read(stream);
+        myHeader = Header.readHeader(stream);
+        myData = (DataClass) FitsFactory.dataFactory(myHeader);
+        myData.read(stream);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -454,6 +454,8 @@ public class Fits implements Closeable {
     }
 
     /**
+     * @deprecated Will be private in 2.0.
+     * 
      * Get a stream from the file and then use the stream initialization.
      * 
      * @param myFile
@@ -463,6 +465,8 @@ public class Fits implements Closeable {
      * @throws FitsException
      *             if the opening of the file failed.
      */
+    // TODO Make private
+    @Deprecated
     @SuppressWarnings("resource")
     @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION", justification = "stream stays open, and will be read when nessesary.")
     protected void fileInit(File myFile, boolean compressed) throws FitsException {
@@ -682,6 +686,8 @@ public class Fits implements Closeable {
     }
 
     /**
+     * @deprecated This will be private in 2.0.
+     * 
      * Initialize using buffered random access. This implies that the data is
      * uncompressed.
      * 
@@ -689,7 +695,10 @@ public class Fits implements Closeable {
      *            the file to open
      * @throws FitsException
      *             if the file could not be read
+     *             
      */
+    // TODO make private
+    @Deprecated
     protected void randomInit(File file) throws FitsException {
 
         String permissions = "r";
@@ -770,7 +779,7 @@ public class Fits implements Closeable {
             return null;
         }
 
-        Data data = hdr.makeData();
+        Data data = FitsFactory.dataFactory(hdr);
         try {
             data.read(this.dataStr);
         } catch (PaddingException e) {

--- a/src/main/java/nom/tam/fits/FitsFactory.java
+++ b/src/main/java/nom/tam/fits/FitsFactory.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
+import nom.tam.fits.header.Standard;
 import nom.tam.fits.header.hierarch.IHierarchKeyFormatter;
 import nom.tam.fits.header.hierarch.StandardIHierarchKeyFormatter;
 import nom.tam.image.compression.hdu.CompressedImageData;
@@ -203,7 +204,10 @@ public final class FitsFactory {
 
         if (ImageHDU.isHeader(hdr)) {
             Data d = ImageHDU.manufactureData(hdr);
-            hdr.afterExtend(); // Fix for positioning error noted by V. Forchi
+            // Fix for positioning error noted by V. Forchi
+            if (hdr.findCard(Standard.EXTEND) != null) {
+                hdr.nextCard();
+            }
             return d;
         } else if (RandomGroupsHDU.isHeader(hdr)) {
             return RandomGroupsHDU.manufactureData(hdr);

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -899,12 +899,12 @@ As of version 1.17, it is also possible to apply incremental updates to existing
 Setting the checksums (`CHECKSUM` and `DATASUM` keywords) should be the last modification to the FITS object or HDU before writing. Here is an example of settting a checksum for an HDU before you write it to disk:
 
 ```java
-  ImageHDU im;
+  BasicHDU<?> hdu;
          
-  // ... prepare the image and header ...
+  // ... prepare the HDU and header ...
    
-  im.setChecksum();
-  im.write(new FitsFile("my-checksummed-image.fits"));
+  hdu.setChecksum();
+  hdu.write(new FitsFile("my-checksummed-image.fits"));
 ```
 
 Or you can set checksums for all HDUs in your `Fits` in one go before writing the entire `Fits` object out to disk:

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -91,24 +91,24 @@ public class HeaderProtectedTest {
     }
     
     @Test
-    public void testTrueDataSize() throws Exception {
+    public void testDataSize() throws Exception {
         Header header = new Header();
         // No BITPIX
-        Assert.assertEquals(0L, header.trueDataSize()); 
+        Assert.assertEquals(0L, header.getDataSize()); 
         header.addValue(Standard.BITPIX, 32);
         // No NAXIS
-        Assert.assertEquals(0L, header.trueDataSize()); 
+        Assert.assertEquals(0L, header.getDataSize()); 
         
         header = new Header();
         header.nullImage();
         header.write(new FitsOutputStream(new ByteArrayOutputStream(), 80));
-        Assert.assertEquals(0L, header.trueDataSize());
+        Assert.assertEquals(0L, header.getDataSize());
         header.setNaxes(2);
         header.setNaxis(1, 0);
         header.setNaxis(2, 2);
         header.addValue(GROUPS, true);
         header.write(new FitsOutputStream(new ByteArrayOutputStream(), 80));
-        Assert.assertEquals(2L, header.trueDataSize());
+        Assert.assertEquals(FitsUtil.addPadding(2L), header.getDataSize());
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1583,7 +1583,6 @@ public class HeaderTest {
     public void invalidHeaderSizeTest() throws Exception {
         Header h = new Header();
         h.addValue("TEST", 1.0, "Some value");
-        assertFalse(h.isValidHeader());
-        assertEquals(0, h.headerSize());
+        assertEquals(0, h.getSize());
     }
 }


### PR DESCRIPTION
Deprecate parts of the API that are slated for removal (or reduced visibility) in 2.0. We will continue to support these interfaces in the 1.x releases however. It's only to give a fair warning to developers about what will be axed in the future...