### PR TITLE
Coverage reporting to Coveralls.io

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
         
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
-      run: mvn coveralls:report -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
+      run: mvn coveralls:report -DrepoToken=${{secrets.COVERALLS_REPO_TOKEN}}
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
         
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
-      run: mvn coveralls:report --define repoToken=${{ secrets.COVERALLS_TOKEN }}
+      run: mvn coveralls:report --define repoToken=${{ secrets.COVERALL_ALT_TOKEN }}
         
     - name: Check Project Site
       run: mvn -B site:stage

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -68,7 +68,8 @@ jobs:
       continue-on-error: true
       env:
         REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: mvn coveralls:report
+      run: |
+        mvn coveralls:report -DrepoToken=$REPO_TOKEN
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,8 +67,7 @@ jobs:
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
       run: mvn coveralls:report --define repoToken=${{ secrets.COVERALL_ALT_TOKEN }}
-      with:
-        working-directory: ./nom-tam-fits
+      working-directory: ./nom-tam-fits
         
     - name: Check Project Site
       run: mvn -B site:stage

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -68,7 +68,7 @@ jobs:
       env:
         COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       continue-on-error: true
-      run: mvn -DrepoToken=${{ env.COVERALLS_TOKEN }} coveralls:report
+      run: mvn -DrepoToken=$COVERALLS_TOKEN coveralls:report
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,10 +65,8 @@ jobs:
         verbose: true
         
     - name: Upload coverage to Coveralls.io
-      env:
-        COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       continue-on-error: true
-      run: mvn coveralls:report
+      run: mvn -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }} coveralls:report
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
         
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
-      run: mvn org.eluder.coveralls:coveralls-maven-plugin:report --define repoToken=${{ secrets.COVERALL_ALT_TOKEN }}
+      run: mvn coveralls:report --define repoToken=${{ secrets.COVERALL_ALT_TOKEN }}
       with:
         working-directory: ./nom-tam-fits
         

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,9 +67,9 @@ jobs:
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |
-        mvn coveralls:report -DrepoToken=${{ env.COVERALLS_REPO_TOKEN }}
+        mvn coveralls:report -DrepoToken=$COVERALLS_TOKEN
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,6 +67,8 @@ jobs:
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
       run: mvn org.eluder.coveralls:coveralls-maven-plugin:report --define repoToken=${{ secrets.COVERALL_ALT_TOKEN }}
+      with:
+        working-directory: ./nom-tam-fits
         
     - name: Check Project Site
       run: mvn -B site:stage

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,8 +65,10 @@ jobs:
         verbose: true
         
     - name: Upload coverage to Coveralls.io
+      env:
+        COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       continue-on-error: true
-      run: mvn coveralls:report -Dcoveralls.repoToken=${{secrets.COVERALLS_REPO_TOKEN}}
+      run: mvn coveralls:report
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
         
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
-      run: mvn coveralls:report --define repoToken=${{ secrets.COVERALL_ALT_TOKEN }}
+      run: mvn org.eluder.coveralls:coveralls-maven-plugin:report --define repoToken=${{ secrets.COVERALL_ALT_TOKEN }}
         
     - name: Check Project Site
       run: mvn -B site:stage

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
         
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
-      run: mvn coveralls:report --define repoToken=${{ secrets.COVERALL_ALT_TOKEN }}
+      run: mvn coveralls:report --define repoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -64,7 +64,8 @@ jobs:
         name: codecov
         verbose: true
         
-    - name: Coveralls report
+    - name: Upload coverage to Coveralls.io
+      continue-on-error: true
       run: mvn coveralls:report --define repoToken=${{ secrets.COVERALLS_TOKEN }}
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
         
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
-      run: mvn coveralls:report --define repoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
+      run: mvn coveralls:report -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }}
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,10 +65,10 @@ jobs:
         verbose: true
         
     - name: Upload coverage to Coveralls.io
+      continue-on-error: true
       env:
         COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      continue-on-error: true
-      run: mvn -DrepoToken=$COVERALLS_TOKEN coveralls:report
+      run: mvn -DrepoToken="$COVERALLS_TOKEN" coveralls:report
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -64,6 +64,9 @@ jobs:
         name: codecov
         verbose: true
         
