### PR TITLE
Use ZDITHER0 and seed dither random generator for each tile as prescribed

### DIFF
--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -81,6 +81,8 @@ public class QuantizeOption implements ICompressOption {
 
     private long seed = 1L;
 
+    private int tileIndex = 0;
+
     private int tileHeight;
 
     private int tileWidth;
@@ -173,6 +175,10 @@ public class QuantizeOption implements ICompressOption {
 
     public long getSeed() {
         return this.seed;
+    }
+
+    public long getTileIndex() {
+        return this.tileIndex;
     }
 
     public int getTileHeight() {
@@ -298,8 +304,32 @@ public class QuantizeOption implements ICompressOption {
         return this;
     }
 
+    /**
+     * Sets the seed value for the dither random generator
+     * 
+     * @param value The seed value, as in <code>ZDITHER0</code>, normally a number between 1 and 10000 (inclusive).
+     * 
+     * @return itself
+     * 
+     * @see #setTileIndex(int)
+     */
     public QuantizeOption setSeed(long value) {
         this.seed = value;
+        return this;
+    }
+
+    /**
+     * Sets the tile index for which to initialize the random number generator with the given seed (i.e.
+     * <code>ZDITHER0</code> value).
+     * 
+     * @param index The 0-based tile index
+     * 
+     * @return itself
+     * 
+     * @see #setSeed(long)
+     */
+    public QuantizeOption setTileIndex(int index) {
+        this.tileIndex = index;
         return this;
     }
 

--- a/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
+++ b/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
@@ -265,6 +265,10 @@ public class CompressorProvider implements ICompressorProvider {
         @Override
         public void setValuesInHeader(IHeaderAccess header) {
         }
+
+        @Override
+        public void setTileIndex(int index) {
+        }
     };
 
     // @formatter:off

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameters.java
@@ -60,6 +60,13 @@ public interface ICompressParameters {
     ICompressParameters copy(ICompressOption option);
 
     /**
+     * Initialize parameters for the given tile index
+     * 
+     * @param index the 0-based tile index
+     */
+    void setTileIndex(int index);
+
+    /**
      * extract the option data from the column and set it in the option.
      * 
      * @param index the index in the column.

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/BundledParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/BundledParameters.java
@@ -128,4 +128,10 @@ public class BundledParameters extends CompressParameters {
         return list.toArray(array);
     }
 
+    @Override
+    public void setTileIndex(int index) {
+        for (ICompressParameters parms : bundle) {
+            parms.setTileIndex(index);
+        }
+    }
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
@@ -65,6 +65,10 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
     }
 
     @Override
+    public void setTileIndex(int index) {
+    }
+
+    @Override
     public void getValuesFromColumn(int index) {
         for (ICompressColumnParameter parameter : columnParameters()) {
             parameter.getValueFromColumn(index);

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
@@ -38,6 +38,12 @@ import nom.tam.fits.compression.provider.param.api.ICompressColumnParameter;
 import nom.tam.fits.compression.provider.param.api.ICompressHeaderParameter;
 import nom.tam.fits.compression.provider.param.base.CompressParameters;
 
+/**
+ * A set of compression parameters used for quantization of floating point data. Quantization is the process of
+ * representing floating-point values by integers.
+ * 
+ * @author Attila Kovacs
+ */
 public class QuantizeParameters extends CompressParameters {
 
     private ZQuantizeParameter quantz;
@@ -52,6 +58,12 @@ public class QuantizeParameters extends CompressParameters {
 
     private ZScaleColumnParameter scale;
 
+    /**
+     * Creates a set of compression parameters used for quantization of floating point data. Quantization is the process
+     * of representing floating-point values by integers.
+     * 
+     * @param option The compression option that is configured with the particular parameter values of this object.
+     */
     public QuantizeParameters(QuantizeOption option) {
         this.quantz = new ZQuantizeParameter(option);
         this.blank = new ZBlankParameter(option);

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
@@ -44,6 +44,8 @@ public class QuantizeParameters extends CompressParameters {
 
     private ZBlankParameter blank;
 
+    private ZDither0Parameter seed;
+
     private ZBlankColumnParameter blankColumn;
 
     private ZZeroColumnParameter zero;
@@ -53,6 +55,7 @@ public class QuantizeParameters extends CompressParameters {
     public QuantizeParameters(QuantizeOption option) {
         this.quantz = new ZQuantizeParameter(option);
         this.blank = new ZBlankParameter(option);
+        this.seed = new ZDither0Parameter(option);
         this.blankColumn = new ZBlankColumnParameter(option);
         this.zero = new ZZeroColumnParameter(option);
         this.scale = new ZScaleColumnParameter(option);
@@ -65,7 +68,12 @@ public class QuantizeParameters extends CompressParameters {
 
     @Override
     protected ICompressHeaderParameter[] headerParameters() {
-        return new ICompressHeaderParameter[] {this.quantz, this.blank};
+        return new ICompressHeaderParameter[] {this.quantz, this.blank, this.seed};
+    }
+
+    @Override
+    public void setTileIndex(int index) {
+        seed.setTileIndex(index);
     }
 
     @Override
@@ -76,6 +84,7 @@ public class QuantizeParameters extends CompressParameters {
             QuantizeParameters p = (QuantizeParameters) super.clone();
             p.quantz = (ZQuantizeParameter) quantz.copy(qo);
             p.blank = (ZBlankParameter) blank.copy(qo);
+            p.seed = (ZDither0Parameter) seed.copy(qo);
             p.blankColumn = (ZBlankColumnParameter) blankColumn.copy(qo);
             p.zero = (ZZeroColumnParameter) zero.copy(qo);
             p.scale = (ZScaleColumnParameter) scale.copy(qo);

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
@@ -37,9 +37,43 @@ import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
 import nom.tam.fits.header.Compression;
 
+/**
+ * <p>
+ * The random seed initialization parameter for consistent dither implementations. Dithering adds a small amount of
+ * noise (at the level of the quantization level increments) to remove possible systematics biases of the quantization.
+ * Since the quantization (integer representation of floating-point values) is inherently lossy (noisy) the added
+ * dithering noise is generally inconsequential in terms of preseving information in the original image. As such, the
+ * image can be recovered close enough to the original, within the level of the quantization noise, without knowing the
+ * exact random sequence that was used to generate the dither.
+ * </p>
+ * <p>
+ * However, The FITS standard requires that when dithering is used in the compression the same tool (or library) should
+ * also undo the dithering exactly using the same sequence of random numbers as was used when compressing the image.
+ * Furthermore, the standard makes some explicit suggestions on how pseudo-random sequences should be generated, and
+ * offers a specific convention for an algorithm that may be used to provide consistent dithering across tools,
+ * platforms, and library implementations.
+ * </p>
+ * <p>
+ * For the dithering to be reversible, the FITS header should store the integer value, usually between 1 and 10000
+ * inclusive, under the <code>ZDITHER0</code> keyword to indicate the value (random sequence index) that was used for
+ * seeding the random number generator according to the described standard.
+ * </p>
+ * <p>
+ * The nom-tam FITS library implements the suggested convention for the random number generator, and this parameter
+ * deals with recording the corresponding random seed value via the <code>ZDITHER0</code> keyword in the compressed
+ * image headers; as well as retrieving this value to seed the random number generator when decompressing the image, in
+ * a way that is consistent with the FITS standard and recommended convention.
+ * </p>
+ * 
+ * @author Attila Kovacs
+ */
 final class ZDither0Parameter extends CompressHeaderParameter<QuantizeOption> {
+
     /**
-     * @param quantizeOption
+     * Creates a new compression parameter that can be used to configure the quantization options when cmpressing /
+     * decompressing image tiles.
+     * 
+     * @param quantizeOption The quantization option that will be configured using this particular parameter.
      */
     ZDither0Parameter(QuantizeOption quantizeOption) {
         super(Compression.ZDITHER0.name(), quantizeOption);

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
@@ -1,0 +1,80 @@
+package nom.tam.fits.compression.provider.param.quant;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import nom.tam.fits.HeaderCard;
+import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
+import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
+import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
+import nom.tam.fits.header.Compression;
+
+final class ZDither0Parameter extends CompressHeaderParameter<QuantizeOption> {
+    /**
+     * @param quantizeOption
+     */
+    ZDither0Parameter(QuantizeOption quantizeOption) {
+        super(Compression.ZDITHER0.name(), quantizeOption);
+    }
+
+    @Override
+    public void getValueFromHeader(IHeaderAccess header) {
+        if (getOption() == null) {
+            return;
+        }
+
+        HeaderCard card = header.findCard(Compression.ZDITHER0);
+        getOption().setSeed(card == null ? 1L : card.getValue(Long.class, 1L));
+    }
+
+    @Override
+    public void setValueInHeader(IHeaderAccess header) {
+        if (getOption() == null) {
+            return;
+        }
+
+        header.addValue(Compression.ZDITHER0, (int) getOption().getSeed());
+    }
+
+    /**
+     * Seeds the random generator for the specific tile
+     * 
+     * @param index the 0-based tile index.
+     */
+    void setTileIndex(int index) {
+        if (getOption() == null) {
+            return;
+        }
+
+        getOption().setTileIndex(index);
+    }
+
+}

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
@@ -68,12 +68,11 @@ final class ZDither0Parameter extends CompressHeaderParameter<QuantizeOption> {
      * Seeds the random generator for the specific tile
      * 
      * @param index the 0-based tile index.
+     * 
+     * @throws NullPointerException if the parameter is no linked to a {@link QuantizeOption} instance (that is
+     *             <code>null</code> was specified in the constructor).
      */
-    void setTileIndex(int index) {
-        if (getOption() == null) {
-            return;
-        }
-
+    void setTileIndex(int index) throws NullPointerException {
         getOption().setTileIndex(index);
     }
 

--- a/src/main/java/nom/tam/image/compression/tile/TileCompressor.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileCompressor.java
@@ -79,6 +79,8 @@ public class TileCompressor extends TileCompressionOperation {
         boolean compressSuccess = false;
         boolean tryNormalCompression = !(this.tileOptions.isLossyCompression() && this.forceNoLoss);
 
+        this.tileOptions.getCompressionParameters().setTileIndex(getTileIndex());
+
         if (tryNormalCompression) {
             compressSuccess = getCompressorControl().compress(getTileBuffer().getBuffer(), this.compressedData,
                     this.tileOptions);

--- a/src/main/java/nom/tam/image/compression/tile/TileDecompressor.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileDecompressor.java
@@ -60,6 +60,8 @@ public class TileDecompressor extends TileCompressionOperation {
     private void decompress() {
         initTileOptions();
 
+        this.tileOptions.getCompressionParameters().setTileIndex(getTileIndex());
+
         if (this.compressionType == TileCompressionType.COMPRESSED) {
             this.tileOptions.getCompressionParameters().getValuesFromColumn(getTileIndex());
             getCompressorControl().decompress(this.compressedData, getTileBuffer().getBuffer(), this.tileOptions);

--- a/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
+++ b/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
@@ -1247,4 +1247,18 @@ public class ReadWriteProvidedCompressedImageTest {
             }
         }
     }
+
+    @Test
+    public void testDitherDecompress() throws Exception {
+        Fits fits = new Fits("../blackbox-images/fpack.fits.fz");
+        fits.readHDU();
+        ImageHDU im = ((CompressedImageHDU) fits.readHDU()).asImageHDU();
+        fits.close();
+
+        fits = new Fits("../blackbox-images/funpack.fits");
+        ImageHDU ref = (ImageHDU) fits.readHDU();
+
+        assertArrayEquals((float[][]) ref.getData().getData(), (float[][]) im.getData().getData(), 0.01f);
+        fits.close();
+    }
 }

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -533,16 +533,16 @@ public class QuantizeTest {
         QuantizeOption baseOption = new QuantizeOption();
         QuantizeTestParameters base = new QuantizeTestParameters(baseOption);
         baseOption.setParameters(base);
-        Assert.assertEquals(2, base.headerParameters().length);
+        Assert.assertEquals(3, base.headerParameters().length);
 
         base.initializeColumns(2);
 
         QuantizeOption optionCopy = baseOption.copy();
         QuantizeTestParameters parameters = (QuantizeTestParameters) optionCopy.getCompressionParameters();
-        Assert.assertEquals(2, parameters.headerParameters().length);
+        Assert.assertEquals(3, parameters.headerParameters().length);
 
         optionCopy.setBNull(-999);
-        Assert.assertEquals(2, parameters.headerParameters().length);
+        Assert.assertEquals(3, parameters.headerParameters().length);
         optionCopy.setBNull(99);
 
         parameters.initializeTestColumn();


### PR DESCRIPTION
This PR addresses two related issues:

1. `ZDITHER0` was not used (written or read) to record or seed the random generator when dithering.
2. Initializing the dither random generator an a per-tile basis using `ZDITHER0` as prescribed by the FITS standard.