### PR TITLE
Common Data padding implementation.

### DIFF
--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -922,7 +922,7 @@ public class AsciiTable extends AbstractTableData {
     }
 
     @Override
-    public void write(ArrayDataOutput str) throws FitsException {
+    public void writeUnpadded(ArrayDataOutput str) throws FitsException {
         // Make sure we have the data in hand.
         if (str != currInput) {
             ensureData();
@@ -979,9 +979,14 @@ public class AsciiTable extends AbstractTableData {
         // Now write the buffer.
         try {
             str.write(buffer);
-            FitsUtil.pad(str, buffer.length, (byte) ' ');
         } catch (IOException e) {
             throw new FitsException("Error writing ASCII Table data", e);
         }
     }
+
+    @Override
+    protected byte getPaddingByte() {
+        return (byte) ' ';
+    }
+
 }

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -3071,7 +3071,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
 
     @SuppressWarnings("resource")
     @Override
-    public void write(ArrayDataOutput os) throws FitsException {
+    protected void writeUnpadded(ArrayDataOutput os) throws FitsException {
         if (os != getRandomAccessInput()) {
             ensureData();
         }
@@ -3090,8 +3090,6 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
                 }
                 getHeap().write(os);
             }
-
-            FitsUtil.pad(os, getTrueSize());
 
         } catch (IOException e) {
             throw new FitsException("Unable to write table:" + e, e);

--- a/src/main/java/nom/tam/fits/Data.java
+++ b/src/main/java/nom/tam/fits/Data.java
@@ -402,8 +402,7 @@ public abstract class Data implements FitsElement {
 
     /**
      * Writes the data segment to the output, without padding. It should only be called by
-     * {@link #write(ArrayDataOutput)}. Subclasses should override as necessary to provide actual implementation. Not
-     * abstract, with NOP default implementation for closer backward compatibility.
+     * {@link #write(ArrayDataOutput)}.
      * 
      * @param  o             the output to which the data is to be written
      * 
@@ -411,8 +410,7 @@ public abstract class Data implements FitsElement {
      * 
      * @since                1.18
      */
-    protected void writeUnpadded(ArrayDataOutput o) throws FitsException {
-    }
+    protected abstract void writeUnpadded(ArrayDataOutput o) throws FitsException;
 
     /**
      * Returns the byte value that should be used to pad after the data to complete the FITS block of 2880 bytes.
@@ -426,7 +424,7 @@ public abstract class Data implements FitsElement {
     }
 
     /**
-     * Writes data to the output, adding padding as necessary to complete the FITS block of 2880 bytes. Subclasses
+     * Writes this data to the output, adding padding as necessary to complete the FITS block of 2880 bytes. Subclasses
      * should typically override {@link #writeUnpadded(ArrayDataOutput)} to provide implementation.
      */
     @Override

--- a/src/main/java/nom/tam/fits/Data.java
+++ b/src/main/java/nom/tam/fits/Data.java
@@ -400,6 +400,38 @@ public abstract class Data implements FitsElement {
         }
     }
 
+    /**
+     * Writes the data segment to the output, without padding. It should only be called by
+     * {@link #write(ArrayDataOutput)}. Subclasses should override as necessary to provide actual implementation. Not
+     * abstract, with NOP default implementation for closer backward compatibility.
+     * 
+     * @param  o             the output to which the data is to be written
+     * 
+     * @throws FitsException if there was an error adding the padding to the output
+     * 
+     * @since                1.18
+     */
+    protected void writeUnpadded(ArrayDataOutput o) throws FitsException {
+    }
+
+    /**
+     * Returns the byte value that should be used to pad after the data to complete the FITS block of 2880 bytes.
+     * 
+     * @return the padding value to use.
+     * 
+     * @since  1.18
+     */
+    protected byte getPaddingByte() {
+        return (byte) 0;
+    }
+
+    /**
+     * Writes data to the output, adding padding as necessary to complete the FITS block of 2880 bytes. Subclasses
+     * should typically override {@link #writeUnpadded(ArrayDataOutput)} to provide implementation.
+     */
     @Override
-    public abstract void write(ArrayDataOutput o) throws FitsException;
+    public void write(ArrayDataOutput o) throws FitsException {
+        writeUnpadded(o);
+        FitsUtil.pad(o, getTrueSize(), getPaddingByte());
+    }
 }

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -197,9 +197,9 @@ public class ImageData extends Data {
         tiler = new ImageDataTiler(null, 0, dataDescription);
     }
 
-    @SuppressWarnings({"resource", "deprecation"})
+    @SuppressWarnings({"resource"})
     @Override
-    public void write(ArrayDataOutput o) throws FitsException {
+    public void writeUnpadded(ArrayDataOutput o) throws FitsException {
 
         // Don't need to write null data (noted by Jens Knudstrup)
         if (byteSize == 0) {
@@ -215,8 +215,6 @@ public class ImageData extends Data {
         } catch (IOException e) {
             throw new FitsException("IO Error on image write" + e);
         }
-
-        FitsUtil.pad(o, getTrueSize());
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/nom/tam/fits/NullData.java
+++ b/src/main/java/nom/tam/fits/NullData.java
@@ -89,7 +89,7 @@ public final class NullData extends ImageData {
     }
 
     @Override
-    public void write(ArrayDataOutput o) {
+    public void writeUnpadded(ArrayDataOutput o) {
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -224,9 +224,9 @@ public class RandomGroupsData extends Data {
         return (Object[][]) super.getData();
     }
 
-    @SuppressWarnings({"resource", "deprecation"})
+    @SuppressWarnings("resource")
     @Override
-    public void write(ArrayDataOutput str) throws FitsException {
+    public void writeUnpadded(ArrayDataOutput str) throws FitsException {
         if (getTrueSize() <= 0) {
             return;
         }
@@ -237,7 +237,6 @@ public class RandomGroupsData extends Data {
 
         try {
             str.writeArray(dataArray);
-            FitsUtil.pad(str, getTrueSize());
         } catch (IOException e) {
             throw new FitsException("IO error writing random groups data ", e);
         }

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -152,9 +152,9 @@ public class UndefinedData extends Data {
         in.readFully(data);
     }
 
-    @SuppressWarnings({"resource", "deprecation"})
+    @SuppressWarnings("resource")
     @Override
-    public void write(ArrayDataOutput o) throws FitsException {
+    public void writeUnpadded(ArrayDataOutput o) throws FitsException {
         if (o != getRandomAccessInput()) {
             ensureData();
         }
@@ -163,6 +163,5 @@ public class UndefinedData extends Data {
         } catch (IOException e) {
             throw new FitsException("IO Error on unknown data write", e);
         }
-        FitsUtil.pad(o, getTrueSize());
     }
 }

--- a/src/main/java/nom/tam/image/StreamingTileImageData.java
+++ b/src/main/java/nom/tam/image/StreamingTileImageData.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import nom.tam.fits.FitsException;
-import nom.tam.fits.FitsUtil;
 import nom.tam.fits.Header;
 import nom.tam.fits.ImageData;
 import nom.tam.util.ArrayDataOutput;
@@ -124,17 +123,15 @@ public class StreamingTileImageData extends ImageData {
         return Arrays.copyOf(steps, steps.length);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
-    public void write(ArrayDataOutput o) throws FitsException {
+    public void writeUnpadded(ArrayDataOutput o) throws FitsException {
         try {
             final ImageTiler tiler = imageTiler;
             if (tiler == null || getTrueSize() == 0) {
                 // Defer writing of unknowns to the parent.
-                super.write(o);
+                super.writeUnpadded(o);
             } else {
                 tiler.getTile(o, corners, lengths, steps);
-                FitsUtil.pad(o, getTrueSize());
             }
         } catch (IOException ioException) {
             throw new FitsException(ioException.getMessage(), ioException);

--- a/src/test/java/nom/tam/fits/BadData.java
+++ b/src/test/java/nom/tam/fits/BadData.java
@@ -57,7 +57,7 @@ public class BadData extends Data {
     }
 
     @Override
-    public void write(ArrayDataOutput o) throws FitsException {
+    public void writeUnpadded(ArrayDataOutput o) throws FitsException {
 
     }
 

--- a/src/test/java/nom/tam/fits/DeferredTest.java
+++ b/src/test/java/nom/tam/fits/DeferredTest.java
@@ -100,7 +100,7 @@ public class DeferredTest {
         }
 
         @Override
-        public void write(ArrayDataOutput o) throws FitsException {
+        public void writeUnpadded(ArrayDataOutput o) throws FitsException {
             throw new FitsException("not implemented");
         }
 


### PR DESCRIPTION
Each `Data` subclass was implementing its own padding in `write()`, but really it's safer and better to have a common implementation in `Data` itself.  `Data.write()` now calls `.writeUnpadded()` and then adds padding with the byte value specified by `.getPaddingByte()` by default.

The changes will affects external `Data` implementations, which must override `writeUnpadded()` instead of `write()` as a result. However, it is very unlikely that anyone would need to extend `Data` beyond the subclasses provided by this package, so we go ahead with the change noting the very slight risk of breaking some niche applications. In the unlikely case someone did implement `Data` externally, the fix should be as easy as renaming the overridden `write()` method to `writeUnpadded()` to fix.