### PR TITLE
Use JDK 17 for CI

### DIFF
--- a/.github/workflows/gh-package.yml
+++ b/.github/workflows/gh-package.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
           cache: 'maven'
                    

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,10 +35,10 @@ jobs:
         repository: nom-tam-fits/blackbox-images
         path: blackbox-images
         
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
         cache: maven
         
@@ -93,7 +93,7 @@ jobs:
     - name: Set up Java for Publishing to Nexus
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
         cache: maven
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -36,10 +36,10 @@ jobs:
         ref: 'gh-pages'
         path: site
         
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
         cache: maven
         server-username: 'git'


### PR DESCRIPTION
Since JDK 17 has somewhat recently became the next LTS release of Java, our github workflows should use it. This means bumping from JDK 11 to JDK 17 in `actions/setup-java@v3`