+    - name: Coveralls report
+      run: mvn coveralls:report --define repoToken=${{ secrets.COVERALLS_TOKEN }}
+        
     - name: Check Project Site
       run: mvn -B site:stage
       working-directory: ./nom-tam-fits

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,8 +67,8 @@ jobs:
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
       env:
-        COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: mvn -DrepoToken="$COVERALLS_TOKEN" coveralls:report
+        REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      run: mvn coveralls:report
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
         
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
-      run: mvn coveralls:report -DrepoToken=${{secrets.COVERALLS_REPO_TOKEN}}
+      run: mvn coveralls:report -Dcoveralls.repoToken=${{secrets.COVERALLS_REPO_TOKEN}}
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,8 +65,10 @@ jobs:
         verbose: true
         
     - name: Upload coverage to Coveralls.io
+      env:
+        COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       continue-on-error: true
-      run: mvn -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }} coveralls:report
+      run: mvn -DrepoToken=${{ env.COVERALLS_TOKEN }} coveralls:report
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -67,9 +67,9 @@ jobs:
     - name: Upload coverage to Coveralls.io
       continue-on-error: true
       env:
-        REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: |
-        mvn coveralls:report -DrepoToken=$REPO_TOKEN
+        mvn coveralls:report -DrepoToken=${{ env.COVERALLS_REPO_TOKEN }}
       working-directory: ./nom-tam-fits
         
     - name: Check Project Site

--- a/pom.xml
+++ b/pom.xml
@@ -392,9 +392,6 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
-        <configuration>
-           <repoToken>${env.REPO_TOKEN}</repoToken>
-        </configuration>
         <dependencies>
           <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,13 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+        </dependencies>
       </plugin>
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,7 @@
 				</executions>
 			</plugin>
 			<plugin>
+			  <!-- Coveralls integration -->
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<!-- TODO Update to 3.0.0-M4 or later -->
 				<version>3.0.0-M7</version>
 				<configuration>
 					<mavenExecutorId>forked-path</mavenExecutorId>

--- a/pom.xml
+++ b/pom.xml
@@ -392,9 +392,6 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
-        <configuration>
-          <repoToken>${env.COVERALLS_TOKEN}</repoToken>
-        </configuration>
         <dependencies>
           <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,11 @@
 				</executions>
 			</plugin>
 			<plugin>
+        <groupId>org.eluder.coveralls</groupId>
+        <artifactId>coveralls-maven-plugin</artifactId>
+        <version>4.3.0</version>
+      </plugin>
+			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
 				<version>4.7.2.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,9 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
+        <configuration>
+          <repoToken>${env.COVERALLS_TOKEN}</repoToken>
+        </configuration>
         <dependencies>
           <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
 				</executions>
 			</plugin>
 			<plugin>
-			  <!-- Coveralls integration -->
+        <!-- Coveralls integration -->
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -392,9 +392,6 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
-        <configuration>
-          <repoToken>yourcoverallsprojectrepositorytoken</repoToken>
-        </configuration>
         <dependencies>
           <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,9 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
+        <configuration>
+          <repoToken>yourcoverallsprojectrepositorytoken</repoToken>
+        </configuration>
         <dependencies>
           <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -392,6 +392,9 @@
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
         <version>4.3.0</version>
+        <configuration>
+           <repoToken>${env.REPO_TOKEN}</repoToken>
+        </configuration>
         <dependencies>
           <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/settings.xml
+++ b/settings.xml
@@ -1,4 +1,7 @@
 <settings>
+  <pluginGroups>
+    <pluginGroup>org.eluder.coveralls</pluginGroup>
+	</pluginGroups>
   <servers>
     <server>
       <id>nexus</id>

--- a/settings.xml
+++ b/settings.xml
@@ -1,7 +1,4 @@
 <settings>
-  <pluginGroups>
-    <pluginGroup>org.eluder.coveralls</pluginGroup>
-	</pluginGroups>
   <servers>
     <server>
       <id>nexus</id>


### PR DESCRIPTION
Unfortunately Codecov has been a pain lately, mostly not doing what it's supposed to be doing to track coverage changes. At the same time, it looks like coveralls.io is back in the game with GitHub Actions, so let's upload coverage reports to it also.