### PR TITLE
Issue 476 -- Checksum verification on stream inputs

### DIFF
--- a/src/main/java/nom/tam/fits/Data.java
+++ b/src/main/java/nom/tam/fits/Data.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import nom.tam.fits.utilities.FitsCheckSum;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
+import nom.tam.util.FitsInputStream;
 import nom.tam.util.RandomAccess;
 
 import static nom.tam.util.LoggerHelper.getLogger;
@@ -82,6 +83,9 @@ public abstract class Data implements FitsElement {
      */
     @Deprecated
     protected RandomAccess input;
+
+    /** The data checksum calculated from the input stream */
+    private long checksum = 0;
 
     /**
      * Returns the random accessible input from which this data can be read, if any.
@@ -150,6 +154,16 @@ public abstract class Data implements FitsElement {
      */
     public long calcChecksum() throws FitsException {
         return FitsCheckSum.checksum(this);
+    }
+
+    /**
+     * Returns the checksum value calculated duting reading from a stream.
+     * 
+     * @return the checksum calculated for the data read from a stream, or else zero if the data was not read from the
+     *             stream.
+     */
+    long getStreamChecksum() {
+        return checksum;
     }
 
     /**
@@ -301,6 +315,12 @@ public abstract class Data implements FitsElement {
             return;
         }
 
+        checksum = 0L;
+
+        if (in instanceof FitsInputStream) {
+            ((FitsInputStream) in).newChecksum();
+        }
+
         setFileOffset(in);
 
         if (getTrueSize() == 0) {
@@ -323,6 +343,10 @@ public abstract class Data implements FitsElement {
         }
 
         skipPadding(in);
+
+        if (in instanceof FitsInputStream) {
+            checksum = ((FitsInputStream) in).getAggregatedChecksum();
+        }
     }
 
     @SuppressWarnings("resource")

--- a/src/main/java/nom/tam/fits/FitsIntegrityException.java
+++ b/src/main/java/nom/tam/fits/FitsIntegrityException.java
@@ -1,0 +1,58 @@
+package nom.tam.fits;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2023 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+/**
+ * Failed checksum verification.
+ * 
+ * @author Attila Kovacs
+ * @since 1.18.1
+ */
+public class FitsIntegrityException extends FitsException {
+
+    private static final long serialVersionUID = -221485588322280968L;
+
+    /**
+     * Creates a new checksum verification failure
+     * 
+     * @param name
+     *            the type of checksum test that failed
+     * @param got
+     *            the checksum value that was found
+     * @param expected
+     *            the checksum value expected
+     */
+    FitsIntegrityException(String name, long got, long expected) {
+        super("Failed " + name + ": got " + got + ", expected " + expected);
+    }
+
+}

--- a/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
@@ -545,18 +545,21 @@ public final class FitsCheckSum {
      * segment from tha prior datasum, and then add the checksum of the new data segment -- without hacing to
      * recalculate the checksum for the entire data again.
      *
-     * @param  total The total checksum.
-     * @param  part  The partial checksum to be subtracted from the total.
+     * @deprecated       Not foolproof, because of the carry over handling in checksums, some additionas are not
+     *                       reversible. E.g. 0xffffffff + 0xffffffff = 0xffffffff, but 0xffffffff - 0xffffffff = 0;
      *
-     * @return       The checksum after subtracting the partial sum, as a 32-bit unsigned value.
+     * @param      total The total checksum.
+     * @param      part  The partial checksum to be subtracted from the total.
      *
-     * @see          #sumOf(long...)
+     * @return           The checksum after subtracting the partial sum, as a 32-bit unsigned value.
      *
-     * @since        1.17
+     * @see              #sumOf(long...)
+     *
+     * @since            1.17
      */
     public static long differenceOf(long total, long part) {
         Checksum sum = new Checksum(total);
-        sum.h -= (part >>> SHIFT_2_BYTES);
+        sum.h -= part >>> SHIFT_2_BYTES;
         sum.l -= part & MASK_2_BYTES;
         return sum.getChecksum();
     }

--- a/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
@@ -91,8 +91,8 @@ public class AbstractNullPixelMask {
      * Returns a byte array containing the mask
      * 
      * @return the byte array containing the pixel mask for the tile.
-     * @deprecated (<i>for internal use</i>) Visibility may be reduced to package
-     *             level in the future.
+     * @deprecated (<i>for internal use</i>) Visibility may be reduced to
+     *             package level in the future.
      */
     public byte[] getMaskBytes() {
         if (mask == null) {
@@ -168,8 +168,8 @@ public class AbstractNullPixelMask {
      * 
      * @param remaining
      *            the number of points the mask should accomodate.
-     * @return the internal buffer that may store the mask data for the specified
-     *         number of data points.
+     * @return the internal buffer that may store the mask data for the
+     *         specified number of data points.
      */
     protected ByteBuffer initializedMask(int remaining) {
         if (mask == null) {

--- a/src/main/java/nom/tam/util/FitsInputStream.java
+++ b/src/main/java/nom/tam/util/FitsInputStream.java
@@ -37,10 +37,10 @@ import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.nio.ByteBuffer;
 
-import static nom.tam.util.LoggerHelper.getLogger;
+import nom.tam.fits.FitsFactory;
+import nom.tam.fits.utilities.FitsCheckSum;
 
 /**
  * For reading FITS files through an {@link InputStream}.
@@ -63,7 +63,11 @@ import static nom.tam.util.LoggerHelper.getLogger;
 @SuppressWarnings("deprecation")
 public class FitsInputStream extends ArrayInputStream implements ArrayDataInput {
 
-    private static final Logger LOG = getLogger(FitsInputStream.class);
+    /** buffer for checksum calculation */
+    private ByteBuffer check;
+
+    /** aggregated checksum */
+    private long sum;
 
     /** the input, as accessible via the <code>DataInput</code> interface */
     private DataInput data;
@@ -77,6 +81,8 @@ public class FitsInputStream extends ArrayInputStream implements ArrayDataInput 
     public FitsInputStream(InputStream i, int bufLength) {
         super(i, bufLength);
         data = new DataInputStream(this);
+        check = ByteBuffer.allocate(FitsFactory.FITS_BLOCK_SIZE);
+        check.limit(check.capacity());
         setDecoder(new FitsDecoder(this));
     }
 
@@ -92,6 +98,62 @@ public class FitsInputStream extends ArrayInputStream implements ArrayDataInput 
     @Override
     protected FitsDecoder getDecoder() {
         return (FitsDecoder) super.getDecoder();
+    }
+
+    @Override
+    public int read() throws IOException {
+        int i = super.read();
+        if (i >= 0) {
+            check.put((byte) i);
+            if (check.remaining() <= 0) {
+                aggregate();
+            }
+        }
+        return i;
+    }
+
+    @Override
+    public int read(byte[] b, int from, int len) throws IOException {
+        int n = super.read(b, from, len);
+        for (int i = 0; i < n;) {
+            int l = Math.min(n - i, check.remaining());
+            check.put(b, from + i, l);
+            if (check.remaining() <= 0) {
+                aggregate();
+            }
+            i += l;
+        }
+        return n;
+    }
+
+    private void aggregate() {
+        sum = FitsCheckSum.sumOf(sum, FitsCheckSum.checksum(check));
+        check.position(0);
+    }
+
+    /**
+     * (<i>for internal use</i>) Returns the aggregated checksum for this stream since the last {@link #newChecksum()}
+     * or since instantiation.
+     * 
+     * @return the aggregated checksum since the last call to {@link #newChecksum()}, or else since instantiation.
+     * 
+     * @since  1.18.1
+     * 
+     * @see    #newChecksum()
+     */
+    public long getAggregatedChecksum() {
+        return sum;
+    }
+
+    /**
+     * (<i>for internal use</i>) Starts accumulating a new checksum, discarding the prior sum.
+     * 
+     * @since 1.18.1
+     * 
+     * @see   #getAggregatedChecksum()
+     */
+    public void newChecksum() {
+        sum = 0;
     }
 
     @Override
@@ -164,21 +226,16 @@ public class FitsInputStream extends ArrayInputStream implements ArrayDataInput 
 
     @Override
     public long skip(long n) throws IOException {
-        // The underlying stream may or may not support skip(). So, if skip()
-        // fails, we'll just default to reading byte-by-byte...
-        try {
-            return super.skip(n);
-        } catch (Exception e) {
-            LOG.log(Level.WARNING, "Built-in skip failed (will try work around it...)", e);
-            // Move on...
-        }
+        byte[] b = new byte[FitsFactory.FITS_BLOCK_SIZE];
 
-        // Fallback byte-by-byte read()...
+        // Always read so we can checksum.
         long skipped = 0;
-        for (; skipped < n; skipped++) {
-            if (read() < 0) {
+        while (skipped < n) {
+            int got = read(b, 0, (int) Math.min(n - skipped, b.length));
+            if (got < 0) {
                 break;
             }
+            skipped += got;
         }
         return skipped;
     }

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1260,14 +1260,12 @@ easily too:
   }
 ```
 
-The above will calculate checksum directly from the (random-accessible) file without reading the potentially large 
-data into memory, and compare HDU checksums and/or data checksums to those stored in the FITS file.
+The above will calculate checksum directly from the file or stream without reading the potentially large 
+data into memory (for random-access inputs), and compare HDU checksums and/or data checksums to those stored in the 
+FITS file.
 
 You can also verify the integrity of HDUs or their data segments individually, via `BasicHDU.verifyIntegrity()` or
 `BasicHDU.verifyDataIntegrity()` calls on specific HDUs.
-
-Note, that because checksum verification requires a second pass over the input byte sequence, it is available only 
-for random accessible inputs. Thus, you cannot (yet) verify checksums from streams or compressed FITS files.
 
 Finally, you might want to update the checksums for a FITS you modify in place:
 

--- a/src/test/java/nom/tam/fits/test/ChecksumTest.java
+++ b/src/test/java/nom/tam/fits/test/ChecksumTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -232,17 +231,18 @@ public class ChecksumTest {
         // No exception...
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testCheckSumVerifyStream() throws Exception {
         try (Fits fits = new Fits(new FileInputStream(new File("src/test/resources/nom/tam/fits/test/checksum.fits")))) {
             fits.verifyIntegrity();
         }
+        /* No exception */
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testDatasumVerifyStream() throws Exception {
         try (Fits fits = new Fits(new FileInputStream(new File("src/test/resources/nom/tam/fits/test/checksum.fits")))) {
-            fits.getHDU(0).verifyDataIntegrity();
+            assertTrue(fits.getHDU(0).verifyDataIntegrity());
         }
     }
 


### PR DESCRIPTION
added automatic checksum aggregation to `FitsInputStream`, and changed HDU / data read methods to store the accumulated stream checksums for verification. The extra calculation does not seem to impact performance (at least in my benchmarks), consistent with reads being IO-limited, not CPU-limited typically. (My tests were performed with a 7th gen Intel Core i7 CPU and a Gen3 nVME SSD). 