### PR TITLE
New ability to stream cutouts from compressed images

### DIFF
--- a/src/main/java/nom/tam/fits/StreamingTileImageData.java
+++ b/src/main/java/nom/tam/fits/StreamingTileImageData.java
@@ -32,7 +32,6 @@ package nom.tam.fits;
  */
 
 import nom.tam.image.ImageTiler;
-import nom.tam.image.StandardImageTiler;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
 
@@ -43,7 +42,6 @@ import java.util.Arrays;
  * Simple implementation that will cut a tile out to the given stream.  Useful for web applications that provide
  * a cutout service.  The idea is that the ImageData object will be extracted from an overlapping HDU (without first
  * reading so as not to fill up the memory), and one of these objects are created for the output.
- *
  * <code>
  *     Fits source = new Fits(myFile);
  *     Fits output = new Fits();
@@ -65,6 +63,7 @@ public class StreamingTileImageData extends ImageData {
     private final int[] corners;
     private final int[] lengths;
     private final int[] steps;
+    private final ImageTiler imageTiler;
 
 
     /**
@@ -72,13 +71,13 @@ public class StreamingTileImageData extends ImageData {
      *
      * @param header  The header representing the desired cutout.  It is the responsibility of the caller to
      *                adjust the header appropriately.
-     * @param tiler   The tiler from the original ImageData object.
+     * @param tiler   The tiler to slice pixels out with.
      * @param corners The corners to start tiling.
      * @param lengths The count of values to extract.
      * @param steps   The number of jumps to make to the next read.  Optional, defaults to 1 for each axis.
      * @throws FitsException If the provided Header is unreadable
      */
-    public StreamingTileImageData(final Header header, final StandardImageTiler tiler, final int[] corners,
+    public StreamingTileImageData(final Header header, final ImageTiler tiler, final int[] corners,
                                   final int[] lengths, int[] steps) throws FitsException {
         super(header);
 
@@ -94,7 +93,7 @@ public class StreamingTileImageData extends ImageData {
             this.steps = steps;
         }
 
-        super.setTiler(tiler);
+        this.imageTiler = tiler;
         this.corners = corners;
         this.lengths = lengths;
     }
@@ -109,7 +108,7 @@ public class StreamingTileImageData extends ImageData {
     @Override
     public void write(ArrayDataOutput o) throws FitsException {
         try {
-            final ImageTiler tiler = this.getTiler();
+            final ImageTiler tiler = this.imageTiler;
             if (tiler == null || getTrueSize() == 0) {
                 // Defer writing of unknowns to the parent.
                 super.write(o);

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorQuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorQuantizeOption.java
@@ -32,7 +32,6 @@ package nom.tam.fits.compression.algorithm.hcompress;
  */
 
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
-import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 
 public class HCompressorQuantizeOption extends QuantizeOption {
 
@@ -40,7 +39,7 @@ public class HCompressorQuantizeOption extends QuantizeOption {
         super(new HCompressorOption());
     }
 
-    public HCompressorQuantizeOption(RiceCompressOption compressOption) {
+    public HCompressorQuantizeOption(HCompressorOption compressOption) {
         super(compressOption);
     }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorQuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorQuantizeOption.java
@@ -32,11 +32,16 @@ package nom.tam.fits.compression.algorithm.hcompress;
  */
 
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
+import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 
 public class HCompressorQuantizeOption extends QuantizeOption {
 
     public HCompressorQuantizeOption() {
         super(new HCompressorOption());
+    }
+
+    public HCompressorQuantizeOption(RiceCompressOption compressOption) {
+        super(compressOption);
     }
 
     public HCompressorOption getHCompressorOption() {

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -92,7 +92,7 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Creates a new set of qunatization options, to be used together with the specified compression options.
+     * Creates a new set of quantization options, to be used together with the specified compression options.
      * 
      * @param compressOption Compression-specific options to pair with these quantization options, or <code>null</code>.
      * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceQuantizeCompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceQuantizeCompressOption.java
@@ -31,7 +31,6 @@ package nom.tam.fits.compression.algorithm.rice;
  * #L%
  */
 
-import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
 
 public class RiceQuantizeCompressOption extends QuantizeOption {
@@ -40,7 +39,7 @@ public class RiceQuantizeCompressOption extends QuantizeOption {
         super(new RiceCompressOption());
     }
 
-    public RiceQuantizeCompressOption(ICompressOption compressOption) {
+    public RiceQuantizeCompressOption(RiceCompressOption compressOption) {
         super(compressOption);
     }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceQuantizeCompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceQuantizeCompressOption.java
@@ -31,12 +31,17 @@ package nom.tam.fits.compression.algorithm.rice;
  * #L%
  */
 
+import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
 
 public class RiceQuantizeCompressOption extends QuantizeOption {
 
     public RiceQuantizeCompressOption() {
         super(new RiceCompressOption());
+    }
+
+    public RiceQuantizeCompressOption(ICompressOption compressOption) {
+        super(compressOption);
     }
 
     public RiceCompressOption getRiceCompressOption() {

--- a/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
+++ b/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
@@ -173,7 +173,9 @@ public class CompressorProvider implements ICompressorProvider {
                 throws InstantiationException, IllegalAccessException, InvocationTargetException {
             QuantizeOption quantOption = null;
 
-            if (option instanceof QuantizeOption) {
+            if (option instanceof RiceQuantizeCompressOption) {
+                quantOption = (RiceQuantizeCompressOption) option;
+            } else if (option instanceof QuantizeOption) {
                 quantOption = (QuantizeOption) option;
                 option = quantOption.getCompressOption();
             }

--- a/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
+++ b/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
@@ -58,8 +58,10 @@ import nom.tam.fits.compression.algorithm.gzip2.GZip2Compressor.IntGZip2Compress
 import nom.tam.fits.compression.algorithm.gzip2.GZip2Compressor.LongGZip2Compressor;
 import nom.tam.fits.compression.algorithm.gzip2.GZip2Compressor.ShortGZip2Compressor;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressor.ByteHCompressor;
+import nom.tam.fits.compression.algorithm.hcompress.HCompressor.FloatHCompressor;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressor.IntHCompressor;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressor.ShortHCompressor;
+import nom.tam.fits.compression.algorithm.hcompress.HCompressorQuantizeOption;
 import nom.tam.fits.compression.algorithm.plio.PLIOCompress.BytePLIOCompressor;
 import nom.tam.fits.compression.algorithm.plio.PLIOCompress.IntPLIOCompressor;
 import nom.tam.fits.compression.algorithm.plio.PLIOCompress.ShortPLIOCompressor;
@@ -67,8 +69,10 @@ import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
 import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor.DoubleQuantCompressor;
 import nom.tam.fits.compression.algorithm.quant.QuantizeProcessor.FloatQuantCompressor;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressor.ByteRiceCompressor;
+import nom.tam.fits.compression.algorithm.rice.RiceCompressor.FloatRiceCompressor;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressor.IntRiceCompressor;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressor.ShortRiceCompressor;
+import nom.tam.fits.compression.algorithm.rice.RiceQuantizeCompressOption;
 import nom.tam.fits.compression.algorithm.uncompressed.NoCompressCompressor.ByteNoCompressCompressor;
 import nom.tam.fits.compression.algorithm.uncompressed.NoCompressCompressor.DoubleNoCompressCompressor;
 import nom.tam.fits.compression.algorithm.uncompressed.NoCompressCompressor.FloatNoCompressCompressor;
@@ -98,16 +102,12 @@ public class CompressorProvider implements ICompressorProvider {
 
         private Class<?> quantType;
 
-        protected TileCompressorControl(Class<?> compressorClass) {
-            this(compressorClass, null);
-        }
-
         @SuppressWarnings("unchecked")
-        protected TileCompressorControl(Class<?> compressorClass, Class<?> parametersClass) {
+        protected TileCompressorControl(Class<?> compressorClass) {
             this.constructor = (Constructor<ICompressor<Buffer>>) compressorClass.getConstructors()[0];
             this.optionClass = (Class<? extends ICompressOption>) (this.constructor.getParameterTypes().length == 0 ?
-                    null :
-                    this.constructor.getParameterTypes()[0]);
+                                                                   null :
+                                                                   this.constructor.getParameterTypes()[0]);
         }
 
         /**
@@ -151,7 +151,7 @@ public class CompressorProvider implements ICompressorProvider {
             ICompressOption option = null;
             if (this.optionClass != null) {
                 try {
-                    option = this.optionClass.newInstance();
+                    option = this.optionClass.getDeclaredConstructor().newInstance();
                 } catch (Exception e) {
                     throw new IllegalStateException("could not instantiate option class for " + this.constructor, e);
                 }
@@ -274,8 +274,10 @@ public class CompressorProvider implements ICompressorProvider {
     // @formatter:off
     private static final Class<?>[][] AVAILABLE_COMPRESSORS = {{ByteRiceCompressor.class, RiceCompressParameters.class},
             {ShortRiceCompressor.class, RiceCompressParameters.class},
+            {FloatRiceCompressor.class, RiceQuantizeCompressOption.class},
             {IntRiceCompressor.class, RiceCompressParameters.class}, {BytePLIOCompressor.class},
             {ShortPLIOCompressor.class}, {IntPLIOCompressor.class}, {ByteHCompressor.class, HCompressParameters.class},
+            {FloatHCompressor.class, HCompressorQuantizeOption.class},
             {ShortHCompressor.class, HCompressParameters.class}, {IntHCompressor.class, HCompressParameters.class},
             {ByteGZip2Compressor.class}, {ShortGZip2Compressor.class}, {IntGZip2Compressor.class},
             {FloatGZip2Compressor.class}, {DoubleGZip2Compressor.class}, {LongGZip2Compressor.class},
@@ -326,12 +328,7 @@ public class CompressorProvider implements ICompressorProvider {
         for (Class<?>[] types : AVAILABLE_COMPRESSORS) {
             Class<?> compressorClass = types[0];
             if (compressorClass.getSimpleName().equals(className)) {
-                TileCompressorControl tc = null;
-                if (types.length > 1) {
-                    tc = new TileCompressorControl(compressorClass, types[1]);
-                } else {
-                    tc = new TileCompressorControl(compressorClass);
-                }
+                TileCompressorControl tc = new TileCompressorControl(compressorClass);
                 tc.setQuantType(quantType);
                 return tc;
             }

--- a/src/main/java/nom/tam/image/compression/CompressedImageTiler.java
+++ b/src/main/java/nom/tam/image/compression/CompressedImageTiler.java
@@ -493,7 +493,7 @@ public class CompressedImageTiler implements ImageTiler {
     }
 
     private String getQuantizAlgorithmName() {
-        return getHeader().getStringValue(Compression.ZQUANTIZ, Compression.ZQUANTIZ_NO_DITHER);
+        return getHeader().getStringValue(Compression.ZQUANTIZ);
     }
 
     private String getCompressionAlgorithmName() {

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
@@ -144,7 +144,7 @@ public class CompressedImageHDU extends BinaryTableHDU {
     }
 
     public ImageHDU asImageHDU() throws FitsException {
-        final Header header = getGenericHeader();
+        final Header header = getImageHeader();
         ImageData data = (ImageData) ImageHDU.manufactureData(header);
         ImageHDU imageHDU = new ImageHDU(header, data);
         data.setBuffer(getUncompressedData());
@@ -158,7 +158,7 @@ public class CompressedImageHDU extends BinaryTableHDU {
      * @throws FitsException
      *             if the axis are configured wrong.
      */
-    public int[] getDecompressedAxes() throws FitsException {
+    public int[] getImageAxes() throws FitsException {
         int nAxis = this.myHeader.getIntValue(Compression.ZNAXIS);
         if (nAxis < 0) {
             throw new FitsException("Negative ZNAXIS (or NAXIS) value " + nAxis);
@@ -185,7 +185,7 @@ public class CompressedImageHDU extends BinaryTableHDU {
      * @throws HeaderCardException
      *          if the card could not be copied
      */
-    public Header getGenericHeader() throws HeaderCardException {
+    public Header getImageHeader() throws HeaderCardException {
         Header header = new Header();
         Cursor<String, HeaderCard> imageIterator = header.iterator();
         Cursor<String, HeaderCard> iterator = getHeader().iterator();

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
@@ -48,12 +48,10 @@ import nom.tam.fits.HeaderCard;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.ImageData;
 import nom.tam.fits.ImageHDU;
-import nom.tam.fits.StreamingTileImageData;
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.IFitsHeader;
-import nom.tam.image.compression.CompressedImageTiler;
 import nom.tam.util.Cursor;
 
 /**
@@ -153,25 +151,7 @@ public class CompressedImageHDU extends BinaryTableHDU {
         return imageHDU;
     }
 
-    /**
-     * Obtain a streaming ImageHDU with preset tile configuration.  This is used to tile from a large CompressedImageHDU
-     * where decompressing the entire file into memory is impossible.  This is quite different from the asImageHDU()
-     * and is therefore a separate function.
-     * @param corners   The corners to start tiling in each axis.
-     * @param lengths   The lengths of data to write in each axis.
-     * @param steps     The number of jumps to the next read in each axis.
-     * @return          An ImageHDU instance.  Never null.
-     * @throws FitsException    Any FITS errors in reading or creating image data instances.
-     */
-    public ImageHDU asTiledImageHDU(final int[] corners, final int[] lengths, final int[] steps) throws FitsException {
-        final Header header = getGenericHeader();
-        final CompressedImageTiler compressedImageTiler = new CompressedImageTiler(this);
-        final StreamingTileImageData streamingTileImageData = new StreamingTileImageData(header, compressedImageTiler,
-                                                                                         corners, lengths, steps);
-        return new ImageHDU(header, streamingTileImageData);
-    }
-
-    /**
+     /**
      * Given this compressed HDU, get the original (decompressed) axes.
      *
      * @return the dimensions of the axis.
@@ -199,7 +179,13 @@ public class CompressedImageHDU extends BinaryTableHDU {
         return axes;
     }
 
-    private Header getGenericHeader() throws HeaderCardException {
+    /**
+     * Obtain a header representative of a decompressed ImageHDU.
+     * @return Header with decompressed cards.
+     * @throws HeaderCardException
+     *          if the card could not be copied
+     */
+    public Header getGenericHeader() throws HeaderCardException {
         Header header = new Header();
         Cursor<String, HeaderCard> imageIterator = header.iterator();
         Cursor<String, HeaderCard> iterator = getHeader().iterator();
@@ -212,7 +198,7 @@ public class CompressedImageHDU extends BinaryTableHDU {
         return header;
     }
 
-    public void compress() throws FitsException {
+     public void compress() throws FitsException {
         getData().compress(this);
     }
 

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -77,7 +77,7 @@ public final class ArrayFuncs {
      * @param step      The number of jumps to the next read.
      */
     public static void copy(Object src, int srcPos, Object dest, int destPos, int length, int step) {
-        if (src instanceof Object[]) {
+        if (src instanceof Object[] && dest instanceof Object[]) {
             final Object[] from = (Object[]) src;
             final Object[] to = (Object[]) dest;
             int toIndex = 0;
@@ -87,12 +87,14 @@ public final class ArrayFuncs {
         } else if (step == 1) {
             System.arraycopy(src, srcPos, dest, destPos, length);
         } else {
-            for (int i = srcPos; i < srcPos + length; i += step) {
+            final int srcLength = Array.getLength(src);
+            final int loopLength = Math.min(srcLength, srcPos + length);
+            for (int i = srcPos; i < loopLength; i += step) {
                 Array.set(dest, destPos++, Array.get(src, i));
             }
         }
     }
-    
+
     /**
      * @return a description of an array (presumed rectangular).
      * @param o
@@ -103,9 +105,7 @@ public final class ArrayFuncs {
         if (base == Void.TYPE) {
             return "NULL";
         }
-        return new StringBuffer(base.getSimpleName())//
-                .append(Arrays.toString(getDimensions(o)))//
-                .toString();
+        return base.getSimpleName() + Arrays.toString(getDimensions(o));
     }
 
     /**

--- a/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
+++ b/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
@@ -114,7 +114,6 @@ import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 import nom.tam.fits.compression.provider.param.rice.RiceCompressParameters;
 import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.Standard;
-import nom.tam.image.compression.hdu.CompressedImageData;
 import nom.tam.image.compression.hdu.CompressedImageHDU;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
@@ -1013,20 +1012,20 @@ public class CompressedImageTilerTest {
     }
 
     @Test
-    public void testGetDecompressedAxes() throws Exception {
+    public void testGetImageAxes() throws Exception {
         final File sourceFile = new File("src/test/resources/nom/tam/image/provided/m13real_rice.fits");
         try (final Fits sourceFits = new Fits(sourceFile, true)) {
             final CompressedImageHDU compressedImageHDU = (CompressedImageHDU) sourceFits.getHDU(1);
 
             Assert.assertArrayEquals("Wrong decompressed axes.", new int[]{300, 300},
-                                     compressedImageHDU.getDecompressedAxes());
+                                     compressedImageHDU.getImageAxes());
 
             compressedImageHDU.getHeader().findCard(Compression.ZNAXIS).setValue(0);
-            Assert.assertNull("Should be null origin axes.", compressedImageHDU.getDecompressedAxes());
+            Assert.assertNull("Should be null origin axes.", compressedImageHDU.getImageAxes());
 
             compressedImageHDU.getHeader().findCard(Compression.ZNAXIS).setValue(-1);
             try {
-                compressedImageHDU.getDecompressedAxes();
+                compressedImageHDU.getImageAxes();
                 fail("Should throw FitsException.");
             } catch (FitsException fitsException) {
                 // Good.
@@ -1035,7 +1034,7 @@ public class CompressedImageTilerTest {
             compressedImageHDU.getHeader().findCard(Compression.ZNAXIS)
                               .setValue(CompressedImageHDU.MAX_NAXIS_ALLOWED + 1);
             try {
-                compressedImageHDU.getDecompressedAxes();
+                compressedImageHDU.getImageAxes();
                 fail("Should throw FitsException.");
             } catch (FitsException fitsException) {
                 // Good.

--- a/src/test/java/nom/tam/util/DefaultMethodsTest.java
+++ b/src/test/java/nom/tam/util/DefaultMethodsTest.java
@@ -323,7 +323,7 @@ public class DefaultMethodsTest {
     }
 
 
-    class DefaultOutput implements ArrayDataOutput {
+    public static class DefaultOutput implements ArrayDataOutput {
 
         @Override
         public void write(int b) throws IOException {


### PR DESCRIPTION
A bit of an ugly one.  This is to support cutting out of Compressed images to a Stream.  We have very large cubes compressed using `fcat` that need to support streamed cutouts.  This also includes some fixes for the re-introduced `Float` support.