### PR TITLE
Issue 460 -- Rice compression BYTEPIX regression in 1.18.0-rc6

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -25,6 +25,9 @@
       <action type="fix" dev="attipaci" issue="456">
 	      Fixed compressed table tiling with tile sizes that do not divide the table rows.
       </action>
+      <action type="fix" dev="attipaci" issue="462">
+	      Fixed incorrect HCompress SCALE parameter handling.
+      </action>
       <action type="add" dev="at88mph" issue="387">
 	      Added ability to stride while tiling.
       </action>
@@ -114,6 +117,9 @@
       </action>
       <action type="update" dev="attipaci" issue="131">
 	      Tables now support up to Integer.MAX_VALUE (~2-billion) rows regardless of entry size.
+      </action>
+      <action type="update" dev="attipaci" issue="461">
+	      Improved handling of shared compression settings across option copies, and including validation
       </action>
       <action type="update" dev="attipaci" issue="394">
 	      Various tweaks to FitsDate that should not affect user behavior.

--- a/src/main/java/nom/tam/fits/ImageHDU.java
+++ b/src/main/java/nom/tam/fits/ImageHDU.java
@@ -49,8 +49,10 @@ import static nom.tam.fits.header.Standard.XTENSION;
 import static nom.tam.util.LoggerHelper.getLogger;
 
 /**
- * Header/data unit for images. Image HDUs are suitable for storing monolithic regular numerical arrays in 1 to 8
- * dimensions, such as a <code>double[]</code>, <code>float[][]</code>, or <code>short[][][]</code>.
+ * Header/data unit for images. Image HDUs are suitable for storing monolithic regular numerical arrays in 1 to 255
+ * dimensions, such as a <code>double[]</code>, <code>float[][]</code>, or <code>short[][][]</code>. ((FITS supports up
+ * to 999 dimensions, but Java support maxes at at 255 -- however it's unlikely you'll find this to be a serious
+ * limitation.)
  * 
  * @see ImageData
  */

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorOption.java
@@ -86,7 +86,7 @@ public class HCompressorOption implements ICompressOption {
      * 
      * @return the value of the scale parameter.
      * 
-     * @see    #setScale(int)
+     * @see    #setScale(double)
      */
     public int getScale() {
         return config.scale;
@@ -104,7 +104,7 @@ public class HCompressorOption implements ICompressOption {
 
     @Override
     public boolean isLossyCompression() {
-        return config.scale > 1 || config.smooth;
+        return config.scale > 0 || config.smooth;
     }
 
     /**
@@ -129,7 +129,8 @@ public class HCompressorOption implements ICompressOption {
     /**
      * Sets the scale parameter
      * 
-     * @param  value                    the new scale parameter
+     * @param  value                    the new scale parameter, which will be rounded to the nearest integer value for
+     *                                      the actual implementation.
      * 
      * @return                          itself
      * 
@@ -137,11 +138,11 @@ public class HCompressorOption implements ICompressOption {
      * 
      * @see                             #getScale()
      */
-    public HCompressorOption setScale(int value) throws IllegalArgumentException {
+    public HCompressorOption setScale(double value) throws IllegalArgumentException {
         if (value < 0.0) {
             throw new IllegalArgumentException("Scale value cannot be negative: " + value);
         }
-        config.scale = value;
+        config.scale = (int) Math.round(value);
         return this;
     }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorOption.java
@@ -50,9 +50,8 @@ public class HCompressorOption implements ICompressOption {
      */
     private HCompressParameters parameters;
 
-    private int scale;
-
-    private boolean smooth;
+    /** Shared configuration across copies. */
+    private final Config config;
 
     private int tileHeight;
 
@@ -62,6 +61,7 @@ public class HCompressorOption implements ICompressOption {
      * Creates a new set of options for HCompress.
      */
     public HCompressorOption() {
+        config = new Config();
         setParameters(new HCompressParameters(this));
     }
 
@@ -89,7 +89,7 @@ public class HCompressorOption implements ICompressOption {
      * @see    #setScale(int)
      */
     public int getScale() {
-        return scale;
+        return config.scale;
     }
 
     @Override
@@ -104,7 +104,7 @@ public class HCompressorOption implements ICompressOption {
 
     @Override
     public boolean isLossyCompression() {
-        return scale > 1 || smooth;
+        return config.scale > 1 || config.smooth;
     }
 
     /**
@@ -115,7 +115,7 @@ public class HCompressorOption implements ICompressOption {
      * @see    #setSmooth(boolean)
      */
     public boolean isSmooth() {
-        return smooth;
+        return config.smooth;
     }
 
     @Override
@@ -129,14 +129,19 @@ public class HCompressorOption implements ICompressOption {
     /**
      * Sets the scale parameter
      * 
-     * @param  value the new scale parameter
+     * @param  value                    the new scale parameter
      * 
-     * @return       itself
+     * @return                          itself
      * 
-     * @see          #getScale()
+     * @throws IllegalArgumentException if the scale value is negative
+     * 
+     * @see                             #getScale()
      */
-    public HCompressorOption setScale(int value) {
-        scale = value;
+    public HCompressorOption setScale(int value) throws IllegalArgumentException {
+        if (value < 0.0) {
+            throw new IllegalArgumentException("Scale value cannot be negative: " + value);
+        }
+        config.scale = value;
         return this;
     }
 
@@ -148,7 +153,7 @@ public class HCompressorOption implements ICompressOption {
      * @return       itself
      */
     public HCompressorOption setSmooth(boolean value) {
-        smooth = value;
+        config.smooth = value;
         return this;
     }
 
@@ -170,5 +175,20 @@ public class HCompressorOption implements ICompressOption {
     public HCompressorOption setTileWidth(int value) {
         tileWidth = value;
         return this;
+    }
+
+    /**
+     * Stores configuration in a way that can be shared and modified across enclosing option copies.
+     * 
+     * @author Attila Kovacs
+     *
+     * @since  1.18
+     */
+    private static final class Config {
+
+        private int scale;
+
+        private boolean smooth;
+
     }
 }

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressOption.java
@@ -59,7 +59,7 @@ public class RiceCompressOption implements ICompressOption {
 
     private int blockSize = DEFAULT_RICE_BLOCKSIZE;
 
-    private Integer bytePix = null;
+    private BytePix bytePix = new BytePix(DEFAULT_RICE_BYTEPIX);
 
     /**
      * Creates a new set of options for Rice compression.
@@ -98,7 +98,7 @@ public class RiceCompressOption implements ICompressOption {
      * @see    #setBytePix(int)
      */
     public final int getBytePix() {
-        return bytePix == null ? DEFAULT_RICE_BYTEPIX : bytePix;
+        return bytePix.value;
     }
 
     @Override
@@ -136,7 +136,7 @@ public class RiceCompressOption implements ICompressOption {
      * @see          #getBytePix()
      */
     public RiceCompressOption setBytePix(int value) {
-        bytePix = value;
+        bytePix.value = value;
         return this;
     }
 
@@ -144,19 +144,18 @@ public class RiceCompressOption implements ICompressOption {
      * Sets a BYTEPIX value to use, but only when a BYTEPIX value is not already defined. If a value was already defined
      * it is left unchanged.
      * 
-     * @param  value the new BYTEPIX value to use as default when no value was set. It is currently not checked for
-     *                   validity, so use carefully.
+     * @param      value the new BYTEPIX value to use as default when no value was set. It is currently not checked for
+     *                       validity, so use carefully.
      * 
-     * @return       itself
+     * @return           itself
      *
-     * @see          #setBytePix(int)
-     * @see          #getBytePix()
+     * @see              #setBytePix(int)
+     * @see              #getBytePix()
+     * 
+     * @deprecated       (<i>Duplicate method</i>) Use {@link #setBytePix(int)} instead. Will be removed in the future.
      */
     protected RiceCompressOption setDefaultBytePix(int value) {
-        if (bytePix == null) {
-            bytePix = value;
-        }
-        return this;
+        return setBytePix(value);
     }
 
     @Override
@@ -183,5 +182,13 @@ public class RiceCompressOption implements ICompressOption {
             return clazz.cast(this);
         }
         return null;
+    }
+
+    private static class BytePix {
+        int value;
+
+        private BytePix(int n) {
+            value = n;
+        }
     }
 }

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressOption.java
@@ -148,7 +148,6 @@ public class RiceCompressOption implements ICompressOption {
      * 
      * @throws IllegalArgumentException if the value is not 1, 2, 4, or 8.
      * 
-     * @see                             #setDefaultBytePix(int)
      * @see                             #getBytePix()
      */
     public RiceCompressOption setBytePix(int value) throws IllegalArgumentException {
@@ -173,7 +172,7 @@ public class RiceCompressOption implements ICompressOption {
      * @see          #setBytePix(int)
      * @see          #getBytePix()
      */
-    protected RiceCompressOption setDefaultBytePix(int value) {
+    RiceCompressOption setDefaultBytePix(int value) {
         if (config.bytePix == 0) {
             return setBytePix(value);
         }

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
@@ -231,7 +231,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
 
     private final int fsMax;
 
-    private RiceCompressor(RiceCompressOption option) throws IllegalArgumentException {
+    private RiceCompressor(RiceCompressOption option) throws UnsupportedOperationException {
         blockSize = option.getBlockSize();
         if (option.getBytePix() == ElementType.BYTE.size()) {
             fsBits = FS_BITS_FOR_BYTE;
@@ -246,7 +246,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
             fsMax = FS_MAX_FOR_INT;
             bitsPerPixel = FitsIO.BITS_OF_4_BYTES;
         } else {
-            throw new IllegalArgumentException("Rice only supports 1/2/4 type per pixel");
+            throw new UnsupportedOperationException("Implemented for 1/2/4 bytes only");
         }
         /*
          * From bsize derive: FSBITS = # bits required to store FS FSMAX = maximum value for FS BBITS = bits/pixel for

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
@@ -64,7 +64,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private ByteBuffer pixelBuffer;
 
         public ByteRiceCompressor(RiceCompressOption option) {
-            super(option.setBytePix(ElementType.BYTE.size()));
+            super(option.setDefaultBytePix(ElementType.BYTE.size()));
         }
 
         @Override
@@ -108,7 +108,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private IntBuffer pixelBuffer;
 
         public IntRiceCompressor(RiceCompressOption option) {
-            super(option.setBytePix(ElementType.INT.size()));
+            super(option.setDefaultBytePix(ElementType.INT.size()));
         }
 
         @Override
@@ -140,7 +140,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private ShortBuffer pixelBuffer;
 
         public ShortRiceCompressor(RiceCompressOption option) {
-            super(option.setBytePix(ElementType.SHORT.size()));
+            super(option.setDefaultBytePix(ElementType.SHORT.size()));
         }
 
         @Override
@@ -231,7 +231,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
 
     private final int fsMax;
 
-    private RiceCompressor(RiceCompressOption option) {
+    private RiceCompressor(RiceCompressOption option) throws IllegalArgumentException {
         blockSize = option.getBlockSize();
         if (option.getBytePix() == ElementType.BYTE.size()) {
             fsBits = FS_BITS_FOR_BYTE;
@@ -246,7 +246,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
             fsMax = FS_MAX_FOR_INT;
             bitsPerPixel = FitsIO.BITS_OF_4_BYTES;
         } else {
-            throw new UnsupportedOperationException("Rice only supports 1/2/4 type per pixel");
+            throw new IllegalArgumentException("Rice only supports 1/2/4 type per pixel");
         }
         /*
          * From bsize derive: FSBITS = # bits required to store FS FSMAX = maximum value for FS BBITS = bits/pixel for

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
@@ -64,7 +64,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private ByteBuffer pixelBuffer;
 
         public ByteRiceCompressor(RiceCompressOption option) {
-            super(option.setDefaultBytePix(ElementType.BYTE.size()));
+            super(option.setBytePix(ElementType.BYTE.size()));
         }
 
         @Override
@@ -108,7 +108,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private IntBuffer pixelBuffer;
 
         public IntRiceCompressor(RiceCompressOption option) {
-            super(option.setDefaultBytePix(ElementType.INT.size()));
+            super(option.setBytePix(ElementType.INT.size()));
         }
 
         @Override
@@ -140,7 +140,7 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         private ShortBuffer pixelBuffer;
 
         public ShortRiceCompressor(RiceCompressOption option) {
-            super(option.setDefaultBytePix(ElementType.SHORT.size()));
+            super(option.setBytePix(ElementType.SHORT.size()));
         }
 
         @Override

--- a/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressScaleParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressScaleParameter.java
@@ -53,7 +53,7 @@ public final class HCompressScaleParameter extends CompressHeaderParameter<HComp
     public void getValueFromHeader(IHeaderAccess header) {
         HeaderCard value = findZVal(header);
         if (value != null) {
-            getOption().setScale(value.getValue(Integer.class, -1));
+            getOption().setScale(value.getValue(Double.class, 0.0));
         }
     }
 

--- a/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
@@ -549,4 +549,9 @@ public class HCompressTest {
         o.setScale(2);
         Assert.assertTrue(o.isLossyCompression());
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWrongScale() throws Exception {
+        new HCompressorOption().setScale(-1);
+    }
 }

--- a/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
@@ -554,4 +554,12 @@ public class HCompressTest {
     public void testWrongScale() throws Exception {
         new HCompressorOption().setScale(-1);
     }
+
+    @Test
+    public void testLossy() throws Exception {
+        Assert.assertFalse(new HCompressorOption().setScale(0).setSmooth(false).isLossyCompression());
+        Assert.assertTrue(new HCompressorOption().setScale(1).setSmooth(false).isLossyCompression());
+        Assert.assertTrue(new HCompressorOption().setScale(0).setSmooth(true).isLossyCompression());
+        Assert.assertTrue(new HCompressorOption().setScale(1).setSmooth(true).isLossyCompression());
+    }
 }

--- a/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
@@ -245,12 +245,12 @@ public class RiceCompressTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testWrongBlockSize() throws Exception {
-        option.setBytePix(31);
+        option.setBlockSize(31);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testWrongBlockSize2() throws Exception {
-        option.setBytePix(64);
+        option.setBlockSize(64);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
@@ -81,11 +81,11 @@ public class RiceCompressTest {
         header.addValue(Compression.ZNAMEn.n(1).key(), Compression.BLOCKSIZE, null);
         header.addValue(Compression.ZVALn.n(1).key(), 32, null);
         header.addValue(Compression.ZNAMEn.n(2).key(), Compression.BYTEPIX, null);
-        header.addValue(Compression.ZVALn.n(2).key(), 16, null);
+        header.addValue(Compression.ZVALn.n(2).key(), 8, null);
         option.getCompressionParameters().getValuesFromHeader(new HeaderAccess(header));
 
         Assert.assertEquals(32, option.getBlockSize());
-        Assert.assertEquals(16, option.getBytePix());
+        Assert.assertEquals(8, option.getBytePix());
 
         Assert.assertNull(option.unwrap(String.class));
     }
@@ -227,14 +227,9 @@ public class RiceCompressTest {
 
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testWrongBytePix() throws Exception {
-        try {
-            new ByteRiceCompressor(option.setBytePix(99));
-        } catch (UnsupportedOperationException e) {
-            Assert.assertTrue(e.getMessage().contains("only"));
-            throw e;
-        }
+        option.setBytePix(99);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
@@ -229,7 +229,28 @@ public class RiceCompressTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testWrongBytePix() throws Exception {
-        option.setBytePix(99);
+        option.setBytePix(7);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWrongBytePix2() throws Exception {
+        option.setBytePix(16);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnsupportedBytePix2() throws Exception {
+        // BYTEPIX=8 is legal but is not implemented (in cfitsio either)
+        new RiceCompressor.IntRiceCompressor(option.setBytePix(8));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWrongBlockSize() throws Exception {
+        option.setBytePix(31);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWrongBlockSize2() throws Exception {
+        option.setBytePix(64);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
The BYTEPIX value was not properly shared across copies of `RiceCompressOption`. Fix by shared config properties in `RiceCompressOption` and also `HCompressorOption` classes. Also validate BYTEPIX and BLOCKSIZE settings (in `RiceCompressOption`) and scale parameter (in `HCompressorOption`) and throw an `IllegalArgumentException` if the set
values are invalid.