### PR TITLE
Try alternative coveralls upload (tokenless)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -69,7 +69,7 @@ jobs:
       continue-on-error: true
       with:
         base-path: nom-tam-fits/src/main/java
-        file: nom-tam-fits/target/jacoco-report/jacoco.xml
+        file: nom-tam-fits/target/site/jacoco/jacoco.xml
         
     - name: Check Project Site
       run: mvn -B site:stage

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,16 +65,11 @@ jobs:
         verbose: true
         
     - name: Upload coverage to Coveralls.io
+      uses: coverallsapp/github-action@v2
       continue-on-error: true
-      env:
-        COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: |
-        if [ "$COVERALLS_TOKEN" != "" ] ; then 
-           mvn coveralls:report -DrepoToken=$COVERALLS_TOKEN
-        else
-           echo "WARNING! COVERALLS_REPO_TOKEN secret is undefined. Skipping Coveralls.io upload."
-        fi
-      working-directory: ./nom-tam-fits
+      with:
+        base-path: nom-tam-fits/src/main/java
+        file: nom-tam-fits/target/jacoco-report/jacoco.xml
         
     - name: Check Project Site
       run: mvn -B site:stage


### PR DESCRIPTION
The current upload requires a repo secret, so it does not upload coverage for PRs. There is a pre-release version of a GitHub Actions that should allow tokenless coverage upload to Coveralls.io. Let's see if we can make that work...