### PR TITLE
Added Header.mergeDistinct(Header source)

### DIFF
--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -308,12 +308,12 @@ public class Header implements FitsElement {
     }
 
     /**
-     * Inherits all cards from another header, provided they are not readily present in this header. That is, it merges
-     * only the non-conflicting header entries from the designated source (in contrast to {@link #updateLines(Header)}).
-     * All comment cards are merged also (since these can always appear multiple times, so they do not conflict). The
-     * merged entries are added at the end of the header, in the same order as they appear in the source. The merged
-     * entries will be copies of the cards in the original, such that subsequent modifications to the source will not
-     * affect this header or vice versa.
+     * Merges copies of all cards from another header, provided they are not readily present in this header. That is, it
+     * merges only the non-conflicting or distinct header entries from the designated source (in contrast to
+     * {@link #updateLines(Header)}). All comment cards are merged also (since these can always appear multiple times,
+     * so they do not conflict). The merged entries are added at the end of the header, in the same order as they appear
+     * in the source. The merged entries will be copies of the cards in the original, such that subsequent modifications
+     * to the source will not affect this header or vice versa.
      * 
      * @param source The header from which to inherit non-conflicting entries
      * 
@@ -321,7 +321,7 @@ public class Header implements FitsElement {
      * 
      * @see          #updateLines(Header)
      */
