### PR TITLE
Issue 390: Restore back compatibility for compression as closely as possible.

### DIFF
--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressor.java
@@ -37,6 +37,8 @@ import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
 
 import nom.tam.fits.compression.algorithm.api.ICompressor;
+import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor.DoubleQuantCompressor;
+import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor.FloatQuantCompressor;
 import nom.tam.util.ArrayFuncs;
 
 public abstract class HCompressor<T extends Buffer> implements ICompressor<T> {
@@ -70,6 +72,18 @@ public abstract class HCompressor<T extends Buffer> implements ICompressor<T> {
             }
         }
 
+    }
+
+    public static class DoubleHCompressor extends DoubleQuantCompressor {
+        public DoubleHCompressor(HCompressorQuantizeOption options) {
+            super(options, new IntHCompressor(options.getHCompressorOption()));
+        }
+    }
+
+    public static class FloatHCompressor extends FloatQuantCompressor {
+        public FloatHCompressor(HCompressorQuantizeOption options) {
+            super(options, new IntHCompressor(options.getHCompressorOption()));
+        }
     }
 
     public static class IntHCompressor extends HCompressor<IntBuffer> {

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorQuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorQuantizeOption.java
@@ -1,0 +1,46 @@
+package nom.tam.fits.compression.algorithm.hcompress;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
+
+public class HCompressorQuantizeOption extends QuantizeOption {
+
+    public HCompressorQuantizeOption() {
+        super(new HCompressorOption());
+    }
+
+    public HCompressorOption getHCompressorOption() {
+        return (HCompressorOption) getCompressOption();
+    }
+
+}

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
@@ -7,6 +7,8 @@ import java.nio.ShortBuffer;
 import java.util.logging.Logger;
 
 import nom.tam.fits.compression.algorithm.api.ICompressor;
+import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor.DoubleQuantCompressor;
+import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor.FloatQuantCompressor;
 import nom.tam.util.FitsIO;
 import nom.tam.util.type.ElementType;
 
@@ -85,6 +87,18 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         @Override
         protected void nextPixel(int pixel) {
             this.pixelBuffer.put((byte) pixel);
+        }
+    }
+
+    public static class DoubleRiceCompressor extends DoubleQuantCompressor {
+        public DoubleRiceCompressor(RiceQuantizeCompressOption options) {
+            super(options, new IntRiceCompressor(options.getRiceCompressOption()));
+        }
+    }
+
+    public static class FloatRiceCompressor extends FloatQuantCompressor {
+        public FloatRiceCompressor(RiceQuantizeCompressOption options) {
+            super(options, new IntRiceCompressor(options.getRiceCompressOption()));
         }
     }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceQuantizeCompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceQuantizeCompressOption.java
@@ -1,0 +1,45 @@
+package nom.tam.fits.compression.algorithm.rice;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
+
+public class RiceQuantizeCompressOption extends QuantizeOption {
+
+    public RiceQuantizeCompressOption() {
+        super(new RiceCompressOption());
+    }
+
+    public RiceCompressOption getRiceCompressOption() {
+        return (RiceCompressOption) super.getCompressOption();
+    }
+}

--- a/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
@@ -44,10 +44,10 @@ import org.junit.Test;
 import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressor.ByteHCompressor;
+import nom.tam.fits.compression.algorithm.hcompress.HCompressor.DoubleHCompressor;
+import nom.tam.fits.compression.algorithm.hcompress.HCompressor.FloatHCompressor;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressor.IntHCompressor;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressor.ShortHCompressor;
-import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
-import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 import nom.tam.fits.compression.provider.param.api.HeaderAccess;
 import nom.tam.fits.compression.provider.param.hcompress.HCompressParameters;
@@ -177,8 +177,7 @@ public class HCompressTest {
         RandomAccessFile file = null;
         try {
             file = new RandomAccessFile("src/test/resources/nom/tam/image/comp/bare/test100Data-64.bin", "r");
-            HCompressorOption hopt = new HCompressorOption();
-            QuantizeOption quant = new QuantizeOption(hopt);
+            HCompressorQuantizeOption quant = new HCompressorQuantizeOption();
             quant.setDither(true);
             quant.setSeed(8864L);
             quant.setQlevel(4);
@@ -186,8 +185,7 @@ public class HCompressTest {
             quant.setTileHeight(100);
             quant.setTileWidth(100);
             quant.unwrap(HCompressorOption.class).setScale(0);
-            QuantizeProcessor.DoubleQuantCompressor doubleHCompress = new QuantizeProcessor.DoubleQuantCompressor(quant,
-                    new HCompressor.IntHCompressor(hopt));
+            DoubleHCompressor doubleHCompress = new DoubleHCompressor(quant);
 
             byte[] bytes = new byte[(int) file.length()];
             file.read(bytes);
@@ -216,8 +214,7 @@ public class HCompressTest {
         RandomAccessFile file = null;
         try {
             file = new RandomAccessFile("src/test/resources/nom/tam/image/comp/bare/test100Data-32.bin", "r");
-            HCompressorOption hopt = new HCompressorOption();
-            QuantizeOption quant = new QuantizeOption(hopt);
+            HCompressorQuantizeOption quant = new HCompressorQuantizeOption();
             quant.setDither(true);
             quant.setSeed(8864L);
             quant.setQlevel(4);
@@ -225,8 +222,7 @@ public class HCompressTest {
             quant.setTileHeight(100);
             quant.setTileWidth(100);
             quant.unwrap(HCompressorOption.class).setScale(0);
-            QuantizeProcessor.FloatQuantCompressor floatHCompress = new QuantizeProcessor.FloatQuantCompressor(quant,
-                    new HCompressor.IntHCompressor(hopt));
+            FloatHCompressor floatHCompress = new FloatHCompressor(quant);
 
             byte[] bytes = new byte[(int) file.length()];
             file.read(bytes);


### PR DESCRIPTION
Some compression classes / methods were deleted with PR #350, but should be brought back to maintain back compatibility to previous releases.