### PR TITLE
verifyIntegrity() via RandomAccess input of header, not data

### DIFF
--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -631,7 +631,7 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
         }
 
         long fsum = (myHeader.getStreamChecksum() < 0) ?
-                FitsCheckSum.checksum(myData.getRandomAccessInput(), getFileOffset(), getSize()) :
+                FitsCheckSum.checksum(myHeader.getRandomAccessInput(), getFileOffset(), getSize()) :
                 FitsCheckSum.sumOf(myHeader.getStreamChecksum(), myData.getStreamChecksum());
 
         if (fsum != FitsCheckSum.HDU_CHECKSUM) {

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -1871,6 +1871,20 @@ public class Header implements FitsElement {
     }
 
     /**
+     * Returns the random-accessible input from which this header was read, or <code>null</code> if the header is not
+     * associated with an input, or the input is not random accessible.
+     * 
+     * @return the random-accessible input associated with this header or <code>null</code>
+     * 
+     * @see    #read(ArrayDataInput)
+     * 
+     * @since  1.18.1
+     */
+    RandomAccess getRandomAccessInput() {
+        return (input instanceof RandomAccess) ? (RandomAccess) input : null;
+    }
+
+    /**
      * Returns the checksum value calculated duting reading from a stream. It is only populated when reading from
      * {@link FitsInputStream} imputs, and never from other types of inputs. Valid values are greater or equal to zero.
      * Thus, the return value will be <code>-1L</code> to indicate an invalid (unpopulated) checksum.


### PR DESCRIPTION
`Data` has too many variants, and thus more ways to mess up verification, whereas all HDUs have the same `Header` component. Thus, `BasicHDU.verifyIntegrity()` should use the input of the header to obrain the random-accessible input that is associated with the HDU. (The HDU is composed of a header and data that are read separately from the same input -- hence the HDU does not have its own input source, per se).