-    public void merge(Header source) {
+    public void mergeDistinct(Header source) {
         seekTail();
 
         Cursor<String, HeaderCard> c = source.iterator();
@@ -2204,7 +2204,7 @@ public class Header implements FitsElement {
      *
      * @throws HeaderCardException if the operation failed
      * 
-     * @see                        #merge(Header)
+     * @see                        #mergeDistinct(Header)
      */
     public void updateLines(final Header newHdr) throws HeaderCardException {
         Cursor<String, HeaderCard> j = newHdr.iterator();

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -308,12 +308,12 @@ public class Header implements FitsElement {
     }
 
     /**
-     * Inherits all cards from another header, which are not readily present in this header. That is, it itherits only
-     * the non-conflicting header entries from the designated source (in contrast to {@link #updateLines(Header)}). All
-     * comment cards are ingerited also (since these can always appear multiple times). The inherited entries are added
-     * at the end of the header, in the same order as they appear in the source. The inherited entries are copies of thr
-     * cards in the oirignal, such that subsequent modifications to the source will not affect this header ot vice
-     * versa.
+     * Inherits all cards from another header, provided they are not readily present in this header. That is, it merges
+     * only the non-conflicting header entries from the designated source (in contrast to {@link #updateLines(Header)}).
+     * All comment cards are merged also (since these can always appear multiple times, so they do not conflict). The
+     * merged entries are added at the end of the header, in the same order as they appear in the source. The merged
+     * entries will be copies of the cards in the original, such that subsequent modifications to the source will not
+     * affect this header or vice versa.
      * 
      * @param source The header from which to inherit non-conflicting entries
      * 
@@ -321,7 +321,7 @@ public class Header implements FitsElement {
      * 
      * @see          #updateLines(Header)
      */
-    public void inherit(Header source) {
+    public void merge(Header source) {
         seekTail();
 
         Cursor<String, HeaderCard> c = source.iterator();
@@ -2204,7 +2204,7 @@ public class Header implements FitsElement {
      *
      * @throws HeaderCardException if the operation failed
      * 
-     * @sa                         {@link #inherit(Header)}
+     * @see                        #merge(Header)
      */
     public void updateLines(final Header newHdr) throws HeaderCardException {
         Cursor<String, HeaderCard> j = newHdr.iterator();

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -308,6 +308,32 @@ public class Header implements FitsElement {
     }
 
     /**
+     * Inherits all cards from another header, which are not readily present in this header. That is, it itherits only
+     * the non-conflicting header entries from the designated source (in contrast to {@link #updateLines(Header)}). All
+     * comment cards are ingerited also (since these can always appear multiple times). The inherited entries are added
+     * at the end of the header, in the same order as they appear in the source. The inherited entries are copies of thr
+     * cards in the oirignal, such that subsequent modifications to the source will not affect this header ot vice
+     * versa.
+     * 
+     * @param source The header from which to inherit non-conflicting entries
+     * 
+     * @since        1.19
+     * 
+     * @see          #updateLines(Header)
+     */
+    public void inherit(Header source) {
+        seekTail();
+
+        Cursor<String, HeaderCard> c = source.iterator();
+        while (c.hasNext()) {
+            HeaderCard card = c.next();
+            if (card.isCommentStyleCard() || !containsKey(card.getKey())) {
+                addLine(card.copy());
+            }
+        }
+    }
+
+    /**
      * Insert a new header card at the current position, deleting any prior occurence of the same card while maintaining
      * the current position to point to after the newly inserted card.
      *
@@ -2177,6 +2203,8 @@ public class Header implements FitsElement {
      * @param  newHdr              the list of new header data lines to replace the current ones.
      *
      * @throws HeaderCardException if the operation failed
+     * 
+     * @sa                         {@link #inherit(Header)}
      */
     public void updateLines(final Header newHdr) throws HeaderCardException {
         Cursor<String, HeaderCard> j = newHdr.iterator();

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -836,6 +836,45 @@ space in headers for later additions using `Header.ensureCardSpace(int)` prior t
 originally.)
 
 
+### Creating new HDUs that reuse existing header information
+
+Sometimes we want to create a new HDU based on an existing HDU, such as a 
+cropped image, or a table segment, in which we want to reuse much of the 
+information contained in the original header. The best way to go about it is 
+via the following 3 steps:
+
+ 1. Start by creating the new data, and with it create a brand new HDU. This 
+ HDU will have the correct mandatory data description (type and size) in its 
+ header and nothing else.
+
+ 2. Merge distict header entries from the original HDU into the header of the
+ new HDU, using the `Header.mergeDistinct(Header source)` method. This will 
+ copy over all header entries without overriding the proper mandatory data 
+ description
+
+ 3. Update any other header entries as necessary, such as WCS etc. Pay 
+ attention to removing obsoleted entries also, such as descriptions of table 
+ columns no longer exist in the new data.
+
+For example:
+
+```java
+  ImageHDU origHDU = ...
+  
+  // 1. create the new image HDU with the new data
+  float[][] newImage = ...
+  ImageHDU newHDU = ImageData.from(newImage).toHDU();
+  
+  // 2. copy over non-conflicting header entries from the original
+  Header.newHeader = newHDU.getHeader();
+  newHeader.mergeDistinct(origHDU.getHeader());
+
+  // 3. Update the WCS for the cropped data...
+  newHeader.addValue(Standard.CRPIXn.n(1), ...);
+  ...
+```
+
+
 -----------------------------------------------------------------------------
 
 <a name="building-tables-from-data"></a>

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1639,7 +1639,7 @@ public class HeaderTest {
         h2.insertComment("comment");
         h2.addValue("TEST", 3, "a test value");
 
-        h.merge(h2);
+        h.mergeDistinct(h2);
 
         assertEquals("EXIST", 1, h.getIntValue("EXIST", -1));
         assertEquals("TEST", 3, h.getIntValue("TEST", -1));

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1639,7 +1639,7 @@ public class HeaderTest {
         h2.insertComment("comment");
         h2.addValue("TEST", 3, "a test value");
 
-        h.inherit(h2);
+        h.merge(h2);
 
         assertEquals("EXIST", 1, h.getIntValue("EXIST", -1));
         assertEquals("TEST", 3, h.getIntValue("TEST", -1));

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1627,4 +1627,32 @@ public class HeaderTest {
         BasicHDU<?> hdu = f.readHDU();
         assertNull(hdu.getHeader().getRandomAccessInput());
     }
+
+    @Test
+    public void testInheritCards() throws Exception {
+        Header h = new Header();
+        h.addValue("EXIST", 1, "existing prior value");
+        assertEquals("orig", 1, h.getIntValue("EXIST", -1));
+
+        Header h2 = new Header();
+        h2.addValue("EXIST", 2, "another value for EXIST");
+        h2.insertComment("comment");
+        h2.addValue("TEST", 3, "a test value");
+
+        h.inherit(h2);
+
+        assertEquals("EXIST", 1, h.getIntValue("EXIST", -1));
+        assertEquals("TEST", 3, h.getIntValue("TEST", -1));
+
+        Cursor<String, HeaderCard> c = h.iterator();
+        while (c.hasNext()) {
+            HeaderCard card = c.next();
+            if (card.isCommentStyleCard()) {
+                assertEquals("comment", card.getComment());
+                return;
+            }
+        }
+
+        throw new IllegalStateException("Missing inherited comment");
+    }
 }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1629,7 +1629,7 @@ public class HeaderTest {
     }
 
     @Test
-    public void testInheritCards() throws Exception {
+    public void testMergeDistinctCards() throws Exception {
         Header h = new Header();
         h.addValue("EXIST", 1, "existing prior value");
         assertEquals("orig", 1, h.getIntValue("EXIST", -1));


### PR DESCRIPTION
This new method complements the existing `Header.updateLines(Header)` method, offering different handling for conflicting header entries. Whereas `updateLines(Header)` will override existing entries for the same keywords, `mergeDistinct(Header)` will leave conflicting pre-existing entries untouched, copying only new keywords and all comments.