### PR TITLE
FitsUtil.reposition() signature and deprecation

### DIFF
--- a/src/main/java/nom/tam/fits/FitsUtil.java
+++ b/src/main/java/nom/tam/fits/FitsUtil.java
@@ -44,11 +44,11 @@ import java.util.logging.Logger;
 
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.AsciiFuncs;
+import nom.tam.util.FitsIO;
 import nom.tam.util.RandomAccess;
 
 /**
- * This class comprises static utility functions used throughout the FITS
- * classes.
+ * This class comprises static utility functions used throughout the FITS classes.
  */
 public final class FitsUtil {
 
@@ -70,20 +70,18 @@ public final class FitsUtil {
     }
 
     /**
-     * @return Total size of blocked FITS element, using e.v. padding to fits
-     *         block size.
-     * @param size
-     *            the current size.
+     * @return Total size of blocked FITS element, using e.v. padding to fits block size.
+     * 
+     * @param size the current size.
      */
     public static int addPadding(int size) {
         return size + padding(size);
     }
 
     /**
-     * @return Total size of blocked FITS element, using e.v. padding to fits
-     *         block size.
-     * @param size
-     *            the current size.
+     * @return Total size of blocked FITS element, using e.v. padding to fits block size.
+     * 
+     * @param size the current size.
      */
     public static long addPadding(long size) {
         return size + padding(size);
@@ -91,8 +89,8 @@ public final class FitsUtil {
 
     /**
      * @return Convert an array of booleans to bytes.
-     * @param bool
-     *            array of booleans
+     * 
+     * @param bool array of booleans
      */
     static byte[] booleanToByte(boolean[] bool) {
 
@@ -105,10 +103,9 @@ public final class FitsUtil {
 
     /**
      * @return Convert bytes to Strings.
-     * @param bytes
-     *            byte array to convert
-     * @param maxLen
-     *            the max string length
+     * 
+     * @param bytes byte array to convert
+     * @param maxLen the max string length
      */
     public static String[] byteArrayToStrings(byte[] bytes, int maxLen) {
         boolean checking = FitsFactory.getCheckAsciiStrings();
@@ -185,8 +182,8 @@ public final class FitsUtil {
 
     /**
      * @return Convert an array of bytes to booleans.
-     * @param bytes
-     *            the array of bytes to get the booleans from.
+     * 
+     * @param bytes the array of bytes to get the booleans from.
      */
     static boolean[] byteToBoolean(byte[] bytes) {
         boolean[] bool = new boolean[bytes.length];
@@ -199,8 +196,8 @@ public final class FitsUtil {
 
     /**
      * @return Find out where we are in a random access file .
-     * @param o
-     *            the stream to get the position
+     * 
+     * @param o the stream to get the position
      */
     public static long findOffset(Closeable o) {
         if (o instanceof RandomAccess) {
@@ -210,16 +207,13 @@ public final class FitsUtil {
     }
 
     /**
-     * @return Get a stream to a URL accommodating possible redirections. Note
-     *         that if a redirection request points to a different protocol than
-     *         the original request, then the redirection is not handled
-     *         automatically.
-     * @param url
-     *            the url to get the stream from
-     * @param level
-     *            max levels of redirection
-     * @throws IOException
-     *             if the operation failed
+     * @return Get a stream to a URL accommodating possible redirections. Note that if a redirection request points to a
+     *             different protocol than the original request, then the redirection is not handled automatically.
+     * 
+     * @param url the url to get the stream from
+     * @param level max levels of redirection
+     * 
+     * @throws IOException if the operation failed
      */
     public static InputStream getURLStream(URL url, int level) throws IOException {
         URLConnection conn = null;
@@ -238,10 +232,10 @@ public final class FitsUtil {
 
     /**
      * @return Get the maximum length of a String in a String array.
-     * @param strings
-     *            array of strings to check
-     * @throws FitsException
-     *             if the operation failed
+     * 
+     * @param strings array of strings to check
+     * 
+     * @throws FitsException if the operation failed
      */
     public static int maxLength(String[] strings) throws FitsException {
 
@@ -257,12 +251,10 @@ public final class FitsUtil {
     /**
      * Add padding to an output stream.
      * 
-     * @param stream
-     *            stream to pad
-     * @param size
-     *            the current size
-     * @throws FitsException
-     *             if the operation failed
+     * @param stream stream to pad
+     * @param size the current size
+     * 
+     * @throws FitsException if the operation failed
      */
     public static void pad(ArrayDataOutput stream, long size) throws FitsException {
         pad(stream, size, (byte) 0);
@@ -271,14 +263,11 @@ public final class FitsUtil {
     /**
      * Add padding to an output stream.
      * 
-     * @param stream
-     *            stream to pad
-     * @param size
-     *            the current size
-     * @param fill
-     *            the fill byte to use
-     * @throws FitsException
-     *             if the operation failed
+     * @param stream stream to pad
+     * @param size the current size
+     * @param fill the fill byte to use
+     * 
+     * @throws FitsException if the operation failed
      */
     public static void pad(ArrayDataOutput stream, long size, byte fill) throws FitsException {
         int len = padding(size);
@@ -296,8 +285,8 @@ public final class FitsUtil {
 
     /**
      * @return How many bytes are needed to fill a 2880 block?
-     * @param size
-     *            the size without padding
+     * 
+     * @param size the size without padding
      */
     public static int padding(int size) {
         return padding((long) size);
@@ -313,16 +302,20 @@ public final class FitsUtil {
     }
 
     /**
-     * Reposition a random access stream to a requested offset.
+     * Attempts to reposition a FITS input ot output. The call will succeed only if the underlying input or output is
+     * random accessible. Othewise, an exception will be thrown.
      * 
-     * @param o
-     *            the closable to reposition
-     * @param offset
-     *            the offset to position it to.
-     * @throws FitsException
-     *             if the operation was failed or not possible
+     * @deprecated This method wraps an {@link IOException} into a {@link FitsException} for no good reason really. A
+     *                 revision of the API should eliminate this method, and procees the underlying exception instead.
+     * 
+     * @param o the FITS input or output
+     * @param offset the offset to position it to.
+     * 
+     * @throws FitsException if the underlying input/output is not random accessible or if the requested position is
+     *             invalid.
      */
-    public static void reposition(Closeable o, long offset) throws FitsException {
+    @Deprecated
+    public static void reposition(FitsIO o, long offset) throws FitsException {
         // TODO AK: argument should be RandomAccess instead of Closeable, since
         // that's the only type we actually handle...
 
@@ -331,13 +324,15 @@ public final class FitsUtil {
         }
 
         if (!(o instanceof RandomAccess) || offset < 0) {
-            throw new FitsException("Invalid attempt to reposition stream " + o + " of type " + o.getClass().getName() + " to " + offset);
+            throw new FitsException("Invalid attempt to reposition stream " + o + " of type " + o.getClass().getName()
+                    + " to " + offset);
         }
 
         try {
             ((RandomAccess) o).seek(offset);
         } catch (IOException e) {
-            throw new FitsException("Unable to repostion stream " + o + " of type " + o.getClass().getName() + " to " + offset + ": " + e.getMessage(), e);
+            throw new FitsException("Unable to repostion stream " + o + " of type " + o.getClass().getName() + " to "
+                    + offset + ": " + e.getMessage(), e);
         }
     }
 
@@ -345,10 +340,9 @@ public final class FitsUtil {
      * Convert an array of Strings to bytes.
      * 
      * @return the resulting bytes
-     * @param stringArray
-     *            the array with Strings
-     * @param maxLen
-     *            the max length (in bytes) of every String
+     * 
+     * @param stringArray the array with Strings
+     * @param maxLen the max length (in bytes) of every String
      */
     public static byte[] stringsToByteArray(String[] stringArray, int maxLen) {
         byte[] res = new byte[stringArray.length * maxLen];

--- a/src/main/java/nom/tam/util/ArrayDataOutput.java
+++ b/src/main/java/nom/tam/util/ArrayDataOutput.java
@@ -1,6 +1,5 @@
 package nom.tam.util;
 
-import java.io.Closeable;
 import java.io.DataOutput;
 
 /*
@@ -39,23 +38,21 @@ import java.io.IOException;
 /**
  * Interface for writing array data to outputs.
  */
-public interface ArrayDataOutput extends DataOutput, Closeable {
-    
+public interface ArrayDataOutput extends OutputWriter, DataOutput, FitsIO {
+
     /**
      * Flush the output buffer
      * 
-     * @throws IOException
-     *             if the flush of the underlying stream failed
+     * @throws IOException if the flush of the underlying stream failed
      */
     void flush() throws IOException;
 
     /**
      * Write an array of boolean's.
      * 
-     * @param buf
-     *            array of boolean's.
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of boolean's.
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     default void write(boolean[] buf) throws IOException {
         write(buf, 0, buf.length);
@@ -64,25 +61,21 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     /**
      * Write a segment of an array of boolean's.
      * 
-     * @param buf
-     *            array of boolean's.
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of boolean's.
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     void write(boolean[] buf, int offset, int size) throws IOException;
 
     /**
      * Write an array of booleans, including legal <code>null</code> values.
      * 
-     * @param buf
-     *            array of booleans.
-     * @throws IOException
-     *             if one of the underlying write operations failed
-     *             
+     * @param buf array of booleans.
+     * 
+     * @throws IOException if one of the underlying write operations failed
+     * 
      * @since 1.16
      */
     default void write(Boolean[] buf) throws IOException {
@@ -90,38 +83,32 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     }
 
     /**
-     * Write a segment of an array of booleans, possibly including legal
-     * <code>null</code> values.
-     * The method has a default implementation, which calls {@link #writeBoolean(boolean)}
-     * element by element. Classes that implement this interface might want to
-     * replace that with a more efficient block read implementation/
+     * Write a segment of an array of booleans, possibly including legal <code>null</code> values. The method has a
+     * default implementation, which calls {@link #writeBoolean(boolean)} element by element. Classes that implement
+     * this interface might want to replace that with a more efficient block read implementation/
      * 
-     * @param buf
-     *            array of booleans.
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
-     *             
+     * @param buf array of booleans.
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
+     * 
      * @since 1.16
      */
     default void write(Boolean[] buf, int offset, int size) throws IOException {
-       int to = offset + size;
+        int to = offset + size;
 
-       for (int i = offset; i < to; i++) {
-           writeBoolean(buf[i].booleanValue());
-       }
+        for (int i = offset; i < to; i++) {
+            writeBoolean(buf[i].booleanValue());
+        }
     }
 
     /**
      * Write an array of char's.
      * 
-     * @param buf
-     *            array of char's.
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of char's.
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     default void write(char[] buf) throws IOException {
         write(buf, 0, buf.length);
@@ -130,24 +117,20 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     /**
      * Write a segment of an array of char's.
      * 
-     * @param buf
-     *            array of char's.
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of char's.
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     void write(char[] buf, int offset, int size) throws IOException;
 
     /**
      * Write an array of double's.
      * 
-     * @param buf
-     *            array of double's.
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of double's.
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     default void write(double[] buf) throws IOException {
         write(buf, 0, buf.length);
@@ -156,24 +139,20 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     /**
      * Write a segment of an array of double's.
      * 
-     * @param buf
-     *            array of double's.
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of double's.
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     void write(double[] buf, int offset, int size) throws IOException;
 
     /**
      * Write an array of float's.
      * 
-     * @param buf
-     *            array of float's.
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of float's.
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     default void write(float[] buf) throws IOException {
         write(buf, 0, buf.length);
@@ -182,24 +161,20 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     /**
      * Write a segment of an array of float's.
      * 
-     * @param buf
-     *            array of float's.
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of float's.
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     void write(float[] buf, int offset, int size) throws IOException;
 
     /**
      * Write an array of int's.
      * 
-     * @param buf
-     *            array of int's
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of int's
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     default void write(int[] buf) throws IOException {
         write(buf, 0, buf.length);
@@ -208,24 +183,20 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     /**
      * Write a segment of an array of int's.
      * 
-     * @param buf
-     *            array of int's
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of int's
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     void write(int[] buf, int offset, int size) throws IOException;
 
     /**
      * Write an array of longs.
      * 
-     * @param buf
-     *            array of longs
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of longs
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     default void write(long[] buf) throws IOException {
         write(buf, 0, buf.length);
@@ -234,24 +205,20 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     /**
      * Write a segment of an array of longs.
      * 
-     * @param buf
-     *            array of longs
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf array of longs
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     void write(long[] buf, int offset, int size) throws IOException;
 
     /**
      * Write an array of shorts.
      * 
-     * @param buf
-     *            the value to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf the value to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     default void write(short[] buf) throws IOException {
         write(buf, 0, buf.length);
@@ -260,59 +227,46 @@ public interface ArrayDataOutput extends DataOutput, Closeable {
     /**
      * Write a segment of an array of shorts.
      * 
-     * @param buf
-     *            the value to write
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf the value to write
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     void write(short[] buf, int offset, int size) throws IOException;
 
     /**
-     * Write an array of Strings. Equivalent to calling writeBytes for the
-     * selected elements.
+     * Write an array of Strings. Equivalent to calling writeBytes for the selected elements.
      * 
-     * @param buf
-     *            the array to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf the array to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     default void write(String[] buf) throws IOException {
         write(buf, 0, buf.length);
     }
 
     /**
-     * Write a segment of an array of Strings. Equivalent to calling writeBytes
-     * for the selected elements.
+     * Write a segment of an array of Strings. Equivalent to calling writeBytes for the selected elements.
      * 
-     * @param buf
-     *            the array to write
-     * @param offset
-     *            start index in the array
-     * @param size
-     *            number of array elements to write
-     * @throws IOException
-     *             if one of the underlying write operations failed
+     * @param buf the array to write
+     * @param offset start index in the array
+     * @param size number of array elements to write
+     * 
+     * @throws IOException if one of the underlying write operations failed
      */
     void write(String[] buf, int offset, int size) throws IOException;
 
     /**
-     * Writes the contents of a Java array to the output translating the data to
-     * the required binary representation. The argument may be a generic Java
-     * array, including multi-dimensional arrays and heterogeneous arrays of
-     * arrays.
+     * Writes the contents of a Java array to the output translating the data to the required binary representation. The
+     * argument may be a generic Java array, including multi-dimensional arrays and heterogeneous arrays of arrays.
      * 
-     * @param o
-     *            the Java array, including heterogeneous arrays of arrays. If
-     *            <code>null</code> nothing will be written to the output.
-     * @throws IOException
-     *             if there was an IO error writing to the output
-     * @throws IllegalArgumentException
-     *             if the supplied object is not a Java array or if it contains
-     *             Java types that are not supported by the encoder.
+     * @param o the Java array, including heterogeneous arrays of arrays. If <code>null</code> nothing will be written
+     *            to the output.
+     * 
+     * @throws IOException if there was an IO error writing to the output
+     * @throws IllegalArgumentException if the supplied object is not a Java array or if it contains Java types that are
+     *             not supported by the encoder.
      */
     void writeArray(Object o) throws IOException, IllegalArgumentException;
 


### PR DESCRIPTION
`FitsUtil.reposition()` had a `Closeable` argument, but it's onlt ever called on `FitsIO` implementations. Also it's main function is to reposition random accessible streams only, or else throw a `FitsException`. It would be more appropriate for it to throw an `IOException` instead if the underlying stream does not support repositioning or if the position is invalid for the given stream. Therefore, deprecate this method in the hope that a revised API may change or eliminate it.