### PR TITLE
Hierarch helper

### DIFF
--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -37,7 +37,9 @@ import nom.tam.fits.header.IFitsHeader;
 /**
  * This is the file represents the common keywords between CXC and STSclExt
  *
- * @author Richard van Nieuwenhoven
+ * @author     Richard van Nieuwenhoven
+ * 
+ * @deprecated (<i>for internal use</i>) Visibility will be reduced to the package leven in the future.
  */
 public enum CXCStclSharedExt implements IFitsHeader {
     /**

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -39,12 +39,12 @@ import nom.tam.fits.header.IFitsHeader;
  * A Set of FITS Standard Extensions for Amateur Astronomical Processing Software Packages published by SBIG.
  * </p>
  * <p>
- * Please note that SBIG has published a FITS Standard SBIGFITSEXT that SBIG with CCDOps , Software Bisque with CCDSoft
+ * Please note that SBIG has published a FITS Standard SBIGFITSEXT that SBIG with CCDOps, Software Bisque with CCDSoft
  * and Diffraction Limited with MaximDl all agreed to and implemented.
  * </p>
  * <p>
- * See
- * <a href="http://archive.sbig.com/pdffiles/SBFITSEXT_1r0.pdf">http://archive.sbig.com/pdffiles/SBFITSEXT_1r0.pdf</a>
+ * See <a href= "https://diffractionlimited.com/wp-content/uploads/2016/11/sbfitsext_1r0.pdf">
+ * https://diffractionlimited.com/wp-content/uploads/2016/11/sbfitsext_1r0.pdf</a>
  * </p>
  *
  * @author Richard van Nieuwenhoven.

--- a/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
@@ -80,7 +80,8 @@ public final class Hierarch {
      * <code>"HIERARCH.group.property"</code>, which is how we refer to this keyword internally within this library.
      * 
      * @param  components A list of hierarchical keyword components. These will be concatenated into a dot-separated
-     *                        keyword, and prepended by <code>HIERARCH.</code>.
+     *                        keyword, and prepended by <code>HIERARCH.</code>. Case-sensitivity depends on the
+     *                        formatter used, see e.g. {@link IHierarchKeyFormatter#isCaseSensitive()}.
      * 
      * @return            The keyword, prepended by "HIERARCH." as per the internal convention for referring to such
      *                        keywords within this library.

--- a/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
@@ -54,7 +54,7 @@ public final class Hierarch {
     /**
      * Creates a hierarch-style (or long) keyword to use within this library, by prepending "HIERARCH." to the
      * user-specified long or hierarchical keyword. For example, for the argument <code>"group.property"</code>, this
-     * will return <code>"HIERARCH.group.property"</code>, which is how we refer to this keyword internally within tis
+     * will return <code>"HIERARCH.group.property"</code>, which is how we refer to this keyword internally within this
      * library.
      * 
      * @param  keyword The user-defined long or hierarchical keyword. Hierarchical keywords should have components
@@ -77,7 +77,7 @@ public final class Hierarch {
     /**
      * Creates a hierarch-style keyword from its hierarchical components to use within this library, For example, for
      * the arguments <code>"group"</code> and <code>"property"</code>, this will return
-     * <code>"HIERARCH.group.property"</code>, which is how we refer to this keyword internally within tis library.
+     * <code>"HIERARCH.group.property"</code>, which is how we refer to this keyword internally within this library.
      * 
      * @param  components A list of hierarchical keyword components. These will be concatenated into a dot-separated
      *                        keyword, and prepended by <code>HIERARCH.</code>.

--- a/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
@@ -32,11 +32,11 @@ package nom.tam.fits.header.hierarch;
  */
 
 /**
- * Helper class for creating HIERARCH-style (or long) FITS keywords for use
- * within this library.
+ * Helper class for creating HIERARCH-style (or long) FITS keywords for use within this library.
  * 
  * @author Attila Kovacs
- * @since 1.18
+ * 
+ * @since  1.18
  */
 public final class Hierarch {
 
@@ -52,26 +52,52 @@ public final class Hierarch {
     }
 
     /**
-     * Creates a hierarch-style (or long) keyword to use within this library, by
-     * prepending "HIERARCH." to the user-specified long or hierarchical
-     * keyword. For example, for the arhument <code>"group.property"</code>,
-     * this will return <code>"HIERARCH.group.property"</code>, which is how we
-     * refer to this keyword internally within tis library.
+     * Creates a hierarch-style (or long) keyword to use within this library, by prepending "HIERARCH." to the
+     * user-specified long or hierarchical keyword. For example, for the argument <code>"group.property"</code>, this
+     * will return <code>"HIERARCH.group.property"</code>, which is how we refer to this keyword internally within tis
+     * library.
      * 
-     * @param keyword
-     *            The user-defined long or hierarchical keyword. Hierarchical
-     *            keywords should have components separated by dots, e.g.
-     *            <code>system.subsystem.property</code>. Case-sensitivity
-     *            depends on the formatter used, see e.g.
-     *            {@link IHierarchKeyFormatter#isCaseSensitive()}.
-     * @return The keyword, prepended by "HIERARCH." as per the internal
-     *         convention for referring to such keywords within this library.
-     * @since 1.18
-     * @see IHierarchKeyFormatter
-     * @see IHierarchKeyFormatter#setCaseSensitive(boolean)
+     * @param  keyword The user-defined long or hierarchical keyword. Hierarchical keywords should have components
+     *                     separated by dots, e.g. <code>system.subsystem.property</code>. Case-sensitivity depends on
+     *                     the formatter used, see e.g. {@link IHierarchKeyFormatter#isCaseSensitive()}.
+     * 
+     * @return         The keyword, prepended by "HIERARCH." as per the internal convention for referring to such
+     *                     keywords within this library.
+     * 
+     * @since          1.18
+     * 
+     * @see            #key(String...)
+     * @see            IHierarchKeyFormatter
+     * @see            IHierarchKeyFormatter#setCaseSensitive(boolean)
      */
     public static String key(String keyword) {
         return PREFIX + "." + keyword;
+    }
+
+    /**
+     * Creates a hierarch-style keyword from its hierarchical components to use within this library, For example, for
+     * the arguments <code>"group"</code> and <code>"property"</code>, this will return
+     * <code>"HIERARCH.group.property"</code>, which is how we refer to this keyword internally within tis library.
+     * 
+     * @param  components A list of hierarchical keyword components. These will be concatenated into a dot-separated
+     *                        keyword, and prepended by <code>HIERACH.</code>.
+     * 
+     * @return            The keyword, prepended by "HIERARCH." as per the internal convention for referring to such
+     *                        keywords within this library.
+     * 
+     * @since             1.18
+     * 
+     * @see               #key(String)
+     * @see               IHierarchKeyFormatter
+     * @see               IHierarchKeyFormatter#setCaseSensitive(boolean)
+     */
+    public static String key(String... components) {
+        StringBuilder s = new StringBuilder(PREFIX);
+        for (int i = 0; i < components.length; i++) {
+            s.append('.');
+            s.append(components[i]);
+        }
+        return s.toString();
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
@@ -1,0 +1,77 @@
+package nom.tam.fits.header.hierarch;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2023 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+/**
+ * Helper class for creating HIERARCH-style (or long) FITS keywords for use
+ * within this library.
+ * 
+ * @author Attila Kovacs
+ * @since 1.18
+ */
+public final class Hierarch {
+
+    /**
+     * The string prefix we use internally to identify HIERARCH-style keywords.
+     */
+    private static final String PREFIX = "HIERARCH";
+
+    /**
+     * Private constructor since we don't want to instantiate this class.
+     */
+    private Hierarch() {
+    }
+
+    /**
+     * Creates a hierarch-style (or long) keyword to use within this library, by
+     * prepending "HIERARCH." to the user-specified long or hierarchical
+     * keyword. For example, for the arhument <code>"group.property"</code>,
+     * this will return <code>"HIERARCH.group.property"</code>, which is how we
+     * refer to this keyword internally within tis library.
+     * 
+     * @param keyword
+     *            The user-defined long or hierarchical keyword. Hierarchical
+     *            keywords should have components separated by dots, e.g.
+     *            <code>system.subsystem.property</code>. Case-sensitivity
+     *            depends on the formatter used, see e.g.
+     *            {@link IHierarchKeyFormatter#isCaseSensitive()}.
+     * @return The keyword, prepended by "HIERARCH." as per the internal
+     *         convention for referring to such keywords within this library.
+     * @since 1.18
+     * @see IHierarchKeyFormatter
+     * @see IHierarchKeyFormatter#setCaseSensitive(boolean)
+     */
+    public static String key(String keyword) {
+        return PREFIX + "." + keyword;
+    }
+
+}

--- a/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
@@ -31,6 +31,8 @@ package nom.tam.fits.header.hierarch;
  * #L%
  */
 
+import nom.tam.fits.FitsFactory;
+
 /**
  * Helper class for creating HIERARCH-style (or long) FITS keywords for use within this library.
  * 
@@ -67,7 +69,7 @@ public final class Hierarch {
      * @since          1.18
      * 
      * @see            #key(String...)
-     * @see            IHierarchKeyFormatter
+     * @see            FitsFactory#getHierarchFormater()
      * @see            IHierarchKeyFormatter#setCaseSensitive(boolean)
      */
     public static String key(String keyword) {
@@ -89,7 +91,7 @@ public final class Hierarch {
      * @since             1.18
      * 
      * @see               #key(String)
-     * @see               IHierarchKeyFormatter
+     * @see               FitsFactory#getHierarchFormater()
      * @see               IHierarchKeyFormatter#setCaseSensitive(boolean)
      */
     public static String key(String... components) {

--- a/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
@@ -80,7 +80,7 @@ public final class Hierarch {
      * <code>"HIERARCH.group.property"</code>, which is how we refer to this keyword internally within tis library.
      * 
      * @param  components A list of hierarchical keyword components. These will be concatenated into a dot-separated
-     *                        keyword, and prepended by <code>HIERACH.</code>.
+     *                        keyword, and prepended by <code>HIERARCH.</code>.
      * 
      * @return            The keyword, prepended by "HIERARCH." as per the internal convention for referring to such
      *                        keywords within this library.

--- a/src/main/java/nom/tam/fits/header/hierarch/IHierarchKeyFormatter.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/IHierarchKeyFormatter.java
@@ -40,6 +40,7 @@ import nom.tam.fits.utilities.FitsLineAppender;
  * keywords and will format them according to its rules when writing them to FITS headers.
  * 
  * @see nom.tam.fits.FitsFactory#setHierarchFormater(IHierarchKeyFormatter)
+ * @see Hierarch
  */
 @SuppressWarnings("deprecation")
 public interface IHierarchKeyFormatter {

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -533,7 +533,10 @@ public class HeaderTest {
         assertEquals(Hierarch.key("TEST.THIS"), keyword);
 
         keyword = HeaderCard.create("HIERARCH.test.this= 'bla bla' ").getKey();
-        assertEquals(Hierarch.key("TEST.THIS"), keyword);
+        assertEquals(Hierarch.key("TEST", "THIS"), keyword);
+
+        keyword = HeaderCard.create("HIERARCH ESO INS OPTI-3 ID = 'ESO#427 ' / Optical element identifier").getKey();
+        assertEquals(Hierarch.key("ESO", "INS", "OPTI-3", "ID"), keyword);
 
         keyword = HeaderCard.create("HIERARCH ESO INS OPTI-3 ID = 'ESO#427 ' / Optical element identifier").getKey();
         assertEquals(Hierarch.key("ESO.INS.OPTI-3.ID"), keyword);

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -28,6 +28,7 @@ import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.Standard;
 import nom.tam.fits.header.hierarch.BlanksDotHierarchKeyFormatter;
+import nom.tam.fits.header.hierarch.Hierarch;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.AsciiFuncs;
 import nom.tam.util.ComplexValue;
@@ -526,28 +527,28 @@ public class HeaderTest {
         FitsFactory.setUseHierarch(true);
 
         String keyword = HeaderCard.create("HIERARCH test this = 'bla bla' ").getKey();
-        assertEquals("HIERARCH.TEST.THIS", keyword);
+        assertEquals(Hierarch.key("TEST.THIS"), keyword);
 
         keyword = HeaderCard.create("HIERARCH test this= 'bla bla' ").getKey();
-        assertEquals("HIERARCH.TEST.THIS", keyword);
+        assertEquals(Hierarch.key("TEST.THIS"), keyword);
 
         keyword = HeaderCard.create("HIERARCH.test.this= 'bla bla' ").getKey();
-        assertEquals("HIERARCH.TEST.THIS", keyword);
+        assertEquals(Hierarch.key("TEST.THIS"), keyword);
 
         keyword = HeaderCard.create("HIERARCH ESO INS OPTI-3 ID = 'ESO#427 ' / Optical element identifier").getKey();
-        assertEquals("HIERARCH.ESO.INS.OPTI-3.ID", keyword);
+        assertEquals(Hierarch.key("ESO.INS.OPTI-3.ID"), keyword);
 
         keyword = HeaderCard.create("HIERARCH ESO INS. OPTI-3 ID = 'ESO#427 ' / Optical element identifier").getKey();
-        assertEquals("HIERARCH.ESO.INS.OPTI-3.ID", keyword);
+        assertEquals(Hierarch.key("ESO.INS.OPTI-3.ID"), keyword);
 
         keyword = HeaderCard.create("HIERARCH ESO.INS OPTI-3 ID = 'ESO#427 ' / Optical element identifier").getKey();
-        assertEquals("HIERARCH.ESO.INS.OPTI-3.ID", keyword);
+        assertEquals(Hierarch.key("ESO.INS.OPTI-3.ID"), keyword);
 
         keyword = HeaderCard.create("HIERARCH..ESO INS OPTI-3 ID = 'ESO#427 ' / Optical element identifier").getKey();
-        assertEquals("HIERARCH.ESO.INS.OPTI-3.ID", keyword);
+        assertEquals(Hierarch.key("ESO.INS.OPTI-3.ID"), keyword);
 
         keyword = HeaderCard.create("HIERARCH    ESO INS   OPTI-3 ID= 'ESO#427 ' / Optical element identifier").getKey();
-        assertEquals("HIERARCH.ESO.INS.OPTI-3.ID", keyword);
+        assertEquals(Hierarch.key("ESO.INS.OPTI-3.ID"), keyword);
 
         // AK: The old test expected "" here, but that's inconsistent behavior for the same type of
         // line if hierarch is enabled or not. When HIERARCH is not enabled, we require it to return the
@@ -961,7 +962,7 @@ public class HeaderTest {
                 f = new Fits();
                 BasicHDU<?> primaryHdu = FitsFactory.hduFactory(new float[0]);
 
-                primaryHdu.getHeader().addValue("HIERARCH.TEST.THIS.LONG.HEADER",
+                primaryHdu.getHeader().addValue(Hierarch.key("TEST.THIS.LONG.HEADER"),
                         "aaaaaaaabbbbbbbbbcccccccccccdddddddddddeeeeeeeeeee", null);
 
                 for (int index = 1; index < 60; index++) {
@@ -969,7 +970,7 @@ public class HeaderTest {
                     for (int charIndex = 0; charIndex < index; charIndex++) {
                         buildder.append((char) ('A' + (charIndex % 26)));
                     }
-                    primaryHdu.getHeader().addValue("HIERARCH.X" + buildder.toString(),
+                    primaryHdu.getHeader().addValue(Hierarch.key("X") + buildder.toString(),
                             "_!_!_!_!_!_!_!_!_!_!_!_!_!_!_!_!_!", buildder.toString());
                 }
 
@@ -994,13 +995,13 @@ public class HeaderTest {
                 Header headerRewriter = f.getHDU(0).getHeader();
 
                 assertEquals("aaaaaaaabbbbbbbbbcccccccccccdddddddddddeeeeeeeeeee",
-                        headerRewriter.findCard("HIERARCH.TEST.THIS.LONG.HEADER").getValue());
+                        headerRewriter.findCard(Hierarch.key("TEST.THIS.LONG.HEADER")).getValue());
                 for (int index = 1; index < 60; index++) {
                     StringBuilder buildder = new StringBuilder();
                     for (int charIndex = 0; charIndex < index; charIndex++) {
                         buildder.append((char) ('A' + (charIndex % 26)));
                     }
-                    HeaderCard card = headerRewriter.findCard("HIERARCH.X" + buildder.toString());
+                    HeaderCard card = headerRewriter.findCard(Hierarch.key("X") + buildder.toString());
                     assertEquals("_!_!_!_!_!_!_!_!_!_!_!_!_!_!_!_!_!", card.getValue());
                     if (card.getComment() != null) {
                         assertTrue(buildder.toString().startsWith(card.getComment()));

--- a/src/test/java/nom/tam/util/ComplexValueTest.java
+++ b/src/test/java/nom/tam/util/ComplexValueTest.java
@@ -47,6 +47,7 @@ import nom.tam.fits.FitsFactory;
 import nom.tam.fits.HeaderCard;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.LongValueException;
+import nom.tam.fits.header.hierarch.Hierarch;
 
 public class ComplexValueTest {
 
@@ -355,8 +356,8 @@ public class ComplexValueTest {
     @Test(expected = HeaderCardException.class)
     public void testNoSpaceComplexCard() throws Exception {
         FitsFactory.setUseHierarch(true);
-        new HeaderCard("HIERARCH.SOME.VERY.LONG.COMPLEX.KEYWORD.TAKING.UP.THE.SPACE", new ComplexValue(Math.PI, -Math.PI),
-                16, "comment");
+        new HeaderCard(Hierarch.key("SOME.VERY.LONG.COMPLEX.KEYWORD.TAKING.UP.THE.SPACE"),
+                new ComplexValue(Math.PI, -Math.PI), 16, "comment");
     }
 
     @Test
@@ -365,7 +366,7 @@ public class ComplexValueTest {
         HeaderCard hc = null;
 
         try {
-            hc = new HeaderCard("HIERARCH.SOME.VERY.LONG.COMPLEX.KEYWORD.TAKING.UP.ALL.THE.SPACE", true, "comment");
+            hc = new HeaderCard(Hierarch.key("SOME.VERY.LONG.COMPLEX.KEYWORD.TAKING.UP.ALL.THE.SPACE"), true, "comment");
             hc.setValue(new ComplexValue(0.0, 0.0));
         } catch (HeaderCardException e) {
 


### PR DESCRIPTION
Make it easier to create HIERARCH-style header keywords, by hiding the internal naming convention for such keys from users, who can instead just create the long or hierarchical FITS keywords they desire. Users can just ise one of the static `Hierarch.key()` methods to constructs HIERARCH-style keywords for use within this library. E.g.:

```java
  String key = Hierarch.key("myLongFitsKeyword");
```
which sets `key` to  `HIERARCH.myLongFitsKeyword` (which is how we refer to this long keyword within the library, such as with header access methods).

or:

```java
  String key = Hierarch.key("my.hierarchical.fits.keyword");
```

to set `key ` to `HIERARCH.my.hierarchical.fits.keyword`, or equivalently to the one above:

```java
  String key = Hierarch.key("my", "hierarchical", "fits", "keyword");
```

The resulting string can be used as the non-standard keyword in the library's header access methods.