### PR TITLE
Issue 368: First extension (2nd HDU) sometimes written as primary

### DIFF
--- a/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.utilities;
 
+import static nom.tam.fits.header.Checksum.CHECKSUM;
+import static nom.tam.fits.header.Checksum.DATASUM;
 
 /*-
  * #%L
@@ -50,34 +52,29 @@ import nom.tam.fits.FitsElement;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
-import static nom.tam.fits.header.Checksum.CHECKSUM;
-import static nom.tam.fits.header.Checksum.DATASUM;
 import nom.tam.util.FitsIO;
 import nom.tam.util.FitsOutputStream;
 import nom.tam.util.RandomAccess;
 
 /**
  * <p>
- * Helper class for dealing with FITS checksums. It implements the Seaman-Pence 32-bit 1's 
- * complement checksum calculation. The implementation accumulates in two 64-bit integer 
- * values the low and high-order 16-bits of adjacent 4-byte groups. A carry-over of bits are 
- * calculated only at the end of the loop. Given the use of 64-bit accumulators, overflow would 
- * occur approximately at 280 billion short values.
+ * Helper class for dealing with FITS checksums. It implements the Seaman-Pence 32-bit 1's complement checksum
+ * calculation. The implementation accumulates in two 64-bit integer values the low and high-order 16-bits of adjacent
+ * 4-byte groups. A carry-over of bits are calculated only at the end of the loop. Given the use of 64-bit accumulators,
+ * overflow would occur approximately at 280 billion short values.
  * </p>
  * <p>
- * This updated version of the class is a little more flexible than the prior incarnation. 
- * Specifically it allows incremental updates to data sums, and provides methods for dealing 
- * with partial checksums (e.g. from modified segments of the data), which may be used e.g. 
- * to calculate delta sums from changed blocks of data. The new implementation  provides methods 
- * for decoding encoded checksums, and for calculating  checksums directly from files without 
- * the need to read potentially huge data into RAM first, and for easily accessing the values 
- * stored in FITS headers.
+ * This updated version of the class is a little more flexible than the prior incarnation. Specifically it allows
+ * incremental updates to data sums, and provides methods for dealing with partial checksums (e.g. from modified
+ * segments of the data), which may be used e.g. to calculate delta sums from changed blocks of data. The new
+ * implementation provides methods for decoding encoded checksums, and for calculating checksums directly from files
+ * without the need to read potentially huge data into RAM first, and for easily accessing the values stored in FITS
+ * headers.
  * </p>
  * 
  * @author R J Mather, Tony Johnson, Attila Kovacs
  * 
  * @see <a href="http://arxiv.org/abs/1201.1345" target="@top">FITS Checksum Proposal</a>
- * 
  * @see nom.tam.fits.header.Checksum#CHECKSUM
  */
 public final class FitsCheckSum {
@@ -91,15 +88,15 @@ public final class FitsCheckSum {
     private static final int ASCII_ZERO = '0';
     private static final int BUFFER_SIZE = 0x8000; // 32 kB
 
-    private static final int[] SELECT_BYTE = {24, 16, 8, 0}; 
-    private static final String EXCLUDE = ":;<=>?@[\\]^_`";    
+    private static final int[] SELECT_BYTE = {24, 16, 8, 0};
+    private static final String EXCLUDE = ":;<=>?@[\\]^_`";
     private static final String CHECKSUM_DEFAULT = "0000000000000000";
 
     private FitsCheckSum() {
     }
-    
+
     /**
-     * Internal class for accumulating FITS checksums. 
+     * Internal class for accumulating FITS checksums.
      */
     private static class Checksum {
         private long h, l;
@@ -117,7 +114,7 @@ public final class FitsCheckSum {
         long getChecksum() {
             long hi = h;
             long lo = l;
-            
+
             for (;;) {
                 long hicarry = hi >>> SHIFT_2_BYTES;
                 long locarry = lo >>> SHIFT_2_BYTES;
@@ -131,38 +128,38 @@ public final class FitsCheckSum {
         }
 
     }
-    
+
     private static class PipeWriter extends Thread {
         private Exception exception;
         private PipedOutputStream out;
         private FitsElement data;
-        
+
         PipeWriter(FitsElement data, PipedInputStream in) throws IOException {
             this.data = data;
             this.out = new PipedOutputStream(in);
         }
-        
+
         @Override
         public void run() {
             exception = null;
-            try (FitsOutputStream fos = new FitsOutputStream(out)) { 
-                data.write(fos); 
+            try (FitsOutputStream fos = new FitsOutputStream(out)) {
+                data.write(fos);
             } catch (Exception e) {
                 exception = e;
             }
         }
-        
+
         public Exception getException() {
             return exception;
         }
     }
 
-    
     /**
      * Computes the checksum for a byte array.
      * 
-     * @param data      the byte sequence for which to calculate a chekcsum
-     * @return          the 32bit checksum in the range from 0 to 2^32-1
+     * @param data the byte sequence for which to calculate a chekcsum
+     * 
+     * @return the 32bit checksum in the range from 0 to 2^32-1
      * 
      * @see #checksum(byte[], int, int)
      */
@@ -173,10 +170,11 @@ public final class FitsCheckSum {
     /**
      * Computes the checksum for a segment of a byte array.
      * 
-     * @param data      the byte sequence for which to calculate a chekcsum
-     * @param from      Stating index of bytes to include in checksum calculation
-     * @param to        Ending index (exclusive) of bytes to include in checksum
-     * @return the      32-bit checksum in the range from 0 to 2^32-1
+     * @param data the byte sequence for which to calculate a chekcsum
+     * @param from Stating index of bytes to include in checksum calculation
+     * @param to Ending index (exclusive) of bytes to include in checksum
+     * 
+     * @return the 32-bit checksum in the range from 0 to 2^32-1
      * 
      * @see #checksum(RandomAccess, long, long)
      * 
@@ -185,19 +183,18 @@ public final class FitsCheckSum {
     public static long checksum(byte[] data, int from, int to) {
         return checksum(ByteBuffer.wrap(data, from, to));
     }
-    
+
     /**
-     * Computes the checksum from a buffer. This method can be used to calculate
-     * partial checksums for any data that can be wrapped into a buffer one way or another.
-     * As such it is suitable for calculating partial sums from segments of data that
-     * can be used to update datasums incrementally (e.g. by incrementing the datasum
-     * with the difference of the checksum of the new data segment vs the old data segment),
-     * or for updating the checksum for new data that has been added to the existing data
-     * (e.g. new rows in a binary table) as long as the modified data segment is a multiple
-     * of 4 bytes.
+     * Computes the checksum from a buffer. This method can be used to calculate partial checksums for any data that can
+     * be wrapped into a buffer one way or another. As such it is suitable for calculating partial sums from segments of
+     * data that can be used to update datasums incrementally (e.g. by incrementing the datasum with the difference of
+     * the checksum of the new data segment vs the old data segment), or for updating the checksum for new data that has
+     * been added to the existing data (e.g. new rows in a binary table) as long as the modified data segment is a
+     * multiple of 4 bytes.
      * 
-     * @param data      the buffer for which to calculate a (partial) checksum
-     * @return          the computed 32-bit unsigned checksum as a Java <code>long</code>
+     * @param data the buffer for which to calculate a (partial) checksum
+     * 
+     * @return the computed 32-bit unsigned checksum as a Java <code>long</code>
      * 
      * @since 1.17
      * 
@@ -223,7 +220,7 @@ public final class FitsCheckSum {
     private static long checksum(InputStream in) throws IOException {
         Checksum sum = new Checksum(0);
         DataInputStream din = new DataInputStream(in);
-        
+
         for (;;) {
             try {
                 sum.add(din.readInt());
@@ -231,10 +228,9 @@ public final class FitsCheckSum {
                 break;
             }
         }
-        
+
         return sum.getChecksum();
     }
-    
 
     private static long compute(final FitsElement data) throws FitsException {
         try (PipedInputStream in = new PipedInputStream()) {
@@ -243,12 +239,12 @@ public final class FitsCheckSum {
 
             long sum = checksum(in);
             in.close();
-            
+
             writer.join();
             if (writer.getException() != null) {
                 throw writer.getException();
             }
-            
+
             return sum;
         } catch (Exception e) {
             if (e instanceof FitsException) {
@@ -257,19 +253,18 @@ public final class FitsCheckSum {
             throw new FitsException("Exception while checksumming FITS element: " + e.getMessage(), e);
         }
     }
-    
+
     /**
-     * Computes the checksum for a FITS data object, e.g. to be used with
-     * {@link #setDatasum(Header, long)}. This call will always calculate the checksum
-     * for the data in memory, and as such load deferred mode data
-     * into RAM as necessary to perform the calculation. If you rather not load
-     * a huge amount of data into RAM, you might consider using 
-     * {@link #checksum(RandomAccess, long, long)} instead.
+     * Computes the checksum for a FITS data object, e.g. to be used with {@link #setDatasum(Header, long)}. This call
+     * will always calculate the checksum for the data in memory, and as such load deferred mode data into RAM as
+     * necessary to perform the calculation. If you rather not load a huge amount of data into RAM, you might consider
+     * using {@link #checksum(RandomAccess, long, long)} instead.
      * 
-     * @param data      The FITS data object for which to calculate a checksum
-     * @return          The checksum of the data
+     * @param data The FITS data object for which to calculate a checksum
      * 
-     * @throws FitsException    If there was an error serializing the data object
+     * @return The checksum of the data
+     * 
+     * @throws FitsException If there was an error serializing the data object
      * 
      * @see Data#calcChecksum()
      * @see nom.tam.fits.Fits#calcDatasum(int)
@@ -282,22 +277,22 @@ public final class FitsCheckSum {
     public static long checksum(Data data) throws FitsException {
         return compute(data);
     }
-    
+
     /**
-     * Computes the checksum for a FITS header object. If the header already contained 
-     * a CHECKSUM card, it will be kept. Otherwise, it will add a CHECKSUM card
-     * to the header with the newly calculated sum.
+     * Computes the checksum for a FITS header object. If the header already contained a CHECKSUM card, it will be kept.
+     * Otherwise, it will add a CHECKSUM card to the header with the newly calculated sum.
      * 
-     * @param header    The FITS header object for which to calculate a checksum
-     * @return          The checksum of the data
+     * @param header The FITS header object for which to calculate a checksum
      * 
-     * @throws FitsException    If there was an error serializing the FITS header
+     * @return The checksum of the data
+     * 
+     * @throws FitsException If there was an error serializing the FITS header
      * 
      * @see #checksum(Data)
      * 
      * @since 1.17
      */
-    public static long checksum(Header header) throws FitsException {   
+    public static long checksum(Header header) throws FitsException {
         HeaderCard hc = header.findCard(CHECKSUM);
         String prior = null;
 
@@ -307,22 +302,23 @@ public final class FitsCheckSum {
         } else {
             hc = header.addValue(CHECKSUM, CHECKSUM_DEFAULT);
         }
-        
+
         long sum = compute(header);
-        
+
         hc.setValue(prior == null ? encode(sum) : prior);
 
         return sum;
     }
-    
+
     /**
-     * Calculates the FITS checksum for a HDU, e.g to compare agains the value stored
-     * under the CHECKSUM header keyword. The 
+     * Calculates the FITS checksum for a HDU, e.g to compare agains the value stored under the CHECKSUM header keyword.
+     * The
      * 
-     * @param hdu       The Fits HDU for which to calculate a checksum, including both the
-     *                  header and data segments.
-     * @return          The calculated checksum for the given HDU.
-     * @throws FitsException        if there was an error accessing the contents of the HDU.
+     * @param hdu The Fits HDU for which to calculate a checksum, including both the header and data segments.
+     * 
+     * @return The calculated checksum for the given HDU.
+     * 
+     * @throws FitsException if there was an error accessing the contents of the HDU.
      * 
      * @see BasicHDU#calcChecksum()
      * @see #checksum(Data)
@@ -333,17 +329,16 @@ public final class FitsCheckSum {
     public static long checksum(BasicHDU<?> hdu) throws FitsException {
         return sumOf(checksum(hdu.getHeader()), checksum(hdu.getData()));
     }
-    
+
     /**
-     * Computes the checksum directly from a region of a random access file, by buffering
-     * moderately sized chunks from the file as necessary. The file may be very large, up to the
-     * full range of 64-bit addresses.
+     * Computes the checksum directly from a region of a random access file, by buffering moderately sized chunks from
+     * the file as necessary. The file may be very large, up to the full range of 64-bit addresses.
      * 
-     * @param f     the random access file, from which to compute a checksum
-     * @param from  the starting position in the file, where to start computing the checksum from.
-     * @param size  the number of bytes in the file to include in the checksum calculation.
+     * @param f the random access file, from which to compute a checksum
+     * @param from the starting position in the file, where to start computing the checksum from.
+     * @param size the number of bytes in the file to include in the checksum calculation.
      * 
-     * @return      the checksum for the given segment of the file
+     * @return the checksum for the given segment of the file
      * 
      * @throws IOException if there was a problem accessing the file during the computation.
      * 
@@ -351,9 +346,12 @@ public final class FitsCheckSum {
      * 
      * @see #checksum(ByteBuffer)
      * @see #checksum(Data)
-     * 
      */
     public static long checksum(RandomAccess f, long from, long size) throws IOException {
+        if (f == null) {
+            return 0L;
+        }
+
         int len = (int) Math.min(BUFFER_SIZE, size);
         byte[] buf = new byte[len];
         long oldpos = f.position();
@@ -379,8 +377,9 @@ public final class FitsCheckSum {
     /**
      * Encodes the complemented checksum. It is the same as <code>encode(checksum, true)</code>.
      * 
-     * @param checksum      The calculated 32-bit (unsigned) checksum
-     * @return              The encoded checksum, suitably encoded for use with the CHECKSUM header
+     * @param checksum The calculated 32-bit (unsigned) checksum
+     * 
+     * @return The encoded checksum, suitably encoded for use with the CHECKSUM header
      * 
      * @see #decode(String)
      * 
@@ -389,14 +388,13 @@ public final class FitsCheckSum {
     public static String encode(long checksum) {
         return encode(checksum, true);
     }
-    
+
     /**
      * Encodes the given checksum as is or by its complement.
      * 
-     * @param checksum      The calculated 32-bit (unsigned) checksum
-     * @param compl         If <code>true</code> the complement of the specified value
-     *                      will be encoded. Otherwise, the value as is will be encoded.
-     *                      (FITS normally uses the complemenyed value).
+     * @param checksum The calculated 32-bit (unsigned) checksum
+     * @param compl If <code>true</code> the complement of the specified value will be encoded. Otherwise, the value as
+     *            is will be encoded. (FITS normally uses the complemenyed value).
      * 
      * @return The encoded checksum, suitably encoded for use with the CHECKSUM header
      * 
@@ -408,7 +406,7 @@ public final class FitsCheckSum {
         if (compl) {
             checksum = ~checksum & FitsIO.INTEGER_MASK;
         }
-        
+
         final byte[] asc = new byte[CHECKSUM_STRING_SIZE];
         final byte[] ch = new byte[CHECKSUM_BLOCK_SIZE];
         final int sum = (int) checksum;
@@ -418,7 +416,7 @@ public final class FitsCheckSum {
             final int byt = MASK_BYTE & (sum >>> SELECT_BYTE[i]);
 
             Arrays.fill(ch, (byte) ((byt >>> 2) + ASCII_ZERO)); // quotient
-            ch[0] += byt & CHECKSUM_BLOCK_MASK;                 // remainder
+            ch[0] += byt & CHECKSUM_BLOCK_MASK; // remainder
 
             for (int j = 0; j < CHECKSUM_BLOCK_SIZE; j += 2) {
                 while (EXCLUDE.indexOf(ch[j]) >= 0 || EXCLUDE.indexOf(ch[j + 1]) >= 0) {
@@ -426,28 +424,28 @@ public final class FitsCheckSum {
                     ch[j + 1]--;
                 }
             }
-            
+
             for (int j = 0; j < CHECKSUM_BLOCK_SIZE; j++) {
                 int k = CHECKSUM_BLOCK_SIZE * j + i;
                 k = (k == CHECKSUM_STRING_SIZE - 1) ? 0 : k + 1; // rotate right
                 asc[k] = ch[j];
             }
         }
-        
+
         return new String(asc, StandardCharsets.US_ASCII);
     }
 
     /**
-     * Decodes an encoded (and complemented) checksum. The same as <code>decode(encoded, true)</code>,
-     * and the the inverse of {@link #encode(long)}.
+     * Decodes an encoded (and complemented) checksum. The same as <code>decode(encoded, true)</code>, and the the
+     * inverse of {@link #encode(long)}.
      * 
      * @param encoded The encoded checksum (16 character string)
      * 
      * @return The unsigned 32-bit integer complemeted checksum.
      * 
-     * @throws IllegalArgumentException     if the checksum string is invalid (wrong length or
-     *                                      contains illegal ASCII characters)
-     *                                      
+     * @throws IllegalArgumentException if the checksum string is invalid (wrong length or contains illegal ASCII
+     *             characters)
+     * 
      * @see #encode(long)
      * 
      * @since 1.17
@@ -455,21 +453,19 @@ public final class FitsCheckSum {
     public static long decode(String encoded) throws IllegalArgumentException {
         return decode(encoded, true);
     }
-    
+
     /**
-     * Decodes an encoded checksum, complementing it as required. It is the inverse of 
-     * {@link #encode(long, boolean)}.
+     * Decodes an encoded checksum, complementing it as required. It is the inverse of {@link #encode(long, boolean)}.
      * 
-     * @param encoded   the encoded checksum (16 character string)
-     * @param compl     whether to complement the checksum after decoding. Normally FITS
-     *                  uses complemented 32-bit checksums, so typically this optional
-     *                  argument should be <code>true</code>.
+     * @param encoded the encoded checksum (16 character string)
+     * @param compl whether to complement the checksum after decoding. Normally FITS uses complemented 32-bit checksums,
+     *            so typically this optional argument should be <code>true</code>.
      * 
      * @return The unsigned 32-bit integer checksum.
      * 
-     * @throws IllegalArgumentException     if the checksum string is invalid (wrong length or
-     *                                      contains illegal ASCII characters)
-     *                                      
+     * @throws IllegalArgumentException if the checksum string is invalid (wrong length or contains illegal ASCII
+     *             characters)
+     * 
      * @see #encode(long, boolean)
      * 
      * @since 1.17
@@ -483,35 +479,35 @@ public final class FitsCheckSum {
         byte tmp = bytes[0];
         System.arraycopy(bytes, 1, bytes, 0, CHECKSUM_STRING_SIZE - 1);
         bytes[CHECKSUM_STRING_SIZE - 1] = tmp;
-        
+
         for (int i = 0; i < CHECKSUM_STRING_SIZE; i++) {
             if (bytes[i] < ASCII_ZERO) {
-                throw new IllegalArgumentException("Bad checksum with illegal char " + 
-                        Integer.toHexString(bytes[i]) + " at pos " + i + " (ASCII below 0x30)");
+                throw new IllegalArgumentException("Bad checksum with illegal char " + Integer.toHexString(bytes[i])
+                        + " at pos " + i + " (ASCII below 0x30)");
             }
             bytes[i] -= ASCII_ZERO;
         }
-        
+
         ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN);
-        
+
         long sum = (bb.getInt() + bb.getInt() + bb.getInt() + bb.getInt());
         return (compl ? ~sum : sum) & FitsIO.INTEGER_MASK;
     }
-    
-    
-    private static long wrap(long sum) { 
+
+    private static long wrap(long sum) {
         while ((sum >>> Integer.SIZE) != 0) {
             sum = (sum & FitsIO.INTEGER_MASK) + (sum >>> Integer.SIZE);
         }
         return sum;
     }
-    
+
     /**
-     * Calculates the total checksum from partial sums. For example combining checksums from
-     * a header and data segment of a HDU, or for composing a data checksum from image tiles.
+     * Calculates the total checksum from partial sums. For example combining checksums from a header and data segment
+     * of a HDU, or for composing a data checksum from image tiles.
      * 
-     * @param parts     The partial sums that are to be added together.
-     * @return          The aggregated checksum as a 32-bit unsigned value. 
+     * @param parts The partial sums that are to be added together.
+     * 
+     * @return The aggregated checksum as a 32-bit unsigned value.
      * 
      * @see #differenceOf(long, long)
      * 
@@ -524,17 +520,17 @@ public final class FitsCheckSum {
         }
         return wrap(sum);
     }
-    
+
     /**
-     * Subtracts a partial checksum from an aggregated total. One may use it, for example to
-     * update the datasum of a large data, when modifying only a small segment of it. Thus, one would
-     * first subtract the checksum of the old segment from tha prior datasum, and then add the
-     * checksum of the new data segment -- without hacing to recalculate the checksum for the entire
-     * data again.
+     * Subtracts a partial checksum from an aggregated total. One may use it, for example to update the datasum of a
+     * large data, when modifying only a small segment of it. Thus, one would first subtract the checksum of the old
+     * segment from tha prior datasum, and then add the checksum of the new data segment -- without hacing to
+     * recalculate the checksum for the entire data again.
      * 
-     * @param total     The total checksum.
-     * @param part      The partial checksum to be subtracted from the total.
-     * @return          The checksum after subtracting the partial sum, as a 32-bit unsigned value.
+     * @param total The total checksum.
+     * @param part The partial checksum to be subtracted from the total.
+     * 
+     * @return The checksum after subtracting the partial sum, as a 32-bit unsigned value.
      * 
      * @see #sumOf(long...)
      * 
@@ -543,23 +539,21 @@ public final class FitsCheckSum {
     public static long differenceOf(long total, long part) {
         return wrap(total - part);
     }
-    
+
     /**
-     * Sets the <code>DATASUM</code> and <code>CHECKSUM</code> keywords in a FITS header, based 
-     * on the provided checksum of the data (calculated elsewhere) and the checksum calculated afresh
-     * for the header.
+     * Sets the <code>DATASUM</code> and <code>CHECKSUM</code> keywords in a FITS header, based on the provided checksum
+     * of the data (calculated elsewhere) and the checksum calculated afresh for the header.
      * 
-     * @param header        the header in which to store the <code>DATASUM</code> and <code>CHECKSUM</code> 
-     *                      values
-     * @param datasum       the checksum for the data segment that follows the header in the HDU.
-     * @throws FitsException    
-     *             if there was an error serializing the header. Note, the method never throws
-     *             any other type of exception (including runtime exceptions), which are
-     *             instead wrapped into a <code>FitsException</code> when they occur.
-     *             
-     * @see #setChecksum(BasicHDU) 
+     * @param header the header in which to store the <code>DATASUM</code> and <code>CHECKSUM</code> values
+     * @param datasum the checksum for the data segment that follows the header in the HDU.
+     * 
+     * @throws FitsException if there was an error serializing the header. Note, the method never throws any other type
+     *             of exception (including runtime exceptions), which are instead wrapped into a
+     *             <code>FitsException</code> when they occur.
+     * 
+     * @see #setChecksum(BasicHDU)
      * @see #getStoredChecksum(Header)
-     * @see #getStoredDatasum(Header)    
+     * @see #getStoredDatasum(Header)
      * 
      * @since 1.17
      */
@@ -568,20 +562,18 @@ public final class FitsCheckSum {
         header.addValue(DATASUM, Long.toString(datasum));
         header.addValue(CHECKSUM, encode(sumOf(checksum(header), datasum)));
     }
-        
+
     /**
-     * Computes and sets the DATASUM and CHECKSUM keywords for a given HDU. This method
-     * calculates the sums from scratch, and can be computationally expensive. There are 
-     * less expensive incremental update methods that can be used if the HDU already 
-     * had sums recorded earlier, which need to be updated e.g. because there were modifications
+     * Computes and sets the DATASUM and CHECKSUM keywords for a given HDU. This method calculates the sums from
+     * scratch, and can be computationally expensive. There are less expensive incremental update methods that can be
+     * used if the HDU already had sums recorded earlier, which need to be updated e.g. because there were modifications
      * to the header, or (parts of) the data.
      * 
-     * @param hdu
-     *            the HDU to be updated.
-     * @throws FitsException
-     *             if there was an error serializing the HDU. Note, the method never throws
-     *             any other type of exception (including runtime exceptions), which are
-     *             instead wrapped into a <code>FitsException</code> when they occur.
+     * @param hdu the HDU to be updated.
+     * 
+     * @throws FitsException if there was an error serializing the HDU. Note, the method never throws any other type of
+     *             exception (including runtime exceptions), which are instead wrapped into a <code>FitsException</code>
+     *             when they occur.
      * 
      * @see #setDatasum(Header, long)
      * @see #getStoredChecksum(Header)
@@ -589,9 +581,8 @@ public final class FitsCheckSum {
      * @see #differenceOf(long, long)
      * 
      * @author R J Mather, Attila Kovacs
-     *             
      */
-    public static void setChecksum(BasicHDU<?> hdu) throws FitsException { 
+    public static void setChecksum(BasicHDU<?> hdu) throws FitsException {
         try {
             setDatasum(hdu.getHeader(), checksum(hdu.getData()));
         } catch (FitsException e) {
@@ -600,13 +591,15 @@ public final class FitsCheckSum {
             throw new FitsException("Exception while computing data checksum: " + e.getMessage(), e);
         }
     }
-    
+
     /**
      * Returns the DATASUM value stored in a FITS header.
      * 
-     * @param header            the FITS header
-     * @return                  The stored datasum value (unsigned 32-bit integer) as a Java <code>long</code>.
-     * @throws FitsException    if the header does not contain a <code>DATASUM</code> entry.
+     * @param header the FITS header
+     * 
+     * @return The stored datasum value (unsigned 32-bit integer) as a Java <code>long</code>.
+     * 
+     * @throws FitsException if the header does not contain a <code>DATASUM</code> entry.
      * 
      * @since 1.17
      * 
@@ -614,23 +607,25 @@ public final class FitsCheckSum {
      * @see #setDatasum(Header, long)
      * @see BasicHDU#getStoredDatasum()
      */
-    public static long getStoredDatasum(Header header) throws FitsException { 
+    public static long getStoredDatasum(Header header) throws FitsException {
         HeaderCard hc = header.findCard(DATASUM);
-        
+
         if (hc == null) {
             throw new FitsException("Header does not have a DATASUM value.");
         }
-        
+
         return hc.getValue(Long.class, 0L) & FitsIO.INTEGER_MASK;
     }
 
     /**
      * Returns the decoded CHECKSUM value stored in a FITS header.
      * 
-     * @param header            the FITS header
-     * @return                  The decoded <code>CHECKSUM</code> value (unsigned 32-bit integer) 
-     *                          recorded in the header as a Java <code>long</code>.
-     * @throws FitsException    if the header does not contain a <code>CHECKSUM</code> entry, or it is invalid.
+     * @param header the FITS header
+     * 
+     * @return The decoded <code>CHECKSUM</code> value (unsigned 32-bit integer) recorded in the header as a Java
+     *             <code>long</code>.
+     * 
+     * @throws FitsException if the header does not contain a <code>CHECKSUM</code> entry, or it is invalid.
      * 
      * @since 1.17
      * 
@@ -638,13 +633,13 @@ public final class FitsCheckSum {
      * @see #setChecksum(BasicHDU)
      * @see BasicHDU#getStoredChecksum()
      */
-    public static long getStoredChecksum(Header header) throws FitsException { 
+    public static long getStoredChecksum(Header header) throws FitsException {
         String encoded = header.getStringValue(CHECKSUM);
-        
+
         if (encoded == null) {
             throw new FitsException("Header does not have a CHECKUM value.");
         }
-        
+
         return decode(encoded);
     }
 }

--- a/src/main/java/nom/tam/util/FitsOutputStream.java
+++ b/src/main/java/nom/tam/util/FitsOutputStream.java
@@ -35,18 +35,13 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-
 /**
- * This class is intended for high performance writing FITS files or 
- * FITS data blocks.
- *
+ * This class is intended for high performance writing FITS files or FITS data blocks.
  * <p>
- * Testing and timing for this class is performed in the
- * nom.tam.util.test.BufferedFileTester class.
- * 
+ * Testing and timing for this class is performed in the nom.tam.util.test.BufferedFileTester class.
  * <p>
- * Version 2.0 -- October 30, 2021: Completely overhauled, with new name and 
- * hierarchy. Performance is 2-4 times better than before. (Attila Kovacs)
+ * Version 2.0 -- October 30, 2021: Completely overhauled, with new name and hierarchy. Performance is 2-4 times better
+ * than before. (Attila Kovacs)
  * 
  * @see FitsInputStream
  * @see FitsFile
@@ -56,12 +51,14 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
 
     /** the output, as accessible via the <code>DataInput</code> interface */
     private final DataOutput data;
-    
+
+    /** Unencoded output byte count */
+    private int count;
+
     /**
      * Use the BufferedOutputStream constructor
      * 
-     * @param o
-     *            An open output stream.
+     * @param o An open output stream.
      */
     public FitsOutputStream(OutputStream o) {
         this(o, FitsIO.DEFAULT_BUFFER_SIZE);
@@ -70,10 +67,8 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
     /**
      * Use the BufferedOutputStream constructor
      * 
-     * @param o
-     *            An open output stream.
-     * @param bufLength
-     *            The buffer size.
+     * @param o An open output stream.
+     * @param bufLength The buffer size.
      */
     public FitsOutputStream(OutputStream o, int bufLength) {
         super(o, bufLength);
@@ -84,10 +79,22 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
             data = new DataOutputStream(o);
         }
     }
-    
+
     @Override
     protected FitsEncoder getEncoder() {
         return (FitsEncoder) super.getEncoder();
+    }
+
+    @Override
+    public synchronized void write(int b) throws IOException {
+        super.write(b);
+        count++;
+    }
+
+    @Override
+    public synchronized void write(byte[] b, int start, int length) throws IOException {
+        super.write(b, start, length);
+        count += length;
     }
 
     @Override
@@ -152,14 +159,14 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
 
     @Override
     public synchronized void writeByte(int b) throws IOException {
-        getEncoder().writeByte(b);        
+        getEncoder().writeByte(b);
     }
 
     @Override
     public synchronized void writeBoolean(boolean b) throws IOException {
         getEncoder().writeBoolean(b);
     }
-    
+
     @Override
     public synchronized void writeChar(int c) throws IOException {
         getEncoder().writeChar(c);
@@ -193,10 +200,10 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
     /**
      * Deprecated use {@link #writeArray(Object)}.
      * 
-     * @param o
-     *            The object to be written.
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param o The object to be written.
+     * 
+     * @throws IOException if one of the underlying write operations failed
+     * 
      * @deprecated use {@link #writeArray(Object)} instead
      */
     @Deprecated
@@ -206,7 +213,7 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
 
     @Override
     public boolean isAtStart() {
-        return getEncoder().getCount() == 0;
+        return (count + getEncoder().getCount()) == 0;
     }
 
 }

--- a/src/main/java/nom/tam/util/FitsOutputStream.java
+++ b/src/main/java/nom/tam/util/FitsOutputStream.java
@@ -53,7 +53,7 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
     private final DataOutput data;
 
     /** Unencoded output byte count */
-    private int count;
+    private int unencodedCount;
 
     /**
      * Use the BufferedOutputStream constructor
@@ -88,13 +88,13 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
     @Override
     public synchronized void write(int b) throws IOException {
         super.write(b);
-        count++;
+        unencodedCount++;
     }
 
     @Override
     public synchronized void write(byte[] b, int start, int length) throws IOException {
         super.write(b, start, length);
-        count += length;
+        unencodedCount += length;
     }
 
     @Override
@@ -213,7 +213,7 @@ public class FitsOutputStream extends ArrayOutputStream implements FitsOutput {
 
     @Override
     public boolean isAtStart() {
-        return (count + getEncoder().getCount()) == 0;
+        return (unencodedCount + getEncoder().getCount()) == 0;
     }
 
 }

--- a/src/main/java/nom/tam/util/OutputEncoder.java
+++ b/src/main/java/nom/tam/util/OutputEncoder.java
@@ -60,7 +60,10 @@ public abstract class OutputEncoder {
      */
     protected OutputWriter out;
 
-    /** Cumulative bytes written to the output, including over-writes */
+    /**
+     * Cumulative encoded byte count written to the output, including
+     * over-writes
+     */
     private long count = 0;
 
     /**
@@ -103,12 +106,12 @@ public abstract class OutputEncoder {
     }
 
     /**
-     * Returns the position in file or stream at which the next write will take
-     * place. For random access files, this is the current file pointer, while
-     * for streams it is the cumulative count of bytes previously written.
+     * Returns the number of <i>encoded</i> bytes that were written to the
+     * output. It does not include bytes written directly (unencoded) to the
+     * output, such as via {@link #write(int)} or
+     * {@link #write(byte[], int, int)}.
      * 
-     * @return the byte offset in the file or stream at which the next write
-     *         will act.
+     * @return the number of encoded bytes written to the output.
      * @see RandomAccess#getFilePointer()
      */
     public synchronized long getCount() {
@@ -164,8 +167,10 @@ public abstract class OutputEncoder {
     }
 
     /**
-     * Writes a byte. See the general contract of
-     * {@link java.io.DataOutputStream#write(int)}.
+     * Writes a byte directly to the output. See the general contract of
+     * {@link java.io.DataOutputStream#write(int)}. Unencoded bytes written by
+     * this method are not reflected in the value returned by
+     * {@link #getCount()}.
      * 
      * @param b
      *            the (unsigned) byte value to write.
@@ -176,13 +181,14 @@ public abstract class OutputEncoder {
     protected synchronized void write(int b) throws IOException {
         flush();
         out.write(b);
-        count++;
     }
 
     /**
-     * Writes up to the specified number of bytes from a buffer to the stream.
-     * See the general contract of
-     * {@link java.io.DataOutputStream#write(byte[], int, int)}.
+     * Writes up to the specified number of bytes from a buffer directly to the
+     * output. See the general contract of
+     * {@link java.io.DataOutputStream#write(byte[], int, int)}. The number of
+     * unencoded bytes written by this method are not reflected in the value
+     * returned by {@link #getCount()}.
      * 
      * @param b
      *            the buffer
@@ -197,7 +203,6 @@ public abstract class OutputEncoder {
     protected synchronized void write(byte[] b, int start, int length) throws IOException {
         flush();
         out.write(b, start, length);
-        count += length;
     }
 
     /**

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -32,7 +32,11 @@ package nom.tam.fits.test;
  */
 
 import static nom.tam.fits.header.Standard.NAXISn;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -51,6 +55,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import nom.tam.fits.AsciiTableHDU;
 import nom.tam.fits.BadData;
@@ -76,24 +85,13 @@ import nom.tam.fits.header.Standard;
 import nom.tam.fits.utilities.FitsCheckSum;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayFuncs;
+import nom.tam.util.Cursor;
+import nom.tam.util.FitsFile;
 import nom.tam.util.FitsInputStream;
 import nom.tam.util.FitsOutputStream;
-import nom.tam.util.FitsFile;
-import nom.tam.util.Cursor;
 import nom.tam.util.LoggerHelper;
 import nom.tam.util.SafeClose;
 import nom.tam.util.test.ThrowAnyException;
-
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.MethodRule;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
-import org.junit.runners.model.FrameworkMethod;
 
 public class BaseFitsTest {
 
@@ -115,14 +113,14 @@ public class BaseFitsTest {
     public static final String FILE = "file:" + File.separator + File.separator + File.separator;
 
     private static final String TMP_FITS_NAME = "tmp.fits";
-    
-//    @Rule
-//    public TestRule watcher = new TestWatcher() {
-//       protected void starting(Description description) {
-//          System.out.println("Starting test: " + description.getMethodName());
-//       }
-//    };
-    
+
+    // @Rule
+    // public TestRule watcher = new TestWatcher() {
+    // protected void starting(Description description) {
+    // System.out.println("Starting test: " + description.getMethodName());
+    // }
+    // };
+
     @Before
     public void setup() {
         FitsFactory.setUseAsciiTables(true);
@@ -138,7 +136,7 @@ public class BaseFitsTest {
     public void cleanup() {
         new File(TMP_FITS_NAME).delete();
     }
-    
+
     @Test
     public void testFitsSkipHdu() throws Exception {
         Fits fits1 = makeAsciiTable();
@@ -153,12 +151,8 @@ public class BaseFitsTest {
 
         hdu2.info(System.out);
         hdu3.info(System.out);
-        Assert.assertArrayEquals(new int[]{
-            11
-        }, (int[]) hdu2.getData().getElement(1, 1));
-        Assert.assertArrayEquals(new int[]{
-            41
-        }, (int[]) hdu3.getData().getElement(1, 1));
+        Assert.assertArrayEquals(new int[] {11}, (int[]) hdu2.getData().getElement(1, 1));
+        Assert.assertArrayEquals(new int[] {41}, (int[]) hdu3.getData().getElement(1, 1));
         hdu3.getData();
 
     }
@@ -191,12 +185,8 @@ public class BaseFitsTest {
         fits1.readHDU();
         AsciiTableHDU hdu2 = (AsciiTableHDU) fits1.readHDU();
         AsciiTableHDU hdu3 = (AsciiTableHDU) fits1.readHDU();
-        Assert.assertArrayEquals(new int[]{
-            11
-        }, (int[]) hdu2.getData().getElement(1, 1));
-        Assert.assertArrayEquals(new int[]{
-            41
-        }, (int[]) hdu3.getData().getElement(1, 1));
+        Assert.assertArrayEquals(new int[] {11}, (int[]) hdu2.getData().getElement(1, 1));
+        Assert.assertArrayEquals(new int[] {41}, (int[]) hdu3.getData().getElement(1, 1));
         hdu3.getData();
 
     }
@@ -257,13 +247,7 @@ public class BaseFitsTest {
         for (int i = 0; i < realCol.length; i += 1) {
             strCol[i] = "ABC" + String.valueOf(realCol[i]) + "CDE";
         }
-        return new Object[]{
-            realCol,
-            intCol,
-            longCol,
-            doubleCol,
-            strCol
-        };
+        return new Object[] {realCol, intCol, longCol, doubleCol, strCol};
     }
 
     @Test
@@ -279,12 +263,8 @@ public class BaseFitsTest {
 
         hdu2.info(System.out);
         hdu3.info(System.out);
-        Assert.assertArrayEquals(new int[]{
-            11
-        }, (int[]) hdu2.getData().getElement(1, 1));
-        Assert.assertArrayEquals(new int[]{
-            41
-        }, (int[]) hdu3.getData().getElement(1, 1));
+        Assert.assertArrayEquals(new int[] {11}, (int[]) hdu2.getData().getElement(1, 1));
+        Assert.assertArrayEquals(new int[] {41}, (int[]) hdu3.getData().getElement(1, 1));
         hdu3.getData();
     }
 
@@ -591,12 +571,7 @@ public class BaseFitsTest {
 
     @Test
     public void testFitsRandomGroupDataWrite() throws Exception {
-        RandomGroupsData data = new RandomGroupsData(new Object[][]{
-            new Object[]{
-                new int[10],
-                new int[10],
-            }
-        });
+        RandomGroupsData data = new RandomGroupsData(new Object[][] {new Object[] {new int[10], new int[10],}});
         FitsOutputStream out = new FitsOutputStream(new ByteArrayOutputStream()) {
 
             @Override
@@ -619,12 +594,7 @@ public class BaseFitsTest {
     public void testFitsRandomGroupDataRead() throws Exception {
         ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
         FitsOutputStream out = new FitsOutputStream(outBytes);
-        Object[][] dataArray = new Object[][]{
-            new Object[]{
-                new int[10],
-                new int[10],
-            }
-        };
+        Object[][] dataArray = new Object[][] {new Object[] {new int[10], new int[10],}};
         out.writeArray(dataArray);
         out.close();
 
@@ -654,7 +624,7 @@ public class BaseFitsTest {
 
             @Override
             public void skipAllBytes(long toSkip) throws IOException {
-               throw new IOException();
+                throw new IOException();
             }
         };
         actual = null;
@@ -753,7 +723,8 @@ public class BaseFitsTest {
         Assert.assertNotNull(actual);
         actual = null;
         try {
-            new Fits(new URL(FILE + new File("src/test/resources/nom/tam/fits/test/test.fitsX").getAbsolutePath()), false);
+            new Fits(new URL(FILE + new File("src/test/resources/nom/tam/fits/test/test.fitsX").getAbsolutePath()),
+                    false);
         } catch (FitsException ex) {
             actual = ex;
         }
@@ -894,9 +865,7 @@ public class BaseFitsTest {
 
     @Test
     public void testDataRepositionErrors() throws Exception {
-        final int[] fail = {
-            100
-        };
+        final int[] fail = {100};
         TestUndefinedData data = new TestUndefinedData(new byte[10]);
         FitsException expected = null;
         try {
@@ -929,7 +898,7 @@ public class BaseFitsTest {
         Assert.assertNotNull(expected);
         // AK: There is no good reason why reset should fail, as the contract of seek() allows
         // going beyond the end of file...
-        //Assert.assertFalse(data.reset());
+        // Assert.assertFalse(data.reset());
     }
 
     @Test
@@ -1002,16 +971,15 @@ public class BaseFitsTest {
 
     @Test(expected = FitsException.class)
     public void testFitsWriteException1() throws Exception {
-        DataOutput out = (DataOutput) Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{
-            DataOutput.class
-        }, new InvocationHandler() {
+        DataOutput out = (DataOutput) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class[] {DataOutput.class}, new InvocationHandler() {
 
-            @Override
-            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                return null;
-            }
-        });
-        
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                        return null;
+                    }
+                });
+
         new Fits().write(out);
     }
 
@@ -1024,7 +992,7 @@ public class BaseFitsTest {
                 throw new IOException("failed flush");
             }
         };
-        
+
         new Fits().write(out);
     }
 
@@ -1162,43 +1130,43 @@ public class BaseFitsTest {
     public void testFitsReadEmpty() throws Exception {
         Assert.assertArrayEquals(new BasicHDU<?>[0], new Fits().read());
     }
-    
+
     @Test()
     public void testFitsSaveClose() throws Exception {
         byte[] b = new byte[80];
         Exception ex = null;
-        
+
         FileInputStream in = new FileInputStream(new File("src/test/resources/nom/tam/fits/test/test.fits.gz"));
-        
+
         assertEquals(b.length, in.read(b));
-        
+
         Fits.saveClose(in);
-        
+
         try {
             in.read(b);
-        } catch(IOException e) {
+        } catch (IOException e) {
             ex = e;
         }
-        
+
         Assert.assertNotNull(ex);
-        
+
         Fits.saveClose(in);
-        
+
         try {
             in.read(b);
-        } catch(IOException e) {
+        } catch (IOException e) {
             ex = e;
         }
-        
-        Assert.assertNotNull(ex);   
+
+        Assert.assertNotNull(ex);
     }
-    
+
     @Test
     public void testWriteToFileName() throws Exception {
         new Fits().write(TMP_FITS_NAME);
         assertTrue(new File(TMP_FITS_NAME).exists());
     }
-    
+
     @Test
     public void testWriteToFitsFile() throws Exception {
         FitsFile f = new FitsFile(TMP_FITS_NAME, "rw");
@@ -1206,7 +1174,7 @@ public class BaseFitsTest {
         f.close();
         assertTrue(new File(TMP_FITS_NAME).exists());
     }
-    
+
     @Test
     public void testWriteToFitsFileAsDataOutput() throws Exception {
         FitsFile f = new FitsFile(TMP_FITS_NAME, "rw");
@@ -1214,7 +1182,7 @@ public class BaseFitsTest {
         f.close();
         assertTrue(new File(TMP_FITS_NAME).exists());
     }
-    
+
     @Test(expected = FitsException.class)
     public void testWriteToFitsStreamAsDataOutputException() throws Exception {
         FitsOutputStream o = new FitsOutputStream(new FileOutputStream(new File(TMP_FITS_NAME))) {
@@ -1225,7 +1193,7 @@ public class BaseFitsTest {
         new Fits().write((DataOutput) o);
         o.close();
     }
-    
+
     @Test
     public void nAxisNullTest() throws Exception {
         Header h = new Header();
@@ -1233,7 +1201,7 @@ public class BaseFitsTest {
         BasicHDU<?> hdu = new ImageHDU(h, null);
         assertNull(hdu.getAxes());
     }
-    
+
     @Test
     public void writeEmptyHDUTest() throws Exception {
         byte[] preamble = new byte[100];
@@ -1244,13 +1212,13 @@ public class BaseFitsTest {
         o.flush();
         assertEquals(hdu.getHeader().getSize(), f.length());
     }
-    
+
     @Test
     public void emptyHDUTest() throws Exception {
         BasicHDU<?> hdu = new ImageHDU(null, null);
         assertEquals(0, hdu.getSize());
     }
-    
+
     @Test
     public void trimmedCommentStringTest() throws Exception {
         Header h = new Header();
@@ -1258,7 +1226,6 @@ public class BaseFitsTest {
         BasicHDU<?> hdu = new ImageHDU(h, null);
         assertNull(hdu.getTrimmedString(Standard.COMMENT));
     }
-    
 
     @Test
     public void rewriteTest() throws Exception {
@@ -1266,16 +1233,36 @@ public class BaseFitsTest {
         fits.read();
         fits.rewrite();
     }
-    
+
     @Test(expected = FitsException.class)
     public void rewriteTestException() throws Exception {
         Fits fits = new Fits(new File("src/test/resources/nom/tam/fits/test/test.fits"));
         Header h = fits.readHDU().getHeader();
         for (int i = 0; i < 36; i++) {
-            h.addValue("TEST" + (i+1), "blah", "blah");
+            h.addValue("TEST" + (i + 1), "blah", "blah");
         }
         fits.rewrite();
     }
-    
+
+    @Test
+    public void autoExtensionTest() throws Exception {
+        Fits fits = new Fits();
+
+        fits.addHDU(BasicHDU.getDummyHDU());
+        fits.addHDU(FitsFactory.hduFactory(new int[10][10]));
+        fits.write("target/auto_ext_test.fits");
+
+        fits = new Fits("target/auto_ext_test.fits");
+        BasicHDU<?>[] hdus = fits.read();
+
+        assertNotNull(hdus);
+        assertEquals(2, hdus.length);
+
+        assertTrue(hdus[0].getHeader().containsKey(Standard.SIMPLE));
+        assertFalse(hdus[0].getHeader().containsKey(Standard.XTENSION));
+
+        assertFalse(hdus[1].getHeader().containsKey(Standard.SIMPLE));
+        assertTrue(hdus[1].getHeader().containsKey(Standard.XTENSION));
+    }
 
 }

--- a/src/test/java/nom/tam/fits/test/ChecksumTest.java
+++ b/src/test/java/nom/tam/fits/test/ChecksumTest.java
@@ -34,8 +34,8 @@ package nom.tam.fits.test;
 import static nom.tam.fits.header.Checksum.CHECKSUM;
 import static nom.tam.fits.header.Checksum.DATASUM;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -43,26 +43,25 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.util.Arrays;
 
+import org.junit.Ignore;
+import org.junit.Test;
+
 import nom.tam.fits.BasicHDU;
 import nom.tam.fits.Fits;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.FitsFactory;
 import nom.tam.fits.Header;
-import nom.tam.fits.HeaderCard;
 import nom.tam.fits.ImageData;
 import nom.tam.fits.ImageHDU;
 import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.Standard;
 import nom.tam.fits.utilities.FitsCheckSum;
+import nom.tam.util.ArrayDataOutput;
+import nom.tam.util.FitsIO;
 import nom.tam.util.FitsInputStream;
 import nom.tam.util.FitsOutputStream;
-import nom.tam.util.ArrayDataOutput;
-import nom.tam.util.Cursor;
-import nom.tam.util.FitsIO;
+import nom.tam.util.RandomAccess;
 import nom.tam.util.test.ThrowAnyException;
-
-import org.junit.Test;
-import org.junit.Ignore;
 
 /**
  * @author tmcglynn
@@ -76,20 +75,7 @@ public class ChecksumTest {
 
     @Test(expected = FitsException.class)
     public void testChecksumDataFailException() throws Exception {
-        int[][] data = new int[][]{
-            {
-                1,
-                2
-            },
-            {
-                3,
-                4
-            },
-            {
-                5,
-                6
-            }
-        };
+        int[][] data = new int[][] {{1, 2}, {3, 4}, {5, 6}};
         ImageData d = ImageHDU.encapsulate(data);
         Header h = ImageHDU.manufactureHeader(d);
         BasicHDU<?> bhdu = new ImageHDU(h, d) {
@@ -106,23 +92,10 @@ public class ChecksumTest {
 
     @Test
     public void testChecksum() throws Exception {
-     // AK: This test requires long strings to be disabled.
+        // AK: This test requires long strings to be disabled.
         FitsFactory.setLongStringsEnabled(false);
         Fits f = new Fits();
-        int[][] data = new int[][]{
-            {
-                1,
-                2
-            },
-            {
-                3,
-                4
-            },
-            {
-                5,
-                6
-            }
-        };
+        int[][] data = new int[][] {{1, 2}, {3, 4}, {5, 6}};
         BasicHDU<?> bhdu1 = FitsFactory.hduFactory(data);
 
         BasicHDU<?> bhdu = bhdu1;
@@ -163,7 +136,7 @@ public class ChecksumTest {
         assertEquals("kGpMn9mJkEmJk9mJ", fits.getHDU(0).getHeader().getStringValue("CHECKSUM"));
     }
 
-    // TODO This test fails in the CI for some reason, but not locally. 
+    // TODO This test fails in the CI for some reason, but not locally.
     @Ignore
     @Test
     public void testIntegerOverflowChecksum() throws Exception {
@@ -177,22 +150,22 @@ public class ChecksumTest {
         imageHdu.setChecksum();
         assertEquals("CVfXFTeVCTeVCTeV", imageHdu.getHeader().card(CHECKSUM).card().getValue());
     }
-        
+
     @Test
     public void testCheckSumDeferred() throws Exception {
         Fits fits = new Fits("src/test/resources/nom/tam/fits/test/test.fits");
         ImageHDU im = (ImageHDU) fits.readHDU();
-        
+
         assertTrue("deferred before checksum", im.getData().isDeferred());
         fits.setChecksum();
-        assertTrue("deferrred after checksum", im.getData().isDeferred());  
+        assertTrue("deferrred after checksum", im.getData().isDeferred());
         String sum1 = im.getHeader().getStringValue(CHECKSUM);
-        
+
         // Now load the data in RAM and repeat.
         im.getData().getData();
         assertFalse("loaded before checksum", im.getData().isDeferred());
         fits.setChecksum();
-        
+
         String sum2 = im.getHeader().getStringValue(CHECKSUM);
         assertEquals(sum1, sum2);
     }
@@ -202,69 +175,69 @@ public class ChecksumTest {
         Fits fits = new Fits("src/test/resources/nom/tam/fits/test/test.fits");
         fits.read();
         fits.setChecksum();
-        
+
         ImageHDU im = (ImageHDU) fits.getHDU(0);
         Header h = im.getHeader();
-        
+
         // Deferred read
         assertEquals(FitsCheckSum.checksum(im.getData()), im.getStoredDatasum());
         assertEquals(FitsCheckSum.checksum(im), im.getStoredChecksum());
         assertEquals(fits.calcChecksum(0), im.getStoredChecksum());
-        
+
         // in-memory
         im.setChecksum();
         assertEquals(im.getData().calcChecksum(), im.getStoredDatasum());
         assertEquals(im.calcChecksum(), im.getStoredChecksum());
     }
-    
+
     @Test
     public void testCheckSumVerifyFail() throws Exception {
         Fits fits = new Fits("src/test/resources/nom/tam/fits/test/test.fits");
         fits.read();
         fits.setChecksum();
-        
+
         ImageHDU im = (ImageHDU) fits.getHDU(0);
         Header h = im.getHeader();
-        
+
         short[][] data = (short[][]) im.getData().getData();
         data[0][0]++;
-        
+
         // Deferree read
         assertNotEquals(FitsCheckSum.checksum(im.getData()), im.getStoredDatasum());
         assertNotEquals(FitsCheckSum.checksum(im), im.getStoredChecksum());
         assertNotEquals(fits.calcChecksum(0), im.getStoredChecksum());
-        
+
         // in-memory
         assertNotEquals(im.getData().calcChecksum(), im.getStoredDatasum());
         assertNotEquals(im.calcChecksum(), im.getStoredChecksum());
     }
-    
+
     @Test
     public void testCheckSumIncrement() throws Exception {
         Fits fits = new Fits("src/test/resources/nom/tam/fits/test/test.fits");
         fits.read();
         fits.setChecksum();
-        
+
         ImageHDU im = (ImageHDU) fits.getHDU(0);
         Header h = im.getHeader();
-        
+
         short[][] data = (short[][]) im.getData().getData();
-        
+
         data[0][0]++;
-        
+
         FitsCheckSum.setDatasum(h, FitsCheckSum.checksum(im.getData()));
-        
+
         // Deferred read
         assertEquals(FitsCheckSum.checksum(im.getData()), im.getStoredDatasum());
         assertEquals(FitsCheckSum.checksum(im), im.getStoredChecksum());
         assertEquals(fits.calcChecksum(0), im.getStoredChecksum());
-        
+
         // in-memory
         im.setChecksum();
         assertEquals(im.getData().calcChecksum(), im.getStoredDatasum());
         assertEquals(im.calcChecksum(), im.getStoredChecksum());
     }
-    
+
     @Test
     public void testCheckSumDecode() throws Exception {
         long sum = 20220829;
@@ -274,7 +247,7 @@ public class ChecksumTest {
         assertEquals(sum, FitsCheckSum.decode(FitsCheckSum.checksumEnc(sum, false), false));
         assertEquals(sum, FitsCheckSum.decode(FitsCheckSum.checksumEnc(sum, true), true));
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void testCheckSumDecodeInvalidLength() throws Exception {
         FitsCheckSum.decode("");
@@ -286,7 +259,7 @@ public class ChecksumTest {
         Arrays.fill(b, (byte) 0x2f);
         FitsCheckSum.decode(new String(b));
     }
-    
+
     @Test(expected = FitsException.class)
     public void testCheckSumNoDatasum() throws Exception {
         FitsCheckSum.getStoredDatasum(new Header());
@@ -296,12 +269,12 @@ public class ChecksumTest {
     public void testCheckSumNoChecksum() throws Exception {
         FitsCheckSum.getStoredChecksum(new Header());
     }
-    
+
     @Test
     public void testCheckSumwWrap() throws Exception {
         assertEquals(0, FitsCheckSum.sumOf(Integer.MAX_VALUE, Integer.MAX_VALUE) & ~FitsIO.INTEGER_MASK);
     }
-    
+
     @Test
     public void testCheckSumAutoAdd() throws Exception {
         Header h = new Header();
@@ -322,19 +295,18 @@ public class ChecksumTest {
         FitsCheckSum.checksum(h);
         assertEquals("blah", h.getStringValue(CHECKSUM));
     }
-    
+
     @Test
     public void testCheckSumSubtract() throws Exception {
         long a = 20220829;
         long b = 19740131;
-        
+
         long sum = FitsCheckSum.sumOf(a, b);
-    
+
         assertEquals(b, FitsCheckSum.differenceOf(sum, a));
         assertEquals(a, FitsCheckSum.differenceOf(sum, b));
     }
-    
-    
+
     @Test(expected = FitsException.class)
     public void testSetChecksumFitsException() throws Exception {
         ImageData data = new ImageData() {
@@ -343,16 +315,16 @@ public class ChecksumTest {
                 throw new FitsException("not implemented");
             }
         };
-        
+
         Header h = new Header();
         h.setSimple(true);
         h.setBitpix(Bitpix.INTEGER);
         h.setNaxes(0);
-        
+
         ImageHDU im = new ImageHDU(h, data);
         FitsCheckSum.setChecksum(im);
     }
-    
+
     @Test
     public void testChecksumFitsLoaded() throws Exception {
         Fits fits = new Fits(new File("src/test/resources/nom/tam/fits/test/test.fits"));
@@ -377,7 +349,7 @@ public class ChecksumTest {
         assertNotEquals(0, hdu.getStoredChecksum());
         assertNotEquals(0, hdu.getStoredDatasum());
     }
-    
+
     @Test
     public void testChecksumFitsCreated() throws Exception {
         int[][] data = new int[5][5];
@@ -392,5 +364,9 @@ public class ChecksumTest {
         assertNotEquals(0, hdu.getStoredChecksum());
         assertNotEquals(0, hdu.getStoredDatasum());
     }
-    
+
+    public void testChecksumNullFile() throws Exception {
+        assertEquals(0, FitsCheckSum.checksum((RandomAccess) null, 0, 1000));
+    }
+
 }

--- a/src/test/java/nom/tam/fits/test/ChecksumTest.java
+++ b/src/test/java/nom/tam/fits/test/ChecksumTest.java
@@ -365,6 +365,7 @@ public class ChecksumTest {
         assertNotEquals(0, hdu.getStoredDatasum());
     }
 
+    @Test
     public void testChecksumNullFile() throws Exception {
         assertEquals(0, FitsCheckSum.checksum((RandomAccess) null, 0, 1000));
     }


### PR DESCRIPTION
`FitsOutputStream` did not count unencoded bytes (such as header entries) when determining whether a HDU should be written as primary or as an extension at the head of a stream. Hence, HDUs following a header-only primary HDU were incorrectly written as primary.

This pull request provides a fix to the issue.