### PR TITLE
Fix CompressorProvider.NULL_PARAMETERS not playing nice when bundled.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -58,7 +58,6 @@ jobs:
       with:
 #        token: ${{ secrets.CODECOV_TOKEN }}
         working-directory: ./nom-tam-fits
-        files: ./target/site/jacoco/jacoco.xml
         fail_ci_if_error: false
         flags: unittests
         name: codecov

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,7 +57,6 @@ jobs:
       continue-on-error: true
       with:
 #        token: ${{ secrets.CODECOV_TOKEN }}
-        working-directory: ./nom-tam-fits
         fail_ci_if_error: false
         flags: unittests
         name: codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,10 @@ coverage:
   range: "80...100"
   status:
     patch: off
+    project:
+      default:
+        target: auto
+        removed_code_behavior: adjust_base
 
 parsers:
   gcov:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,7 @@ coverage:
     project:
       default:
         target: auto
+        threshold: 0.03%
         removed_code_behavior: adjust_base
 
 parsers:

--- a/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
+++ b/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
@@ -39,9 +39,6 @@ import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import nom.tam.fits.BinaryTable;
-import nom.tam.fits.BinaryTableHDU;
-import nom.tam.fits.FitsException;
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.algorithm.api.ICompressor;
 import nom.tam.fits.compression.algorithm.api.ICompressorControl;
@@ -76,8 +73,9 @@ import nom.tam.fits.compression.algorithm.uncompressed.NoCompressCompressor.IntN
 import nom.tam.fits.compression.algorithm.uncompressed.NoCompressCompressor.LongNoCompressCompressor;
 import nom.tam.fits.compression.algorithm.uncompressed.NoCompressCompressor.ShortNoCompressCompressor;
 import nom.tam.fits.compression.provider.api.ICompressorProvider;
+import nom.tam.fits.compression.provider.param.api.ICompressHeaderParameter;
 import nom.tam.fits.compression.provider.param.api.ICompressParameters;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
+import nom.tam.fits.compression.provider.param.base.CompressParameters;
 import nom.tam.fits.compression.provider.param.hcompress.HCompressParameters;
 import nom.tam.fits.compression.provider.param.rice.RiceCompressParameters;
 
@@ -231,43 +229,16 @@ public class CompressorProvider implements ICompressorProvider {
         }
     };
 
