### PR TITLE
Fix ASCII table read regression

### DIFF
--- a/src/main/java/nom/tam/fits/FitsFactory.java
+++ b/src/main/java/nom/tam/fits/FitsFactory.java
@@ -297,7 +297,7 @@ public final class FitsFactory {
         if (RandomGroupsHDU.isHeader(hdr)) {
             return RandomGroupsHDU.manufactureData(hdr);
         }
-        if (current().isUseAsciiTables() && AsciiTableHDU.isHeader(hdr)) {
+        if (AsciiTableHDU.isHeader(hdr)) {
             return AsciiTableHDU.manufactureData(hdr);
         }
         if (CompressedImageHDU.isHeader(hdr)) {


### PR DESCRIPTION
ASCII tables can only be read after `FitsFactory.setUseAsciiTables(true)` was set prior. This is a regression in 1.18.0.