### PR TITLE
Allow accessing binary table elements / rows in deferred mode

### DIFF
--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -780,10 +780,6 @@ public class AsciiTable extends AbstractTableData {
         return res;
     }
 
-    /**
-     * @deprecated Strongly discouraged, since it requires data to be supplied in an unnatural flattened format or heap
-     *                 pointers only for variable-sized data (use {@link #setElement(int, int, Object)} instead).
-     */
     @Override
     public void setColumn(int col, Object newData) throws FitsException {
         ensureData();

--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -117,8 +117,7 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
     public static boolean isData(Object o) {
 
         if (o instanceof Object[]) {
-            Object[] oo = (Object[]) o;
-            for (Object element : oo) {
+            for (Object element : (Object[]) o) {
                 if (!(element instanceof String[]) && //
                         !(element instanceof int[]) && //
                         !(element instanceof long[]) && //

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -127,7 +127,7 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
     protected DataClass myData = null;
 
     /**
-     * Creates a new HDU from the specified FITS header and associated data object
+     * Creates a new HDU from the specified FITS header and associated data object.
      * 
      * @deprecated          intended for internal use. Its visibility should be reduced to package level in the future.
      * 

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -404,11 +404,10 @@ public class BinaryTable extends AbstractTableData {
     }
 
     /**
-     * Enables or disables the use of <code>long</code> heap pointers rather than
-     * <code>int<code> pointers, when creating
-     * variable length columns in this table.
+     * Enables or disables the use of <code>long</code> heap pointers rather than <code>int</code> pointers, when
+     * creating variable length columns in this table.
      * 
-     * @param value     <code>true</code> to use 64-bit heap pointers, or <code>false</code> for 32-bit pointers.
+     * @param value <code>true</code> to use 64-bit heap pointers, or <code>false</code> for 32-bit pointers.
      * 
      * @since       1.18
      * 
@@ -419,10 +418,10 @@ public class BinaryTable extends AbstractTableData {
     }
 
     /**
-     * Checks if <code>long</code> heap pointers are used rather than <code>int<code> pointers, when creating
-     * variable length columns in this table.
+     * Checks if <code>long</code> heap pointers are used rather than <code>int</code> pointers, when creating variable
+     * length columns in this table.
      * 
-     * @return   <code>true</code> if 64-bit heap pointers are to be used, or <code>false</code> if 32-bit pointers.
+     * @return <code>true</code> if 64-bit heap pointers are to be used, or <code>false</code> if 32-bit pointers.
      * 
      * @since  1.18
      * 

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -47,6 +47,7 @@ import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
 import nom.tam.util.ColumnTable;
 import nom.tam.util.Cursor;
+import nom.tam.util.FitsEncoder;
 import nom.tam.util.FitsIO;
 import nom.tam.util.RandomAccess;
 import nom.tam.util.TableException;
@@ -1004,6 +1005,13 @@ public class BinaryTable extends AbstractTableData {
     }
 
     private Object arrayToVariableColumn(ColumnDesc added, Object o) throws FitsException {
+        if (!added.isLongVary()) {
+            if (getHeapSize() + FitsEncoder.computeSize(o) > Integer.MAX_VALUE) {
+                // Automatically bump heap pointer size if we need it
+                added.isLongVary = true;
+            }
+        }
+
         if (added.isBoolean) {
             // Handle addRow/addElement
             if (o instanceof boolean[]) {
@@ -1513,7 +1521,8 @@ public class BinaryTable extends AbstractTableData {
     }
 
     /**
-     * (<i>for internal use</i>)
+     * (<i>for internal use</i>) Used Only by {@link nom.tam.image.compression.hdu.CompressedTableData} so it would make
+     * a better private method in there.
      * 
      * @throws TableException if the column could not be added.
      */

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -405,10 +405,12 @@ public class BinaryTable extends AbstractTableData {
     }
 
     /**
-     * Enables or disables the use of <code>long</code> heap pointers rather than <code>int</code> pointers, when
-     * creating variable length columns in this table.
+     * Enables or disables a preference for <code>long</code> heap pointers rather than <code>int</code> pointers, when
+     * creating variable length columns in this table. Even if the preference is for 32-bit pointers, the type actually
+     * used may be bumped automatically to 64-bit if need be to store and access the new column data on the heap.
      * 
-     * @param value <code>true</code> to use 64-bit heap pointers, or <code>false</code> for 32-bit pointers.
+     * @param value <code>true</code> to use 64-bit heap pointers, or <code>false</code> to prefer 32-bit pointers when
+     *                  possible.
      * 
      * @since       1.18
      * 
@@ -420,9 +422,11 @@ public class BinaryTable extends AbstractTableData {
 
     /**
      * Checks if <code>long</code> heap pointers are used rather than <code>int</code> pointers, when creating variable
-     * length columns in this table.
+     * length columns in this table. Even if the preference is for 32-bit pointers, the type actually used may be bumped
+     * automatically to 64-bit if need be to store and access the new column data on the heap.
      * 
-     * @return <code>true</code> if 64-bit heap pointers are to be used, or <code>false</code> if 32-bit pointers.
+     * @return <code>true</code> if 64-bit heap pointers are to be used, or <code>false</code> if we prefer 32-bit
+     *             pointers when possible.
      * 
      * @since  1.18
      * 

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -799,10 +799,12 @@ public class BinaryTable extends AbstractTableData {
             throw new FitsException("Invalid row");
         }
 
-        if (table != null) {
-            return getMemoryRow(row);
+        Object[] data = new Object[columnList.size()];
+
+        for (int col = 0; col < data.length; col++) {
+            data[col] = getElement(row, col);
         }
-        return getFileRow(row);
+        return data;
     }
 
     /**
@@ -1287,65 +1289,6 @@ public class BinaryTable extends AbstractTableData {
         } catch (Exception e) {
             BinaryTable.LOG.log(Level.SEVERE, "reading data of binary table failed!", e);
         }
-    }
-
-    /**
-     * @return               row from the file.
-     *
-     * @throws FitsException if the operation failed
-     */
-    private Object[] getFileRow(int row) throws FitsException {
-        /**
-         * Read the row from memory
-         */
-        Object[] data = new Object[columnList.size()];
-
-        FitsUtil.reposition(currInput, getFileOffset() + (long) row * (long) rowLen);
-
-        for (int col = 0; col < data.length; col++) {
-            ColumnDesc colDesc = columnList.get(col);
-            data[col] = colDesc.newInstance(1);
-
-            try {
-                if (!colDesc.isBoolean && colDesc.base != char.class) {
-                    currInput.readImage(data[col]);
-                } else {
-                    currInput.readArrayFully(data[col]);
-                }
-            } catch (IOException e) {
-                throw new FitsException("Error in file row read", e);
-            }
-
-            data[col] = columnToArray(colDesc, data[col], 1);
-            data[col] = encurl(data[col], col, 1);
-            if (data[col] instanceof Object[]) {
-                data[col] = ((Object[]) data[col])[0];
-            }
-        }
-        return data;
-    }
-
-    /**
-     * Get a row from memory.
-     *
-     * @throws FitsException if the operation failed
-     */
-    private Object[] getMemoryRow(int row) throws FitsException {
-
-        Object[] modelRow = getModelRow();
-        Object[] data = new Object[modelRow.length];
-        for (int col = 0; col < modelRow.length; col++) {
-            ColumnDesc colDesc = columnList.get(col);
-            Object o = table.getElement(row, col);
-            o = columnToArray(colDesc, o, 1);
-            data[col] = encurl(o, col, 1);
-            if (data[col] instanceof Object[]) {
-                data[col] = ((Object[]) data[col])[0];
-            }
-        }
-
-        return data;
-
     }
 
     /**

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -678,7 +678,7 @@ public class BinaryTable extends AbstractTableData {
         if (table == null) {
             try {
                 RandomAccess r = (RandomAccess) currInput;
-                r.position(getFileOffset() + i * rowLen + colDesc.offset);
+                r.position(getFileOffset() + i * (long) rowLen + colDesc.offset);
 
                 ele = colDesc.newInstance(1);
                 if (!colDesc.isBoolean && colDesc.base != char.class) {

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -215,11 +215,6 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
         }
 
         stream.println("      Data Information:");
-        if (myData == null) {
-            stream.println("         No data present");
-            return;
-        }
-
         stream.println("          Number of rows=" + this.myData.getNRows());
         stream.println("          Number of columns=" + this.myData.getNCols());
         stream.println("          Heap size is: " + this.myData.getHeapSize() + " bytes");
@@ -316,13 +311,7 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
             }
         }
         // Now update the header.
-        myHeader.findCard(TFORMn.n(index + 1));
-        HeaderCard hc = myHeader.nextCard();
-        String oldComment = hc.getComment();
-        if (oldComment == null) {
-            oldComment = "Column converted to complex";
-        }
-        myHeader.card(TFORMn.n(index + 1)).value(dim + prefix + suffix).comment(oldComment);
+        myHeader.card(TFORMn.n(index + 1)).value(dim + prefix + suffix).comment("converted to complex");
         if (tdim.length() > 0) {
             myHeader.addValue(TDIMn.n(index + 1), "(" + tdim + ")");
         } else {

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -255,6 +255,23 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
     }
 
     /**
+     * Checks if a column contains complex-valued data (rather than just regular float or double arrays)
+     * 
+     * @param  index the column index
+     * 
+     * @return       <code>true</code> if the column contains complex valued data (as floats or doubles), otherwise
+     *                   <code>false</code>
+     * 
+     * @since        1.18
+     * 
+     * @see          BinaryTable#isComplexColumn(int)
+     * @see          #setComplexColumn(int)
+     */
+    public final boolean isComplexColumn(int index) {
+        return myData.isComplexColumn(index);
+    }
+
+    /**
      * Convert a column in the table to complex. Only tables with appropriate types and dimensionalities can be
      * converted. It is legal to call this on a column that is already complex.
      *
@@ -263,59 +280,64 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
      * @return               Whether the column can be converted
      *
      * @throws FitsException if the header could not be adapted
+     * 
+     * @see                  BinaryTableHDU#setComplexColumn(int)
      */
     public boolean setComplexColumn(int index) throws FitsException {
-        Standard.context(BinaryTable.class);
-        boolean status = false;
-        if (myData.setComplexColumn(index)) {
-            // No problem with the data. Make sure the header
-            // is right.
-            BinaryTable.ColumnDesc colDesc = myData.getDescriptor(index);
-            int dim = 1;
-            String tdim = "";
-            String sep = "";
-            // Don't loop over all values.
-            // The last is the [2] for the complex data.
-            int[] dimens = colDesc.getDimens();
-            for (int i = 0; i < dimens.length - 1; i++) {
-                dim *= dimens[i];
-                tdim = dimens[i] + sep + tdim;
-                sep = ",";
-            }
-            String suffix = "C"; // For complex
-            // Update the TFORMn keyword.
 
-            if (colDesc.getBase() == double.class) {
-                suffix = "M";
-            }
-            // Worry about variable length columns.
-            String prefix = "";
-            if (myData.getDescriptor(index).isVarying()) {
-                prefix = "P";
-                dim = 1;
-                if (myData.getDescriptor(index).isLongVary()) {
-                    prefix = "Q";
-                }
-            }
-            // Now update the header.
-            myHeader.findCard(TFORMn.n(index + 1));
-            HeaderCard hc = myHeader.nextCard();
-            String oldComment = hc.getComment();
-            if (oldComment == null) {
-                oldComment = "Column converted to complex";
-            }
-            myHeader.card(TFORMn.n(index + 1)).value(dim + prefix + suffix).comment(oldComment);
-            if (tdim.length() > 0) {
-                myHeader.addValue(TDIMn.n(index + 1), "(" + tdim + ")");
-            } else {
-                // Just in case there used to be a TDIM card that's no longer
-                // needed.
-                myHeader.deleteKey(TDIMn.n(index + 1));
-            }
-            status = true;
+        if (!myData.setComplexColumn(index)) {
+            return false;
         }
+
+        Standard.context(BinaryTable.class);
+
+        // No problem with the data. Make sure the header
+        // is right.
+        BinaryTable.ColumnDesc colDesc = myData.getDescriptor(index);
+        int dim = 1;
+        String tdim = "";
+        String sep = "";
+        // Don't loop over all values.
+        // The last is the [2] for the complex data.
+        int[] dimens = colDesc.getDimens();
+        for (int i = 0; i < dimens.length - 1; i++) {
+            dim *= dimens[i];
+            tdim = dimens[i] + sep + tdim;
+            sep = ",";
+        }
+        String suffix = "C"; // For complex
+        // Update the TFORMn keyword.
+
+        if (colDesc.getBase() == double.class) {
+            suffix = "M";
+        }
+        // Worry about variable length columns.
+        String prefix = "";
+        if (myData.getDescriptor(index).isVarying()) {
+            prefix = "P";
+            dim = 1;
+            if (myData.getDescriptor(index).isLongVary()) {
+                prefix = "Q";
+            }
+        }
+        // Now update the header.
+        myHeader.findCard(TFORMn.n(index + 1));
+        HeaderCard hc = myHeader.nextCard();
+        String oldComment = hc.getComment();
+        if (oldComment == null) {
+            oldComment = "Column converted to complex";
+        }
+        myHeader.card(TFORMn.n(index + 1)).value(dim + prefix + suffix).comment(oldComment);
+        if (tdim.length() > 0) {
+            myHeader.addValue(TDIMn.n(index + 1), "(" + tdim + ")");
+        } else {
+            // Just in case there used to be a TDIM card that's no longer
+            // needed.
+            myHeader.deleteKey(TDIMn.n(index + 1));
+        }
+
         Standard.context(null);
-        return status;
+        return true;
     }
 
     // Need to tell header about the Heap before writing.

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -193,9 +193,6 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
 
     @Override
     public void info(PrintStream stream) {
-
-        BinaryTable myData = this.myData;
-
         stream.println("  Binary Table");
         stream.println("      Header Information:");
 
@@ -215,11 +212,11 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
         }
 
         stream.println("      Data Information:");
-        stream.println("          Number of rows=" + this.myData.getNRows());
-        stream.println("          Number of columns=" + this.myData.getNCols());
-        stream.println("          Heap size is: " + this.myData.getHeapSize() + " bytes");
+        stream.println("          Number of rows=" + myData.getNRows());
+        stream.println("          Number of columns=" + myData.getNCols());
+        stream.println("          Heap size is: " + myData.getHeapSize() + " bytes");
 
-        Object[] cols = this.myData.getFlatColumns();
+        Object[] cols = myData.getFlatColumns();
         for (int i = 0; i < cols.length; i++) {
             stream.println("           " + i + ":" + ArrayFuncs.arrayDescription(cols[i]));
         }

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -217,21 +217,16 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
         stream.println("      Data Information:");
         if (myData == null) {
             stream.println("         No data present");
-        } else if (this.myData.getNRows() == 0 || this.myData.getNCols() == 0) {
-            stream.println("         Empty data content");
-            if (this.myData.getHeapSize() > 0) {
-                stream.println("         Heap size is: " + this.myData.getHeapSize() + " bytes");
-            }
-        } else {
-            stream.println("          Number of rows=" + this.myData.getNRows());
-            stream.println("          Number of columns=" + this.myData.getNCols());
-            if (this.myData.getHeapSize() > 0) {
-                stream.println("         Heap size is: " + this.myData.getHeapSize() + " bytes");
-            }
-            Object[] cols = this.myData.getFlatColumns();
-            for (int i = 0; i < cols.length; i++) {
-                stream.println("           " + i + ":" + ArrayFuncs.arrayDescription(cols[i]));
-            }
+            return;
+        }
+
+        stream.println("          Number of rows=" + this.myData.getNRows());
+        stream.println("          Number of columns=" + this.myData.getNCols());
+        stream.println("          Heap size is: " + this.myData.getHeapSize() + " bytes");
+
+        Object[] cols = this.myData.getFlatColumns();
+        for (int i = 0; i < cols.length; i++) {
+            stream.println("           " + i + ":" + ArrayFuncs.arrayDescription(cols[i]));
         }
     }
 

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -99,11 +99,11 @@ import static nom.tam.fits.header.extra.CXCExt.LONGSTRN;
  * Beyond the keywords that describe the type, shape, and size of data, the library will not add further information to
  * the header. The users of the library are responsible to complete the header description as necessary. This includes
  * non-enssential data descriptions (such as <code>EXTNAME</code>, <code>BUNIT</code>, <code>OBSERVER</code>, or
- * optional table column descriptors <code>TTYPE</code><i>n</i>, <code>TDIM</code><i>n</i>, <code>TUNIT</code><i>n</i>,
- * coordinate systems via the appropriate WCS keywords, or checksums). Users of the library are responsible for
- * completing the data description using whatever standard or conventional keywords are available and appropriate.
- * Please refer to the <a href="https://fits.gsfc.nasa.gov/fits_standard.html">FITS Standard</a> documentation to see
- * what typical descriptions of data you might want to use.
+ * optional table column descriptors <code>TTYPE</code><i>n</i>, <code>TUNIT</code><i>n</i>, coordinate systems via the
+ * appropriate WCS keywords, or checksums). Users of the library are responsible for completing the data description
+ * using whatever standard or conventional keywords are available and appropriate. Please refer to the
+ * <a href="https://fits.gsfc.nasa.gov/fits_standard.html">FITS Standard</a> documentation to see what typical
+ * descriptions of data you might want to use.
  * </p>
  * <p>
  * Last but not least, the header is also a place where FITS creators can store (nearly) arbitrary key/value pairs. In

--- a/src/main/java/nom/tam/fits/TableData.java
+++ b/src/main/java/nom/tam/fits/TableData.java
@@ -225,10 +225,8 @@ public interface TableData {
     Object[] getRow(int row) throws FitsException;
 
     /**
-     * Sets new data for a table column. Unlike {@link #addColumn(Object)}, the
-     * data must be supplied in flattened form as a single 1D array. See
-     * {@link #addColumn(Object)} for more information on the column data
-     * format.
+     * Sets new data for a table column. See {@link #addColumn(Object)} for more
+     * information on the column data format.
      * 
      * @param col
      *            the 0-based column index
@@ -238,10 +236,6 @@ public interface TableData {
      *            information on the column data format.
      * @throws FitsException
      *             if the table could not be modified
-     * @deprecated Strongly discouraged, since it requires data to be supplied
-     *             in an unnatural flattened format or heap pointers only for
-     *             variable-sized data (use
-     *             {@link #setElement(int, int, Object)} instead).
      * @see #getNCols()
      * @see #getColumn(int)
      * @see #setRow(int, Object[])

--- a/src/main/java/nom/tam/fits/TableData.java
+++ b/src/main/java/nom/tam/fits/TableData.java
@@ -238,8 +238,8 @@ public interface TableData {
      *            information on the column data format.
      * @throws FitsException
      *             if the table could not be modified
-     * @deprecated Strongly discouraged, since it requires data to be supplied in
-     *             an unnatural flattened format or heap pointers only for
+     * @deprecated Strongly discouraged, since it requires data to be supplied
+     *             in an unnatural flattened format or heap pointers only for
      *             variable-sized data (use
      *             {@link #setElement(int, int, Object)} instead).
      * @see #getNCols()

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -406,39 +406,34 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
     }
 
     /**
-     * Update a column within a table. The new column should have the same format ast the column being replaced.
+     * Update a column within a table. The new column should have the same format ast the column being replaced. See
+     * {@link TableData#addColumn(Object)} for more information about the column data format.
      *
-     * @param      col           index of the column to replace
-     * @param      newCol        the replacement column
+     * @param  col           index of the column to replace
+     * @param  newCol        the replacement column
      *
-     * @throws     FitsException if the operation failed
+     * @throws FitsException if the operation failed
      * 
-     * @deprecated               Strongly discouraged, since it requires data to be supplied in an unnatural flattened
-     *                               format or heap pointers only for variable-sized data (use
-     *                               {@link #setElement(int, int, Object)} instead).
-     * 
-     * @see                      #getColumn(int)
-     * @see                      #setColumn(String, Object)
+     * @see                  #getColumn(int)
+     * @see                  #setColumn(String, Object)
+     * @see                  TableData#addColumn(Object)
      */
     public void setColumn(int col, Object newCol) throws FitsException {
         myData.setColumn(col, newCol);
     }
 
     /**
-     * Update a column within a table. The new column should have the same format as the column being replaced.
+     * Update a column within a table. The new column should have the same format as the column being replaced. See
+     * {@link TableData#addColumn(Object)} for more information about the column data format.
      *
-     * @param      colName       name of the column to replace
-     * @param      newCol        the replacement column
+     * @param  colName       name of the column to replace
+     * @param  newCol        the replacement column
      *
-     * @throws     FitsException if the operation failed
+     * @throws FitsException if the operation failed
      * 
-     * @deprecated               Strongly discouraged, since it requires data to be supplied in an unnatural flattened
-     *                               format or heap pointers only for variable-sized data (use
-     *                               {@link #findColumn(String)} in combination with
-     *                               {@link #setElement(int, int, Object)} instead).
-     * 
-     * @see                      #getColumn(String)
-     * @see                      #setColumn(int, Object)
+     * @see                  #getColumn(String)
+     * @see                  #setColumn(int, Object)
+     * @see                  TableData#addColumn(Object)
      */
     public void setColumn(String colName, Object newCol) throws FitsException {
         setColumn(findColumn(colName), newCol);

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
@@ -122,6 +122,7 @@ public class CompressedTableData extends BinaryTable {
         }
         tiles = new ArrayList<>();
         for (int column = 0; column < ncols; column++) {
+            setCreateLongVary(true);
             addByteVaryingColumn();
             int tileIndex = 1;
             for (int rowStart = 0; rowStart < nrows; rowStart += rowsPerTile) {

--- a/src/main/java/nom/tam/util/ColumnTable.java
+++ b/src/main/java/nom/tam/util/ColumnTable.java
@@ -629,8 +629,8 @@ public class ColumnTable<T> implements DataTable {
     }
 
     /**
-     * @deprecated Strongly discouraged, since it returns data in an unnatural flattened format or  heap pointers only for
-     *                 variable-sized data (use {@link #getElement(int, int)} instead)
+     * @deprecated Strongly discouraged, since it returns data in an unnatural flattened format or heap pointers only
+     *                 for variable-sized data (use {@link #getElement(int, int)} instead)
      */
     @Override
     public Object getColumn(int col) {
@@ -638,7 +638,7 @@ public class ColumnTable<T> implements DataTable {
     }
 
     /**
-     * @deprecated Strongly discouraged, since it returns columns in an unnatural flattened format or  heap pointers only
+     * @deprecated Strongly discouraged, since it returns columns in an unnatural flattened format or heap pointers only
      *                 for variable-sized data (use {@link #getElement(int, int)} or {@link #getRow(int)} instead)
      * 
      * @return     An array containing the flattened data for each column. Each columns's data is represented by a
@@ -763,10 +763,6 @@ public class ColumnTable<T> implements DataTable {
         }
     }
 
-    /**
-     * @deprecated Strongly discouraged, since it requires data to be supplied in an unnatural flattened format or heap
-     *                 pointer only for variable-sized data (use {@link #setElement(int, int, Object)} instead).
-     */
     @Override
     public void setColumn(int col, Object newColumn) throws TableException {
 

--- a/src/main/java/nom/tam/util/DataTable.java
+++ b/src/main/java/nom/tam/util/DataTable.java
@@ -116,7 +116,9 @@ public interface DataTable {
     Object getRow(int row);
 
     /**
-     * Sets new data for a table column
+     * Sets new data for a table column. See
+     * {@link nom.tam.fits.TableData#addColumn(Object)} for more information
+     * about the expected column data format.
      * 
      * @param column
      *            the column index
@@ -125,10 +127,6 @@ public interface DataTable {
      *            specified column.
      * @throws TableException
      *             if the table could not be modified
-     * @deprecated Strongly discouraged, since it requires data to be supplied
-     *             in an unnatural flattened format or heap pointers only for
-     *             variable-sized data (use
-     *             {@link #setElement(int, int, Object)} instead).
      * @see #getNCols()
      * @see #getColumn(int)
      * @see #setRow(int, Object)

--- a/src/main/java/nom/tam/util/DataTable.java
+++ b/src/main/java/nom/tam/util/DataTable.java
@@ -125,8 +125,8 @@ public interface DataTable {
      *            specified column.
      * @throws TableException
      *             if the table could not be modified
-     * @deprecated Strongly discouraged, since it requires data to be supplied in
-     *             an unnatural flattened format or heap pointers only for
+     * @deprecated Strongly discouraged, since it requires data to be supplied
+     *             in an unnatural flattened format or heap pointers only for
      *             variable-sized data (use
      *             {@link #setElement(int, int, Object)} instead).
      * @see #getNCols()

--- a/src/test/java/nom/tam/fits/FitsHeapTest.java
+++ b/src/test/java/nom/tam/fits/FitsHeapTest.java
@@ -157,4 +157,12 @@ public class FitsHeapTest {
         heap.putData(new Header());
     }
 
+    @Test
+    public void testHeapSize() throws Exception {
+        int size = 1033;
+        FitsHeap heap = new FitsHeap(size);
+        Assert.assertEquals(size, heap.getSize());
+
+    }
+
 }

--- a/src/test/java/nom/tam/fits/test/BinaryTableTest.java
+++ b/src/test/java/nom/tam/fits/test/BinaryTableTest.java
@@ -289,7 +289,6 @@ public class BinaryTableTest {
         }
         // Tom -> here the table is replaced by a copy that is not the same but
         // should be?
-        FitsFactory.setUseAsciiTables(true);
         btab = new BinaryTable(btab.getData());
 
         f = new Fits();

--- a/src/test/java/nom/tam/fits/test/BinaryTableTest.java
+++ b/src/test/java/nom/tam/fits/test/BinaryTableTest.java
@@ -1688,6 +1688,66 @@ public class BinaryTableTest {
         hdu.getData().getRow(0);
     }
 
+    @Test
+    public void testModelRow() throws Exception {
+        BinaryTable bt = createTestTable();
+
+        Object[] m = bt.getModelRow();
+
+        assertEquals(8, m.length);
+
+        assertEquals(floats[0].getClass(), m[0].getClass());
+        assertEquals(int[].class, m[1].getClass()); // var-array
+        assertEquals(byte[].class, m[2].getClass()); // string
+        assertEquals(int[].class, m[3].getClass()); // var-array
+        assertEquals(int[].class, m[4].getClass()); // int
+        assertEquals(int[].class, m[5].getClass()); // var-array
+        assertEquals(float[].class, m[6].getClass()); // complex
+        assertEquals(byte[][].class, m[7].getClass()); // string[]
+    }
+
+    @Test
+    public void testConvertVarComplexColumn() throws Exception {
+        float[][] f = new float[3][];
+
+        f[0] = new float[10];
+        f[1] = new float[2];
+        f[2] = new float[14];
+
+        BinaryTable t = new BinaryTable();
+        t.setCreateLongVary(false);
+        t.addColumn(f);
+        Assert.assertTrue(t.isVarLengthColumn(0));
+
+        BinaryTableHDU h = new BinaryTableHDU(new Header(), t);
+        t.fillHeader(h.getHeader());
+
+        Assert.assertFalse(h.isComplexColumn(0));
+        h.setComplexColumn(0);
+        Assert.assertTrue(h.isComplexColumn(0));
+    }
+
+    @Test
+    public void testConvertLongVarComplexColumn() throws Exception {
+        float[][] f = new float[3][];
+
+        f[0] = new float[10];
+        f[1] = new float[2];
+        f[2] = new float[14];
+
+        BinaryTable t = new BinaryTable();
+        t.setCreateLongVary(true);
+        t.addColumn(f);
+        Assert.assertTrue(t.isVarLengthColumn(0));
+
+        BinaryTableHDU h = new BinaryTableHDU(new Header(), t);
+        t.fillHeader(h.getHeader());
+
+        Assert.assertFalse(h.isComplexColumn(0));
+        h.setComplexColumn(0);
+        Assert.assertTrue(h.isComplexColumn(0));
+    }
+
     private BinaryTable createTestTable() throws FitsException {
         BinaryTable btab = new BinaryTable();
 

--- a/src/test/java/nom/tam/fits/test/BinaryTableTest.java
+++ b/src/test/java/nom/tam/fits/test/BinaryTableTest.java
@@ -1597,7 +1597,7 @@ public class BinaryTableTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PrintStream stream = new PrintStream(out);
         tableHdu.info(stream);
-        Assert.assertFalse(out.toString().contains("Number of rows="));
+        Assert.assertTrue(out.toString().contains("Number of rows=0"));
     }
 
     @Test(expected = TableException.class)
@@ -1716,6 +1716,7 @@ public class BinaryTableTest {
 
         BinaryTable t = new BinaryTable();
         t.setCreateLongVary(false);
+        Assert.assertFalse(t.isCreateLongVary());
         t.addColumn(f);
         Assert.assertTrue(t.isVarLengthColumn(0));
 
@@ -1737,6 +1738,8 @@ public class BinaryTableTest {
 
         BinaryTable t = new BinaryTable();
         t.setCreateLongVary(true);
+        Assert.assertTrue(t.isCreateLongVary());
+
         t.addColumn(f);
         Assert.assertTrue(t.isVarLengthColumn(0));
 
@@ -1746,6 +1749,23 @@ public class BinaryTableTest {
         Assert.assertFalse(h.isComplexColumn(0));
         h.setComplexColumn(0);
         Assert.assertTrue(h.isComplexColumn(0));
+    }
+
+    @Test
+    public void testEncapsulateColumnTable() throws Exception {
+        ColumnTable ct = createTestTable().getData();
+
+        BinaryTableHDU hdu = (BinaryTableHDU) Fits.makeHDU(ct);
+        assertEquals(ct.getNRows(), hdu.getData().getNRows());
+        assertEquals(ct.getNCols(), hdu.getData().getNCols());
+    }
+
+    @Test
+    public void testCheckCompatibleData() throws Exception {
+        Assert.assertTrue(BinaryTableHDU.isData(createTestTable().getData()));
+        Assert.assertTrue(BinaryTableHDU.isData(new Object[3]));
+        Assert.assertTrue(BinaryTableHDU.isData(new Object[3][2]));
+        Assert.assertFalse(BinaryTableHDU.isData(new Object()));
     }
 
     private BinaryTable createTestTable() throws FitsException {

--- a/src/test/java/nom/tam/util/FitsDecoderTest.java
+++ b/src/test/java/nom/tam/util/FitsDecoderTest.java
@@ -441,6 +441,14 @@ public class FitsDecoderTest {
         e.readImage(new boolean[10]);
     }
 
+    @Test
+    public void testReadZeroLengthImage() throws Exception {
+        byte[] data = new byte[100];
+        FitsDecoder e = new FitsDecoder(InputReader.from(new ByteArrayInputStream(data)));
+        e.readImage(new byte[0]);
+        // No exception
+    }
+
     private static class EOFExceptionInputReader implements InputReader {
         @Override
         public int read(byte[] b, int off, int len) throws IOException {


### PR DESCRIPTION
Up to now, we always loaded the whole shebang of a binary table into memory as soon as we accessed a single element or row from it. But, we don't have to when using random-accessible inputs. Tables can be huge, and often we need only select elements from it (e.g. a few columns from a set of rows).

So, update `BinaryTable` to allow accessing elements and rows directly from the random-accessible input. (The heap will get lazy loaded at the first access to prevent buffer swapping between the main table and heap areas within the same file -- however heaps load fast, since it's a direct byte transfer into an `java.nio.ByteBuffer` without any processing). We still have the option to load the main table into memory as well if that is practical, using `TableHDU.getKernel()` or the equivalent `TableData.getKernel()` methods.

(The upstream README is already updated to reflect the effect of this PR)