-    private static final ICompressParameters NULL_PARAMETERS = new ICompressParameters() {
+    private static final ICompressParameters NULL_PARAMETERS = new CompressParameters() {
 
         @Override
-        public void addColumnsToTable(BinaryTableHDU hdu) {
+        protected ICompressHeaderParameter[] headerParameters() {
+            return new ICompressHeaderParameter[0];
         }
 
         @Override
-        public ICompressParameters copy(ICompressOption clone) {
+        public ICompressParameters copy(ICompressOption option) {
             return this;
-        }
-
-        @Override
-        public void getValuesFromColumn(int index) {
-        }
-
-        @Override
-        public void getValuesFromHeader(IHeaderAccess header) {
-        }
-
-        @Override
-        public void initializeColumns(IHeaderAccess header, BinaryTable binaryTable, int size) throws FitsException {
-        }
-
-        @Override
-        public void initializeColumns(int length) {
-        }
-
-        @Override
-        public void setValuesInColumn(int index) {
-        }
-
-        @Override
-        public void setValuesInHeader(IHeaderAccess header) {
-        }
-
-        @Override
-        public void setTileIndex(int index) {
         }
     };
 

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameters.java
@@ -5,6 +5,7 @@ import nom.tam.fits.BinaryTableHDU;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
+import nom.tam.fits.compression.provider.param.base.CompressParameters;
 
 /*
  * #%L
@@ -36,8 +37,17 @@ import nom.tam.fits.compression.algorithm.api.ICompressOption;
  * OTHER DEALINGS IN THE SOFTWARE.
  * #L%
  */
+
 /**
+ * <p>
  * Group of parameters that must be synchronized with the hdu meta data for a specific compression algorithm.
+ * </p>
+ * <p>
+ * NOTE, this interface is meant for internal use only. Implementing it externally to this library might not result in
+ * the desired behavior. If you feed the need to implement compression parameters externally to what is privided by this
+ * library, you are advised to extend the abstract {@link CompressParameters} class or of of its known subclasses
+ * instead
+ * </p>
  */
 public interface ICompressParameters {
 

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -285,6 +285,21 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
         return this;
     }
 
+    /**
+     * Returns the name of the currently configured quantization algorithm.
+     * 
+     * @return The name of the standard quantization algorithm (i.e. a FITS standard value for the <code>ZQUANTIZ</code>
+     *             keyword), or <code>null</code> if not quantization is currently defined, possibly because an invalid
+     *             value was set before.
+     * 
+     * @see #setQuantAlgorithm(HeaderCard)
+     * 
+     * @since 1.18
+     */
+    public String getQuantAlgorithm() {
+        return this.quantAlgorithm;
+    }
+
     public synchronized TiledImageCompressionOperation setQuantAlgorithm(HeaderCard quantAlgorithmCard) {
         this.quantAlgorithm = null;
 

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -55,6 +55,7 @@ import java.lang.reflect.Array;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ExecutorService;
+import java.util.logging.Logger;
 
 import nom.tam.fits.BinaryTable;
 import nom.tam.fits.BinaryTableHDU;
@@ -287,14 +288,19 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
     public synchronized TiledImageCompressionOperation setQuantAlgorithm(HeaderCard quantAlgorithmCard) {
         this.quantAlgorithm = null;
 
-        if (quantAlgorithmCard != null) {
-            String algo = quantAlgorithmCard.getValue().toUpperCase();
-
-            if (algo.equals(Compression.ZQUANTIZ_NO_DITHER) || algo.equals(Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_1)
-                    || algo.equals(Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_2)) {
-                this.quantAlgorithm = algo;
-            }
+        if (quantAlgorithmCard == null) {
+            return this;
         }
+
+        String algo = quantAlgorithmCard.getValue().toUpperCase();
+
+        if (algo.equals(Compression.ZQUANTIZ_NO_DITHER) || algo.equals(Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_1)
+                || algo.equals(Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_2)) {
+            this.quantAlgorithm = algo;
+        } else {
+            Logger.getLogger(Header.class.getName()).warning("Ignored invalid ZQUANTIZ value: " + algo);
+        }
+
         return this;
     }
 

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -285,10 +285,15 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
     }
 
     public synchronized TiledImageCompressionOperation setQuantAlgorithm(HeaderCard quantAlgorithmCard) {
+        this.quantAlgorithm = null;
+
         if (quantAlgorithmCard != null) {
-            this.quantAlgorithm = quantAlgorithmCard.getValue();
-        } else {
-            this.quantAlgorithm = null;
+            String algo = quantAlgorithmCard.getValue().toUpperCase();
+
+            if (algo.equals(Compression.ZQUANTIZ_NO_DITHER) || algo.equals(Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_1)
+                    || algo.equals(Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_2)) {
+                this.quantAlgorithm = algo;
+            }
         }
         return this;
     }

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressionTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressionTest.java
@@ -150,4 +150,5 @@ public class TileCompressionTest {
         TiledImageCompressionOperation op = new TiledImageCompressionOperation(null);
         op.readPrimaryHeaders(h);
     }
+
 }

--- a/src/test/java/nom/tam/image/tile/operation/TileImageCompressionOperationTest.java
+++ b/src/test/java/nom/tam/image/tile/operation/TileImageCompressionOperationTest.java
@@ -90,5 +90,37 @@ public class TileImageCompressionOperationTest {
 
         op.setQuantAlgorithm(HeaderCard.create(Compression.ZQUANTIZ, "invalid value"));
         Assert.assertNull(op.getQuantAlgorithm());
+
+        op.setQuantAlgorithm(null);
+        Assert.assertNull(op.getQuantAlgorithm());
+    }
+
+    @Test
+    public void testZcmptypeValues() throws Exception {
+        TiledImageCompressionOperation op = new TiledImageCompressionOperation(null);
+
+        op.setCompressAlgorithm(HeaderCard.create(Compression.ZCMPTYPE, Compression.ZCMPTYPE_NOCOMPRESS));
+        Assert.assertEquals(op.getCompressAlgorithm(), Compression.ZCMPTYPE_NOCOMPRESS);
+
+        op.setCompressAlgorithm(HeaderCard.create(Compression.ZCMPTYPE, Compression.ZCMPTYPE_GZIP_1));
+        Assert.assertEquals(op.getCompressAlgorithm(), Compression.ZCMPTYPE_GZIP_1);
+
+        op.setCompressAlgorithm(HeaderCard.create(Compression.ZCMPTYPE, Compression.ZCMPTYPE_GZIP_2));
+        Assert.assertEquals(op.getCompressAlgorithm(), Compression.ZCMPTYPE_GZIP_2);
+
+        op.setCompressAlgorithm(HeaderCard.create(Compression.ZCMPTYPE, Compression.ZCMPTYPE_RICE_1));
+        Assert.assertEquals(op.getCompressAlgorithm(), Compression.ZCMPTYPE_RICE_1);
+
+        op.setCompressAlgorithm(HeaderCard.create(Compression.ZCMPTYPE, Compression.ZCMPTYPE_PLIO_1));
+        Assert.assertEquals(op.getCompressAlgorithm(), Compression.ZCMPTYPE_PLIO_1);
+
+        op.setCompressAlgorithm(HeaderCard.create(Compression.ZCMPTYPE, Compression.ZCMPTYPE_HCOMPRESS_1));
+        Assert.assertEquals(op.getCompressAlgorithm(), Compression.ZCMPTYPE_HCOMPRESS_1);
+
+        op.setCompressAlgorithm(HeaderCard.create(Compression.ZCMPTYPE, "invalid value"));
+        Assert.assertNull(op.getCompressAlgorithm());
+
+        op.setCompressAlgorithm(null);
+        Assert.assertNull(op.getCompressAlgorithm());
     }
 }

--- a/src/test/java/nom/tam/image/tile/operation/TileImageCompressionOperationTest.java
+++ b/src/test/java/nom/tam/image/tile/operation/TileImageCompressionOperationTest.java
@@ -39,6 +39,8 @@ import org.junit.Test;
 
 import nom.tam.fits.BinaryTable;
 import nom.tam.fits.FitsException;
+import nom.tam.fits.HeaderCard;
+import nom.tam.fits.header.Compression;
 import nom.tam.image.compression.tile.TiledImageCompressionOperation;
 import nom.tam.util.type.ElementType;
 
@@ -48,28 +50,45 @@ public class TileImageCompressionOperationTest {
         TiledImageCompressionOperation op = new TiledImageCompressionOperation(null);
         op.setTileAxes(new int[] {2, 3, 4});
     }
-    
+
     @Test
     public void tileImageSubtileTest() throws Exception {
         Buffer buf = ByteBuffer.wrap(new byte[10000]);
-        
+
         TiledImageCompressionOperation op = new TiledImageCompressionOperation(new BinaryTable());
         op.setTileAxes(new int[] {10});
-        op.setAxes(new int[] { 100, 100 });
+        op.setAxes(new int[] {100, 100});
         op.setBaseType(ElementType.forNearestBitpix(8));
         op.prepareUncompressedData(buf);
-        Assert.assertArrayEquals(new int[] { 1,  10}, op.getTileAxes());
+        Assert.assertArrayEquals(new int[] {1, 10}, op.getTileAxes());
     }
-    
+
     @Test
     public void tileSize3DTest() throws Exception {
         TiledImageCompressionOperation op = new TiledImageCompressionOperation(new BinaryTable());
         op.setTileAxes(new int[] {1, 3, 4});
     }
-    
+
     @Test(expected = FitsException.class)
     public void illegalTileSizeTest() throws Exception {
         TiledImageCompressionOperation op = new TiledImageCompressionOperation(new BinaryTable());
         op.setTileAxes(new int[] {2, 3, 4});
+    }
+
+    @Test
+    public void testZquantizValues() throws Exception {
+        TiledImageCompressionOperation op = new TiledImageCompressionOperation(null);
+
+        op.setQuantAlgorithm(HeaderCard.create(Compression.ZQUANTIZ, Compression.ZQUANTIZ_NO_DITHER));
+        Assert.assertEquals(op.getQuantAlgorithm(), Compression.ZQUANTIZ_NO_DITHER);
+
+        op.setQuantAlgorithm(HeaderCard.create(Compression.ZQUANTIZ, Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_1));
+        Assert.assertEquals(op.getQuantAlgorithm(), Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_1);
+
+        op.setQuantAlgorithm(HeaderCard.create(Compression.ZQUANTIZ, Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_2));
+        Assert.assertEquals(op.getQuantAlgorithm(), Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_2);
+
+        op.setQuantAlgorithm(HeaderCard.create(Compression.ZQUANTIZ, "invalid value"));
+        Assert.assertNull(op.getQuantAlgorithm());
     }
 }


### PR DESCRIPTION
Compression parameters have a doubly abstracted hierarchy, based on an interface, on top of which lies an abstract class providing another layer of abstract method stems that subclasses must all implement. In effect, the abstract class does what default methods should have been used for in the base interface. This double layering of abstract methods is unfortunate, but since this is how it has been since the compression classes were added in 1.15, we have no choice but to keep it that way, lest we want to risk back compatibility issues.

The problems start when bundling options (in PR #350) that implement only the base interface, but not the additional abstract methods of the abstract class atop the interface, such as was the case for `CompressorProvider.NULL_PARAMETERS`. The problem is easily fixed by deriving these internal parameters from the abstract class rather than the base interface.

We also need to warn users to avoid implementing the base interface directly externally to the library, and instead implement the methods of the abstract `CompressParameters` class instead.