### PR TITLE
Add some missing javadoc, disable warnings for missing comments / tags.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,7 @@
           <source>8</source>
           <aggregate>false</aggregate>
           <failOnError>true</failOnError>
+          <doclint>all,-missing</doclint>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -133,6 +133,9 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
      *
      * @param      o a column table object, an Object[][], or an Object[]. This routine doesn't check that the
      *                   dimensions of arrays are properly consistent.
+     * 
+     * @return       <code>true</code> if the data object can be represented as a FITS binary table, otherwise
+     *                   <code>false</code>.
      *
      * @deprecated   (<i>for internal use</i>) Will reduce visibility in the future
      */

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
@@ -59,6 +59,13 @@ public abstract class CompressColumnParameter<T, OPTION> extends CompressParamet
 
     private final Class<T> type;
 
+    /**
+     * Creates a new compression parameter, which stores a per-tile value for a compression option in a table column.
+     * 
+     * @param name   the FITS parameter name, that is the column name which stores the values
+     * @param option the compression option that uses the parameter value
+     * @param type   the Java class of the parameter, such as {@link java.lang.Integer} or {@link java.lang.String}.
+     */
     protected CompressColumnParameter(String name, OPTION option, Class<T> type) {
         super(name, option);
         column = new Data();

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
@@ -39,10 +39,11 @@ import static nom.tam.fits.header.Compression.ZNAMEn;
 import static nom.tam.fits.header.Compression.ZVALn;
 
 /**
- * (<i>for internal use</i>)
+ * (<i>for internal use</i>) Visibility may be reduced to protected.
  * 
  * @param <OPTION> The generic type of the compression option for which this parameter is used.
  */
+@SuppressWarnings("javadoc")
 public abstract class CompressHeaderParameter<OPTION> extends CompressParameter<OPTION>
         implements ICompressHeaderParameter {
 

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTile.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTile.java
@@ -47,6 +47,7 @@ import nom.tam.util.type.ElementType;
  * (<i>for internal use</i>) A table 'tile' representing a set of consecutive table rows that are compressed together as
  * a block.
  */
+@SuppressWarnings("javadoc")
 public abstract class BinaryTableTile implements Runnable {
 
     protected final ColumnTable<?> data;

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileCompressor.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileCompressor.java
@@ -44,6 +44,7 @@ import nom.tam.util.FitsOutputStream;
 /**
  * (<i>for internal use</i>) Handles the compression of binary table 'tiles'.
  */
+@SuppressWarnings("javadoc")
 public class BinaryTableTileCompressor extends BinaryTableTile {
 
     private static final int FACTOR_15 = 15;
@@ -59,7 +60,6 @@ public class BinaryTableTileCompressor extends BinaryTableTile {
     /**
      * @deprecated for internal use
      */
-    @SuppressWarnings("javadoc")
     public BinaryTableTileCompressor(CompressedTableData binData, ColumnTable<?> columnTable,
             BinaryTableTileDescription description) {
         super(columnTable, description);

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDecompressor.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDecompressor.java
@@ -44,6 +44,7 @@ import nom.tam.util.FitsInputStream;
 /**
  * (<i>for internal use</i>) Handles the decompression of binary table 'tiles'.
  */
+@SuppressWarnings("javadoc")
 public class BinaryTableTileDecompressor extends BinaryTableTile {
 
     private final ByteBuffer compressedBytes;
@@ -55,7 +56,6 @@ public class BinaryTableTileDecompressor extends BinaryTableTile {
     /**
      * @deprecated (<i>for internal use</i>)
      */
-    @SuppressWarnings("javadoc")
     public BinaryTableTileDecompressor(CompressedTableData binData, ColumnTable<?> columnTable,
             BinaryTableTileDescription description) throws FitsException {
         super(columnTable, description);

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDescription.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDescription.java
@@ -36,6 +36,7 @@ import nom.tam.fits.header.Compression;
 /**
  * (<i>for internal use</i>) The specifications of a binary table 'tile'.
  */
+@SuppressWarnings("javadoc")
 public final class BinaryTableTileDescription {
 
     private int rowStart;

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedImageData.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedImageData.java
@@ -52,6 +52,7 @@ import static nom.tam.fits.header.Compression.ZIMAGE;
  * 
  * @see CompressedImageHDU
  */
+@SuppressWarnings("deprecation")
 public class CompressedImageData extends BinaryTable {
 
     /**
@@ -167,9 +168,12 @@ public class CompressedImageData extends BinaryTable {
     }
 
     /**
-     * This should only be called by {@link CompressedImageHDU}.
+     * Sets the size of the image to be compressed.
+     * 
+     * @param  axes the image size
+     * 
+     * @return      itself This should only be called by {@link CompressedImageHDU}.
      */
-    @SuppressWarnings("javadoc")
     protected CompressedImageData setAxis(int[] axes) {
         tiledImageOperation().setAxes(axes);
         return this;
@@ -200,9 +204,14 @@ public class CompressedImageData extends BinaryTable {
     }
 
     /**
-     * This should only be called by {@link CompressedImageHDU}.
+     * Sets the tile size to use for sompressing.
+     * 
+     * @param  axes          the tile size along all dimensions. Only the last 2 dimensions may differ from 1.
+     * 
+     * @return               itself
+     * 
+     * @throws FitsException if the tile size is invalid. This should only be called by {@link CompressedImageHDU}.
      */
-    @SuppressWarnings("javadoc")
     protected CompressedImageData setTileSize(int... axes) throws FitsException {
         tiledImageOperation().setTileAxes(axes);
         return this;

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
@@ -207,7 +207,15 @@ public class CompressedImageHDU extends BinaryTableHDU {
     }
 
     /**
-     * @deprecated (<i>for internal use</i>) Will reduce visibility in the future
+     * Returns an empty compressed image data object based on its description in a FITS header.
+     * 
+     * @param      hdr           the FITS header containing a description of the compressed image
+     * 
+     * @return                   an empty compressed image data corresponding to the header description.
+     * 
+     * @throws     FitsException if the header does not sufficiently describe a compressed image
+     * 
+     * @deprecated               (<i>for internal use</i>) Will reduce visibility in the future
      */
     @Deprecated
     public static CompressedImageData manufactureData(Header hdr) throws FitsException {

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
@@ -270,7 +270,8 @@ public class CompressedTableData extends BinaryTable {
     }
 
     /**
-     * This should only be called by {@link CompressedTableHDU}.
+     * (<i>for internal use</i>) Visibility may be reduced to the package level. This should only be called by
+     * {@link CompressedTableHDU}.
      */
     @SuppressWarnings("javadoc")
     protected void setColumnCompressionAlgorithms(String[] columnCompressionAlgorithms) {
@@ -278,7 +279,8 @@ public class CompressedTableData extends BinaryTable {
     }
 
     /**
-     * This should only be called by {@link CompressedTableHDU}.
+     * (<i>for internal use</i>) Visibility may be reduced to the package level. This should only be called by
+     * {@link CompressedTableHDU}.
      */
     @SuppressWarnings("javadoc")
     protected CompressedTableData setRowsPerTile(int value) {

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -81,6 +81,7 @@ import static nom.tam.image.compression.tile.TileCompressionType.UNCOMPRESSED;
  * complete compression of a tiled describing an image ordered from left to right and top down. the tiles all have the
  * same geometry only the tiles at the right and bottom sides can have different (truncated) sizes.
  */
+@SuppressWarnings("deprecation")
 public class TiledImageCompressionOperation extends AbstractTiledImageOperation<TileCompressionOperation> {
 
     /**
@@ -377,7 +378,6 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
         return compressAlgorithm;
     }
 
-    @SuppressWarnings("deprecation")
     private <T> T getNullableColumn(Header header, Class<T> class1, String columnName) throws FitsException {
         for (int i = 1; i <= binaryTable.getNCols(); i++) {
             String val = header.getStringValue(TTYPEn.n(i));

--- a/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
@@ -50,6 +50,7 @@ public class AbstractNullPixelMask {
 
     private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
+    /** Byte value signifying invalid / null data */
     protected static final byte NULL_INDICATOR = (byte) 1;
 
     private final TileBuffer tileBuffer;
@@ -62,6 +63,20 @@ public class AbstractNullPixelMask {
 
     private final ICompressorControl compressorControl;
 
+    /**
+     * Creates a new pixel mask got a given image tile and designated null
+     * value.
+     * 
+     * @param tileBuffer
+     *            the buffer containing the tile data
+     * @param tileIndex
+     *            the tile index
+     * @param nullValue
+     *            the integer value representing <code>null</code> or invalid
+     *            data
+     * @param compressorControl
+     *            The class managing the compression
+     */
     protected AbstractNullPixelMask(TileBuffer tileBuffer, int tileIndex, long nullValue, ICompressorControl compressorControl) {
         this.tileBuffer = tileBuffer;
         this.tileIndex = tileIndex;
@@ -72,6 +87,13 @@ public class AbstractNullPixelMask {
         }
     }
 
+    /**
+     * Returns a byte array containing the mask
+     * 
+     * @return the byte array containing the pixel mask for the tile.
+     * @deprecated (<i>for internal use</i>) Visibility may be reduced to package
+     *             level in the future.
+     */
     public byte[] getMaskBytes() {
         if (mask == null) {
             return EMPTY_BYTE_ARRAY;
@@ -83,30 +105,72 @@ public class AbstractNullPixelMask {
         return result;
     }
 
+    /**
+     * Sets data for a new mask as a flattened buffer of data.
+     * 
+     * @param mask
+     *            the buffer containing the mask data in flattened format.
+     */
     public void setMask(ByteBuffer mask) {
         this.mask = mask;
     }
 
+    /**
+     * Returns the object that manages the compression, and which therefore
+     * handles the masking
+     * 
+     * @return the object that manages the compression.
+     */
     protected ICompressorControl getCompressorControl() {
         return compressorControl;
     }
 
+    /**
+     * Returns the mask data as a buffer in flattened format.
+     * 
+     * @return the buffer containing the mask data in flattened format.
+     */
     protected ByteBuffer getMask() {
         return mask;
     }
 
+    /**
+     * Returns the value that represents a <code>null</code> or an undefined
+     * data point.
+     * 
+     * @return the value that demarks an undefined datum.
+     */
     protected long getNullValue() {
         return nullValue;
     }
 
+    /**
+     * Returns the buffer that holds data for an image tile.
+     * 
+     * @return the buffer that holds data for a single image tile.
+     */
     protected TileBuffer getTileBuffer() {
         return tileBuffer;
     }
 
+    /**
+     * Return the tile index for the image tile that is processed.
+     * 
+     * @return the image tile index
+     */
     protected int getTileIndex() {
         return tileIndex;
     }
 
+    /**
+     * Creates an internal buffer for holding the mask data, for the specified
+     * number of points.
+     * 
+     * @param remaining
+     *            the number of points the mask should accomodate.
+     * @return the internal buffer that may store the mask data for the specified
+     *         number of data points.
+     */
     protected ByteBuffer initializedMask(int remaining) {
         if (mask == null) {
             mask = ByteBuffer.allocate(remaining);

--- a/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
@@ -62,6 +62,13 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
 
     private final Class<OPERATION> operationClass;
 
+    /**
+     * Creates a new tiling foperation.
+     * 
+     * @param      operationClass the class of tile operation.
+     * 
+     * @deprecated                (<i>for internal use</i>) This constructor should have protected visibility.
+     */
     public AbstractTiledImageOperation(Class<OPERATION> operationClass) {
         this.operationClass = operationClass;
     }
@@ -71,6 +78,11 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
         return baseType;
     }
 
+    /**
+     * Returns the number of elements that a buffer must have to store the entire image.
+     * 
+     * @return The number of points in the full image.
+     */
     public int getBufferSize() {
         int bufferSize = 1;
         for (int axisValue : axes) {
@@ -124,10 +136,20 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
         tileAxes = Arrays.copyOf(value, value.length);
     }
 
+    /**
+     * Checks if the image size has been defined.
+     * 
+     * @return <code>true</code> if the size of the image to be tiled has been set, otherwise <code>false</code>.
+     */
     protected boolean hasAxes() {
         return axes != null;
     }
 
+    /**
+     * Checks if the tiling has been defined and tile sizes are set.
+     * 
+     * @return <code>true</code> if the tile sizes have been defined already, otherwise <code>false</code>
+     */
     protected boolean hasTileAxes() {
         return tileAxes != null;
     }
@@ -142,6 +164,13 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
         return l;
     }
 
+    /**
+     * Creates a tiling pattern for an image.
+     * 
+     * @param  init          the parameters that determine the tiling pattern
+     * 
+     * @throws FitsException if the parameters are invalid.
+     */
     @SuppressWarnings("unchecked")
     protected void createTiles(ITileOperationInitialisation<OPERATION> init) throws FitsException {
         int[] offset = new int[axes.length]; // Tile start in image (Java index order)
@@ -203,10 +232,20 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
         }
     }
 
+    /**
+     * Returns the dimensionality of the image.
+     * 
+     * @return the dimensinality of the image, that is the number of cartesian axes it contains.
+     */
     protected int getNAxes() {
         return axes.length;
     }
 
+    /**
+     * Returns the number of tile operations that are needed to cover a tiled image.
+     * 
+     * @return the number of tiles in the image.
+     */
     protected int getNumberOfTileOperations() {
         return tileOperations.length;
     }
@@ -221,10 +260,20 @@ public abstract class AbstractTiledImageOperation<OPERATION extends ITileOperati
         return tileAxes;
     }
 
+    /**
+     * Returns an array of parallel tile oprations, which cover the full image.
+     * 
+     * @return an array of parallel tile operations.
+     */
     protected OPERATION[] getTileOperations() {
         return tileOperations;
     }
 
+    /**
+     * Sets the FITS element type that is contained in the tiles for this operation.
+     * 
+     * @param baseType the FITS element type of data in the tile.
+     */
     protected void setBaseType(ElementType<Buffer> baseType) {
         this.baseType = baseType;
     }

--- a/src/main/java/nom/tam/util/BufferedFileIO.java
+++ b/src/main/java/nom/tam/util/BufferedFileIO.java
@@ -50,6 +50,7 @@ import java.nio.channels.FileChannel;
  */
 class BufferedFileIO implements InputReader, OutputWriter, Flushable, Closeable {
 
+    /** Bit mask for a single byte */
     protected static final int BYTE_MASK = 0xFF;
 
     /** The underlying unbuffered random access file IO */
@@ -107,6 +108,14 @@ class BufferedFileIO implements InputReader, OutputWriter, Flushable, Closeable 
         writeAhead = false;
     }
 
+    /**
+     * Sets a new position in the file for subsequent reading or writing.
+     * 
+     * @param  newPos      the new byte offset from the beginning of the file. It may be beyond the current end of the
+     *                         file, for example for writing more data after some 'gap'.
+     * 
+     * @throws IOException if the position is negative or cannot be set.
+     */
     public final synchronized void seek(long newPos) throws IOException {
         // Check that the new position is valid
         if (newPos < 0) {


### PR DESCRIPTION
Various fixes and additions to API documentation. Disable warning on missing comments / tags since javadoc does not process `@SuppressWarnings("javadoc")` tags, of which have many -- resulting in a long spam of useless warnings otherwise.