### PR TITLE
Targeted Data creation, improved RandomGroups and UndefinedData support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,6 @@
           <configLocation>${project.basedir}/src/main/checkstyle/nom-tam-fits-style.xml</configLocation>
           <suppressionsLocation>${project.basedir}/src/main/checkstyle/checkstyle-suppressions.xml</suppressionsLocation>
           <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
-          <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
         </configuration>

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -140,7 +140,7 @@ public class AsciiTable extends AbstractTableData {
     /**
      * Creates an ASCII table given a header. For tables that contain integer-valued columns of format <code>I10</code>,
      * the {@link #setI10PreferInt(boolean)} mayb be used to control whether to treat them as <code>int</code> or as
-     * </code>long</code> values (the latter is the default).
+     * <code>long</code> values (the latter is the default).
      *
      * @param      hdr           The header describing the table
      *

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -79,6 +79,9 @@ public class AsciiTable extends AbstractTableData {
 
     private static final int DOUBLE_MAX_LENGTH = 24;
 
+    /** Whether I10 columns should be treated as <code>int</code> provided that defined limits allow for it. */
+    private static boolean isI10PreferInt = false;
+
     // private static final Logger LOG = Logger.getLogger(AsciiTable.class.getName());
 
     /** The number of rows in the table */
@@ -135,14 +138,18 @@ public class AsciiTable extends AbstractTableData {
     }
 
     /**
-     * Create an ASCII table given a header
+     * Creates an ASCII table given a header. For tables that contain integer-valued columns of format <code>I10</code>,
+     * the {@link #setI10PreferInt(boolean)} mayb be used to control whether to treat them as <code>int</code> or as
+     * </code>long</code> values (the latter is the default).
      *
-     * @param  hdr           The header describing the table
+     * @param      hdr           The header describing the table
      *
-     * @throws FitsException if the operation failed
+     * @throws     FitsException if the operation failed
+     * 
+     * @deprecated               (<i>for internal use</i>) Visibility may be reduced to the package level in the future.
      */
     public AsciiTable(Header hdr) throws FitsException {
-        this(hdr, true);
+        this(hdr, isI10PreferInt);
     }
 
     /**
@@ -155,14 +162,16 @@ public class AsciiTable extends AbstractTableData {
      * integers. Setting it <code>true</code> may make it more likely to avoid unexpected type changes during
      * round-tripping, but it also means that some (large number) data in I10 columns may be impossible to read.
      * </p>
+     * 
+     * @param      hdr           The header describing the table
+     * @param      preferInt     if <code>true</code>, format "I10" columns will be assumed <code>int.class</code>,
+     *                               provided TLMINn/TLMAXn or TDMINn/TDMAXn limits (if defined) allow it. if
+     *                               <code>false</code>, I10 columns that have no clear indication of data range will be
+     *                               assumed <code>long.class</code>.
      *
-     * @param  hdr           The header describing the table
-     * @param  preferInt     if <code>true</code>, format "I10" columns will be assumed <code>int.class</code>, provided
-     *                           TLMINn/TLMAXn or TDMINn/TDMAXn limits (if defined) allow it. if <code>false</code>, I10
-     *                           columns that have no clear indication of data range will be assumed
-     *                           <code>long.class</code>.
-     *
-     * @throws FitsException if the operation failed
+     * @throws     FitsException if the operation failed
+     * 
+     * @deprecated               Use {@link #setI10PreferInt(boolean)} instead prior to reading ASCII tables.
      */
     public AsciiTable(Header hdr, boolean preferInt) throws FitsException {
         if (!hdr.getStringValue(Standard.XTENSION, Standard.XTENSION_ASCIITABLE)
@@ -985,5 +994,41 @@ public class AsciiTable extends AbstractTableData {
         Header h = new Header();
         fillHeader(h);
         return new AsciiTableHDU(h, this);
+    }
+
+    /**
+     * <p>
+     * Controls how columns with format "<code>I10</code>" are handled; this is tricky because some, but not all,
+     * integers that can be represented in 10 characters form 32-bit integers. Setting it <code>true</code> may make it
+     * more likely to avoid unexpected type changes during round-tripping, but it also means that some values in I10
+     * columns may be impossible to read. The default behavior is to assume <code>false</code>, and thus to treat I10
+     * columns as <code>long</code> values.
+     * </p>
+     * 
+     * @param value if <code>true</code>, format "I10" columns will be assumed <code>int.class</code>, provided
+     *                  TLMINn/TLMAXn or TDMINn/TDMAXn limits (if defined) allow it. if <code>false</code>, I10 columns
+     *                  that have no clear indication of data range will be assumed <code>long.class</code>.
+     *
+     * @since       1.19
+     * 
+     * @see         AsciiTable#isI10PreferInt()
+     */
+    public static void setI10PreferInt(boolean value) {
+        isI10PreferInt = value;
+    }
+
+    /**
+     * Checks if I10 columns should be treated as containing 32-bit <code>int</code> values, rather than 64-bit
+     * <code>long</code> values, when possible.
+     * 
+     * @return <code>true</code> if I10 columns should be treated as containing 32-bit <code>int</code> values,
+     *             otherwise <code>false</code>.
+     * 
+     * @since  1.19
+     * 
+     * @see    #setI10PreferInt(boolean)
+     */
+    public static boolean isI10PreferInt() {
+        return isI10PreferInt;
     }
 }

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -174,8 +174,9 @@ public class AsciiTable extends AbstractTableData {
      * @deprecated               Use {@link #setI10PreferInt(boolean)} instead prior to reading ASCII tables.
      */
     public AsciiTable(Header hdr, boolean preferInt) throws FitsException {
-        if (!hdr.getStringValue(Standard.XTENSION, Standard.XTENSION_ASCIITABLE)
-                .equalsIgnoreCase(Standard.XTENSION_ASCIITABLE)) {
+        String ext = hdr.getStringValue(Standard.XTENSION, Standard.XTENSION_IMAGE);
+
+        if (!ext.equalsIgnoreCase(Standard.XTENSION_ASCIITABLE)) {
             throw new FitsException("Not an ASCII table header (XTENSION = " + hdr.getStringValue(Standard.XTENSION) + ")");
         }
 

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -80,7 +80,7 @@ public class AsciiTable extends AbstractTableData {
     private static final int DOUBLE_MAX_LENGTH = 24;
 
     /** Whether I10 columns should be treated as <code>int</code> provided that defined limits allow for it. */
-    private static boolean isI10PreferInt = false;
+    private static boolean isI10PreferInt = true;
 
     // private static final Logger LOG = Logger.getLogger(AsciiTable.class.getName());
 
@@ -1001,8 +1001,8 @@ public class AsciiTable extends AbstractTableData {
      * Controls how columns with format "<code>I10</code>" are handled; this is tricky because some, but not all,
      * integers that can be represented in 10 characters form 32-bit integers. Setting it <code>true</code> may make it
      * more likely to avoid unexpected type changes during round-tripping, but it also means that some values in I10
-     * columns may be impossible to read. The default behavior is to assume <code>false</code>, and thus to treat I10
-     * columns as <code>long</code> values.
+     * columns may be impossible to read. The default behavior is to assume <code>true</code>, and thus to treat I10
+     * columns as <code>int</code> values.
      * </p>
      * 
      * @param value if <code>true</code>, format "I10" columns will be assumed <code>int.class</code>, provided

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -1340,7 +1340,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
      * @see                      #isDeferred()
      */
     public BinaryTable(Header header) throws FitsException {
-        String ext = header.getStringValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
+        String ext = header.getStringValue(Standard.XTENSION, Standard.XTENSION_IMAGE);
 
         if (!ext.equalsIgnoreCase(Standard.XTENSION_BINTABLE) && !ext.equalsIgnoreCase(NonStandard.XTENSION_A3DTABLE)) {
             throw new FitsException(

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -522,9 +522,6 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
          * @see    #getLeadingShape()
          */
         private int getLastFitsDim() {
-            if (fitsShape.length == 0) {
-                return 1;
-            }
             return fitsShape[fitsShape.length - 1];
         }
 
@@ -1304,9 +1301,8 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
         this();
 
         try {
-            table = tab.copy();
+            table = new ColumnTable<>();
             nRow = tab.getNRows();
-
             columns = new ArrayList<>();
 
             for (int i = 0; i < tab.getNCols(); i++) {

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -3881,7 +3881,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
     }
 
     @Override
-    public BinaryTableHDU toHDU() {
+    public BinaryTableHDU toHDU() throws IllegalStateException {
         Header h = new Header();
         try {
             fillHeader(h);

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -7,6 +7,7 @@ import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
 import nom.tam.util.ColumnTable;
+import nom.tam.util.Cursor;
 
 /*
  * #%L
@@ -199,8 +200,10 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
     @Override
     public int addColumn(Object data) throws FitsException {
         int n = myData.addColumn(data);
-        myHeader.setNaxis(1, myData.getRowBytes());
-        myData.fillForColumn(myHeader, n - 1);
+        myHeader.addValue(Standard.NAXISn.n(1), myData.getRowBytes());
+        Cursor<String, HeaderCard> c = myHeader.iterator();
+        c.end();
+        myData.fillForColumn(c, n - 1);
         return super.addColumn(data);
     }
 

--- a/src/main/java/nom/tam/fits/Data.java
+++ b/src/main/java/nom/tam/fits/Data.java
@@ -438,7 +438,9 @@ public abstract class Data implements FitsElement {
      * Returns an approprotae HDU object that encapsulates this FITS data, and contains the minimal mandatory header
      * description for that data.
      * 
-     * @return a HDU object ocntaining the data and its minimal required header description
+     * @throws IllegalStateException If the data cannot be converted to an HDU for some reason.
+     * 
+     * @return                       a HDU object ocntaining the data and its minimal required header description
      */
-    public abstract BasicHDU<?> toHDU();
+    public abstract BasicHDU<?> toHDU() throws IllegalStateException;
 }

--- a/src/main/java/nom/tam/fits/Data.java
+++ b/src/main/java/nom/tam/fits/Data.java
@@ -433,4 +433,12 @@ public abstract class Data implements FitsElement {
 
     @Override
     public abstract void write(ArrayDataOutput o) throws FitsException;
+
+    /**
+     * Returns an approprotae HDU object that encapsulates this FITS data, and contains the minimal mandatory header
+     * description for that data.
+     * 
+     * @return a HDU object ocntaining the data and its minimal required header description
+     */
+    public abstract BasicHDU<?> toHDU();
 }

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -869,6 +869,10 @@ public class Fits implements Closeable {
         if (position < 0 || position > getNumberOfHDUs()) {
             throw new FitsException("Attempt to insert HDU at invalid location: " + position);
         }
+        if (myHDU instanceof RandomGroupsHDU && position != 0) {
+            throw new FitsException("Random groups HDUs must be the first (primary) HDU. Requested pos: " + position);
+        }
+
         try {
             if (position == 0) {
                 // Note that the previous initial HDU is no longer the first.

--- a/src/main/java/nom/tam/fits/HeaderOrder.java
+++ b/src/main/java/nom/tam/fits/HeaderOrder.java
@@ -61,8 +61,8 @@ public class HeaderOrder implements java.util.Comparator<String>, Serializable {
     /**
      * This array defines the order of ordered keywords, except END (which we handle separately)
      */
-    private static final String[] ORDER = {SIMPLE.key(), XTENSION.key(), BITPIX.key(), NAXIS.key(), EXTEND.key(),
-            PCOUNT.key(), GCOUNT.key(), TFIELDS.key(), BLOCKED.key(), THEAP.key()};
+    private static final String[] ORDER = {SIMPLE.key(), XTENSION.key(), BITPIX.key(), NAXIS.key(), PCOUNT.key(),
+            GCOUNT.key(), EXTEND.key(), TFIELDS.key(), BLOCKED.key(), THEAP.key()};
 
     /**
      * Every keyword is assigned an index. Because NAXIS can have 999 NAXISn variants, we'll space the indices of the

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -392,12 +392,12 @@ public class ImageData extends Data {
 
     @Override
     @SuppressWarnings("deprecation")
-    public ImageHDU toHDU() {
+    public ImageHDU toHDU() throws IllegalStateException {
         Header h = new Header();
         try {
             fillHeader(h);
         } catch (FitsException e) {
-            // This should never happen really...
+            throw new IllegalStateException(e.getMessage(), e);
         }
         return new ImageHDU(h, this);
     }

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -245,12 +245,10 @@ public class ImageData extends Data {
                 Bitpix.forPrimitiveType(ArrayFuncs.getBaseClass(dataArray)).getHeaderValue()));
 
         int[] dims = ArrayFuncs.getDimensions(dataArray);
-        c.add(HeaderCard.create(Standard.NAXIS, dims == null ? 0 : dims.length));
+        c.add(HeaderCard.create(Standard.NAXIS, dims.length));
 
-        if (dims != null) {
-            for (int i = 1; i <= dims.length; i++) {
-                c.add(HeaderCard.create(Standard.NAXISn.n(i), dims[dims.length - i]));
-            }
+        for (int i = 1; i <= dims.length; i++) {
+            c.add(HeaderCard.create(Standard.NAXISn.n(i), dims[dims.length - i]));
         }
 
         // Just in case!

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -122,8 +122,8 @@ public class ImageData extends Data {
     }
 
     /**
-     * Create an array from a header description. This is typically how data will be created when reading FITS data from
-     * a file where the header is read first. This creates an empty array.
+     * (<i>for internal use</i>) Create an array from a header description. This is typically how data will be created
+     * when reading FITS data from a file where the header is read first. This creates an empty array.
      *
      * @param  h             header to be used as a template.
      *

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -35,22 +35,18 @@ import java.io.IOException;
 import java.nio.Buffer;
 
 import nom.tam.fits.header.Bitpix;
+import nom.tam.fits.header.NonStandard;
 import nom.tam.fits.header.Standard;
 import nom.tam.image.ImageTiler;
 import nom.tam.image.StandardImageTiler;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
+import nom.tam.util.Cursor;
 import nom.tam.util.FitsEncoder;
 import nom.tam.util.RandomAccess;
 import nom.tam.util.array.MultiArrayIterator;
 import nom.tam.util.type.ElementType;
-
-import static nom.tam.fits.header.Standard.EXTEND;
-import static nom.tam.fits.header.Standard.GCOUNT;
-import static nom.tam.fits.header.Standard.NAXIS;
-import static nom.tam.fits.header.Standard.NAXISn;
-import static nom.tam.fits.header.Standard.PCOUNT;
 
 /**
  * <p>
@@ -140,9 +136,18 @@ public class ImageData extends Data {
     /**
      * Create an ImageData object using the specified object to initialize the data array.
      *
-     * @param x The initial data array. This should be a primitive array but this is not checked currently.
+     * @param  x                        The initial data array. This should be a primitive array but this is not checked
+     *                                      currently.
+     * 
+     * @throws IllegalArgumentException if x is not a suitable primitive array
      */
-    public ImageData(Object x) {
+    public ImageData(Object x) throws IllegalArgumentException {
+        try {
+            checkCompatible(x);
+        } catch (FitsException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+
         dataArray = x;
         byteSize = FitsEncoder.computeSize(x);
     }
@@ -229,32 +234,29 @@ public class ImageData extends Data {
         }
 
         Standard.context(ImageData.class);
-        String classname = dataArray.getClass().getName();
 
-        int[] dimens = ArrayFuncs.getDimensions(dataArray);
+        // We'll assume it's a primary image, until we know better...
+        // Just in case, we don't want an XTENSION key lingering around...
+        head.deleteKey(Standard.XTENSION);
 
-        if (dimens == null || dimens.length == 0) {
-            throw new FitsException("Image data object not array");
-        }
+        Cursor<String, HeaderCard> c = head.iterator();
+        c.add(HeaderCard.create(Standard.SIMPLE, true));
+        c.add(HeaderCard.create(Standard.BITPIX,
+                Bitpix.forPrimitiveType(ArrayFuncs.getBaseClass(dataArray)).getHeaderValue()));
 
-        // if this is neither a primary header nor an image extension,
-        // make it a primary header
-        head.setSimple(true);
-        head.setBitpix(Bitpix.forArrayID(classname.charAt(dimens.length)));
+        int[] dims = ArrayFuncs.getDimensions(dataArray);
+        c.add(HeaderCard.create(Standard.NAXIS, dims == null ? 0 : dims.length));
 
-        overrideHeaderAxes(head, dimens);
-
-        for (int i = 1; i <= dimens.length; i++) {
-            if (dimens[i - 1] == -1) {
-                throw new FitsException("Unfilled array for dimension: " + i);
+        if (dims != null) {
+            for (int i = 1; i <= dims.length; i++) {
+                c.add(HeaderCard.create(Standard.NAXISn.n(i), dims[dims.length - i]));
             }
-            head.setNaxis(i, dimens[dimens.length - i]);
         }
-        // Just in case!
-        head.addValue(EXTEND, true);
 
-        head.addValue(PCOUNT, 0);
-        head.addValue(GCOUNT, 1);
+        // Just in case!
+        c.add(HeaderCard.create(Standard.PCOUNT, 0));
+        c.add(HeaderCard.create(Standard.GCOUNT, 1));
+        c.add(HeaderCard.create(Standard.EXTEND, true));
 
         Standard.context(null);
     }
@@ -274,28 +276,34 @@ public class ImageData extends Data {
      * @throws FitsException If there was a problem accessing or interpreting the required header values.
      */
     protected ArrayDesc parseHeader(Header h) throws FitsException {
-        int gCount = h.getIntValue(GCOUNT, 1);
-        int pCount = h.getIntValue(PCOUNT, 0);
+        String ext = h.getStringValue(Standard.XTENSION, Standard.XTENSION_IMAGE);
+
+        if (!ext.equalsIgnoreCase(Standard.XTENSION_IMAGE) && !ext.equalsIgnoreCase(NonStandard.XTENSION_IUEIMAGE)) {
+            throw new FitsException("Not an image header (XTENSION = " + h.getStringValue(Standard.XTENSION) + ")");
+        }
+
+        int gCount = h.getIntValue(Standard.GCOUNT, 1);
+        int pCount = h.getIntValue(Standard.PCOUNT, 0);
         if (gCount > 1 || pCount != 0) {
             throw new FitsException("Group data treated as images");
         }
 
         Bitpix bitpix = Bitpix.fromHeader(h);
         Class<?> baseClass = bitpix.getPrimitiveType();
-        int ndim = h.getIntValue(NAXIS, 0);
+        int ndim = h.getIntValue(Standard.NAXIS, 0);
         int[] dims = new int[ndim];
         // Note that we have to invert the order of the axes
         // for the FITS file to get the order in the array we
         // are generating.
 
         byteSize = ndim > 0 ? 1 : 0;
-        for (int i = 0; i < ndim; i++) {
-            int cdim = h.getIntValue(NAXISn.n(i + 1), 0);
+        for (int i = 1; i <= ndim; i++) {
+            int cdim = h.getIntValue(Standard.NAXISn.n(i), 0);
             if (cdim < 0) {
                 throw new FitsException("Invalid array dimension:" + cdim);
             }
             byteSize *= cdim;
-            dims[ndim - i - 1] = cdim;
+            dims[ndim - i] = cdim;
         }
         byteSize *= bitpix.byteSize();
         return new ArrayDesc(dims, baseClass);
@@ -332,5 +340,52 @@ public class ImageData extends Data {
             }
             header.addValue(Standard.NAXISn.n(i), l);
         }
+    }
+
+    /**
+     * Creates a new FITS image using the specified primitive numerical Java array containing data.
+     * 
+     * @param  data                     A regulatly shaped primitive numerical Java array, which can be
+     *                                      multi-dimensional.
+     * 
+     * @return                          A new FITS image that encapsulates the specified array data.
+     * 
+     * @throws IllegalArgumentException if the argument is not a primitive numerical Java array.
+     * 
+     * @since                           1.19
+     */
+    public static ImageData from(Object data) throws IllegalArgumentException {
+        return new ImageData(data);
+    }
+
+    /**
+     * Checks if a given data object may constitute the kernel for an image. To conform, the data must be a regularly
+     * shaped primitive numerical array of ant dimensions, or <code>null</code>.
+     * 
+     * @param  data                     A regularly shaped primitive numerical array of ny dimension, or
+     *                                      <code>null</code>
+     * 
+     * @throws IllegalArgumentException If the array is not regularly shaped.
+     * @throws FitsException            If the argument is not a primitive numerical array type
+     * 
+     * @since                           1.19
+     */
+    static void checkCompatible(Object data) throws IllegalArgumentException, FitsException {
+        if (data != null) {
+            Bitpix.forPrimitiveType(ArrayFuncs.getBaseClass(data));
+            ArrayFuncs.checkRegularArray(data, false);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public ImageHDU toHDU() {
+        Header h = new Header();
+        try {
+            fillHeader(h);
+        } catch (FitsException e) {
+            // This should never happen really...
+        }
+        return new ImageHDU(h, this);
     }
 }

--- a/src/main/java/nom/tam/fits/ImageHDU.java
+++ b/src/main/java/nom/tam/fits/ImageHDU.java
@@ -7,7 +7,6 @@ import java.util.logging.Logger;
 import nom.tam.fits.header.Standard;
 import nom.tam.image.StandardImageTiler;
 import nom.tam.util.ArrayFuncs;
-import nom.tam.util.type.ElementType;
 
 /*
  * #%L
@@ -89,14 +88,12 @@ public class ImageHDU extends BasicHDU<ImageData> {
      */
     @Deprecated
     public static boolean isData(Object o) {
-        if (o.getClass().isArray()) {
-            ElementType<?> type = ElementType.forClass(ArrayFuncs.getBaseClass(o));
-            return type != ElementType.BOOLEAN && //
-                    type != ElementType.STRING && //
-                    type != ElementType.UNKNOWN;
-
+        try {
+            ImageData.checkCompatible(o);
+        } catch (Exception e) {
+            return false;
         }
-        return false;
+        return true;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -266,6 +266,8 @@ public class RandomGroupsData extends Data {
      * @throws ArrayIndexOutOfBoundsException if the group index is out of bounds
      * 
      * @see                                   RandomGroupsHDU#getParameter(String, int)
+     * 
+     * @since                                 1.19
      */
     public Object getImage(int group) throws ArrayIndexOutOfBoundsException {
         return dataArray[group][1];

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -256,4 +256,23 @@ public class RandomGroupsData extends Data {
         return new RandomGroupsHDU(h, this);
     }
 
+    /**
+     * Returns the image component stored in the specified group.
+     * 
+     * @param  group                          The group index
+     * 
+     * @return                                The image array for the specified group
+     * 
+     * @throws ArrayIndexOutOfBoundsException if the group index is out of bounds
+     * 
+     * @see                                   RandomGroupsHDU#getParameter(String, int)
+     */
+    public Object getImage(int group) throws ArrayIndexOutOfBoundsException {
+        return dataArray[group][1];
+    }
+
+    Object getParameterArray(int group) throws ArrayIndexOutOfBoundsException {
+        return dataArray[group][0];
+    }
+
 }

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -264,16 +264,19 @@ public class RandomGroupsData extends Data {
      * @return                                The image array for the specified group
      * 
      * @throws ArrayIndexOutOfBoundsException if the group index is out of bounds
+     * @throws FitsException                  if the deferred data could not be loaded.
      * 
      * @see                                   RandomGroupsHDU#getParameter(String, int)
      * 
      * @since                                 1.19
      */
-    public Object getImage(int group) throws ArrayIndexOutOfBoundsException {
+    public Object getImage(int group) throws ArrayIndexOutOfBoundsException, FitsException {
+        ensureData();
         return dataArray[group][1];
     }
 
-    Object getParameterArray(int group) throws ArrayIndexOutOfBoundsException {
+    Object getParameterArray(int group) throws ArrayIndexOutOfBoundsException, FitsException {
+        ensureData();
         return dataArray[group][0];
     }
 

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -246,7 +246,7 @@ public class RandomGroupsData extends Data {
 
     @SuppressWarnings("deprecation")
     @Override
-    public RandomGroupsHDU toHDU() {
+    public RandomGroupsHDU toHDU() throws IllegalStateException {
         Header h = new Header();
         try {
             fillHeader(h);

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -259,7 +259,7 @@ public class RandomGroupsData extends Data {
     /**
      * Returns the image component stored in the specified group.
      * 
-     * @param  group                          The group index
+     * @param  group                          The zero-based group index
      * 
      * @return                                The image array for the specified group
      * 

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -67,11 +67,10 @@ import static nom.tam.fits.header.Standard.XTENSION_IMAGE;
  * parameters. When analyzing group data structure only the first group is examined, but for a valid FITS file all
  * groups must have the same structure.
  * <p>
- * Note also, that we do not provide support for accessing parameters by names or for building up higher-precision
- * values by combining multiple related parameters through scalings and offsets, as described in the FITS standard (e.g.
- * combining 3 or 4 related <code>byte</code> parameter values to obtain a full-precision 32-bit <code>float</code>
- * parameter value when <code>BITPIX</code> is 8). Users of random groups must make these translations themselves. We
- * may add more support in the future...
+ * As of version 1.19, we provide support for accessing parameters by names including building up higher-precision
+ * values by combining multiple related parameter conversion recipes through scalings and offsets, as described in the
+ * FITS standard (e.g. combining 3 or 4 related <code>byte</code> parameter values to obtain a full-precision 32-bit
+ * <code>float</code> parameter value when <code>BITPIX</code> is 8).
  * </p>
  * 
  * @see BinaryTableHDU

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -299,7 +299,7 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
                 parameters.put(name, p);
             }
 
-            p.components.add(new ParameterScaling(header, i));
+            p.components.add(new ParameterConversion(header, i));
         }
     }
 
@@ -469,19 +469,19 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
 
     /**
      * A conversion recipe from the native BITPIX type to a floating-point value. Each parameter may have multiple such
-     * recipes, which in combination can provide the required precision for the parameter regardless the BITPIX storage
+     * recipes, the sum of which can provide the required precision for the parameter regardless the BITPIX storage
      * type.
      * 
      * @author Attila Kovacs
      * 
      * @since  1.19
      */
-    private final class ParameterScaling {
+    private static final class ParameterConversion {
         private int index;
         private double scaling;
         private double offset;
 
-        private ParameterScaling(Header h, int n) {
+        private ParameterConversion(Header h, int n) {
             index = n - 1;
             scaling = h.getDoubleValue(Standard.PSCALn.n(n), 1.0);
             offset = h.getDoubleValue(Standard.PZEROn.n(n), 0.0);
@@ -495,12 +495,12 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
      * 
      * @since  1.19
      */
-    private class Parameter {
-        private ArrayList<ParameterScaling> components = new ArrayList<>();
+    private static class Parameter {
+        private ArrayList<ParameterConversion> components = new ArrayList<>();
 
         private double getValue(Object array) {
             double value = 0.0;
-            for (ParameterScaling c : components) {
+            for (ParameterConversion c : components) {
                 double x = Array.getDouble(array, c.index);
                 value += c.scaling * x + c.offset;
             }

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -4,7 +4,9 @@ import java.io.PrintStream;
 
 import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.Standard;
+import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
+import nom.tam.util.FitsOutput;
 
 /*
  * #%L
@@ -373,6 +375,16 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
     @Override
     public double getBZero() {
         return super.getBZero();
+    }
+
+    @Override
+    public void write(ArrayDataOutput stream) throws FitsException {
+        if (stream instanceof FitsOutput) {
+            if (!((FitsOutput) stream).isAtStart()) {
+                throw new FitsException("Random groups are only permitted in the primary HDU");
+            }
+        }
+        super.write(stream);
     }
 
 }

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -270,10 +270,15 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
     public RandomGroupsHDU(Header header, RandomGroupsData data) throws IllegalStateException {
         super(header, data);
 
+        if (header == null) {
+            return;
+        }
+
         int eSize = 1;
+
         try {
             eSize = getBitpix().byteSize();
-        } catch (FitsException e) {
+        } catch (Exception e) {
             throw new IllegalStateException(e.getMessage(), e);
         }
 
@@ -284,8 +289,9 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
 
         for (int i = 1; i <= nparms; i++) {
             String name = header.getStringValue(Standard.PTYPEn.n(i));
-            if (name == null)
+            if (name == null) {
                 continue;
+            }
 
             Parameter p = parameters.get(name);
             if (p == null) {
@@ -429,6 +435,8 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
      * @return A set containing the parameter names contained in this HDU
      * 
      * @see    #getParameter(String, int)
+     * 
+     * @since  1.19
      */
     public Set<String> getParameterNames() {
         return parameters.keySet();
@@ -447,6 +455,8 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
      * 
      * @see                                   #getParameterNames()
      * @see                                   RandomGroupsData#getImage(int)
+     * 
+     * @since                                 1.19
      */
     public double getParameter(String name, int group) throws ArrayIndexOutOfBoundsException {
         Parameter p = parameters.get(name);
@@ -457,10 +467,19 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
         return p.getValue(getData().getParameterArray(group));
     }
 
-    private class ParameterScaling {
-        int index;
-        double scaling;
-        double offset;
+    /**
+     * A conversion recipe from the native BITPIX type to a floating-point value. Each parameter may have multiple such
+     * recipes, which in combination can provide the required precision for the parameter regardless the BITPIX storage
+     * type.
+     * 
+     * @author Attila Kovacs
+     * 
+     * @since  1.19
+     */
+    private final class ParameterScaling {
+        private int index;
+        private double scaling;
+        private double offset;
 
         private ParameterScaling(Header h, int n) {
             index = n - 1;
@@ -469,8 +488,15 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
         }
     }
 
+    /**
+     * Represents a single parameter in the random groups data.
+     * 
+     * @author Attila Kovacs
+     * 
+     * @since  1.19
+     */
     private class Parameter {
-        ArrayList<ParameterScaling> components = new ArrayList<>();
+        private ArrayList<ParameterScaling> components = new ArrayList<>();
 
         private double getValue(Object array) {
             double value = 0.0;

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -1,29 +1,18 @@
 package nom.tam.fits;
 
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import nom.tam.fits.header.Bitpix;
-import nom.tam.fits.header.Standard;
-import nom.tam.util.ArrayDataInput;
-import nom.tam.util.ArrayDataOutput;
-import nom.tam.util.ArrayFuncs;
-import nom.tam.util.FitsEncoder;
-
-/*
+/*-
  * #%L
- * nom.tam FITS library
+ * nom.tam.fits
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2023 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
- *
+ * 
  * Anyone is free to copy, modify, publish, use, compile, sell, or
  * distribute this software, either in source code form or as a compiled
  * binary, for any purpose, commercial or non-commercial, and by any
  * means.
- *
+ * 
  * In jurisdictions that recognize copyright laws, the author or authors
  * of this software dedicate any and all copyright interest in the
  * software to the public domain. We make this dedication for the benefit
@@ -31,7 +20,7 @@ import nom.tam.util.FitsEncoder;
  * successors. We intend this dedication to be an overt act of
  * relinquishment in perpetuity of all present and future rights to this
  * software under copyright law.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -42,12 +31,15 @@ import nom.tam.util.FitsEncoder;
  * #L%
  */
 
-import static nom.tam.fits.header.Standard.EXTEND;
-import static nom.tam.fits.header.Standard.GCOUNT;
-import static nom.tam.fits.header.Standard.NAXIS;
-import static nom.tam.fits.header.Standard.NAXISn;
-import static nom.tam.fits.header.Standard.PCOUNT;
-import static nom.tam.util.LoggerHelper.getLogger;
+import java.io.IOException;
+
+import nom.tam.fits.header.Bitpix;
+import nom.tam.fits.header.Standard;
+import nom.tam.util.ArrayDataInput;
+import nom.tam.util.ArrayDataOutput;
+import nom.tam.util.ArrayFuncs;
+import nom.tam.util.Cursor;
+import nom.tam.util.FitsEncoder;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -60,10 +52,17 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class UndefinedData extends Data {
 
-    private static final Logger LOG = getLogger(UndefinedData.class);
+    private static final String XTENSION_UNKNOWN = "UNKNOWN";
+    // private static final Logger LOG = getLogger(UndefinedData.class);
 
+    private Bitpix bitpix = Bitpix.BYTE;
+    private int[] dims;
     private int byteSize = 0;
     private byte[] data;
+    private int pCount = 0;
+    private int gCount = 1;
+
+    private String extensionType = XTENSION_UNKNOWN;
 
     /**
      * Creates a new empty container for data of unknown type based on the provided FITS header information.
@@ -73,55 +72,80 @@ public class UndefinedData extends Data {
      * @throws FitsException if there wan an error accessing or interpreting the provided header information.
      */
     public UndefinedData(Header h) throws FitsException {
+        extensionType = h.getStringValue(Standard.XTENSION, XTENSION_UNKNOWN);
 
         /**
          * Just get a byte buffer to hold the data.
          */
         // Bug fix by Vincenzo Forzi.
-        int naxis = h.getIntValue(NAXIS);
+        int naxis = h.getIntValue(Standard.NAXIS);
+
+        dims = new int[naxis];
 
         int size = naxis > 0 ? 1 : 0;
-        for (int i = 0; i < naxis; i++) {
-            size *= h.getIntValue(NAXISn.n(i + 1));
+        for (int i = 1; i <= naxis; i++) {
+            dims[naxis - i] = h.getIntValue(Standard.NAXISn.n(i));
+            size *= dims[naxis - i];
         }
-        size += h.getIntValue(PCOUNT);
-        if (h.getIntValue(GCOUNT) > 1) {
-            size *= h.getIntValue(GCOUNT);
+
+        pCount = h.getIntValue(Standard.PCOUNT);
+        size += pCount;
+
+        gCount = h.getIntValue(Standard.GCOUNT);
+        if (gCount > 1) {
+            size *= h.getIntValue(Standard.GCOUNT);
         }
-        size *= Bitpix.fromHeader(h).byteSize();
+
+        bitpix = Bitpix.fromHeader(h);
+        size *= bitpix.byteSize();
 
         byteSize = size;
     }
 
     /**
-     * Create an UndefinedData object using the specified object.
+     * @deprecated   (<i>for internal use</i>). Visibility will be reduced to package level. Users should always
+     *                   construct known data types. Create an UndefinedData object using the specified object.
      *
-     * @param x object to create the hdu from
+     * @param      x object to create the hdu from
      */
     public UndefinedData(Object x) {
         byteSize = (int) FitsEncoder.computeSize(x);
+
+        dims = ArrayFuncs.getDimensions(x);
+        for (int i = 0; i < dims.length; i++) {
+            if (dims[i] < 0) {
+                dims = new int[byteSize];
+                break;
+            }
+        }
+
         data = new byte[byteSize];
         ArrayFuncs.copyInto(x, data);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected void fillHeader(Header head) {
-        try {
-            Standard.context(UndefinedData.class);
-            head.setXtension("UNKNOWN");
-            head.setBitpix(Bitpix.BYTE);
-            head.setNaxes(1);
-            head.addValue(NAXISn.n(1), byteSize);
-            head.addValue(PCOUNT, 0);
-            head.addValue(GCOUNT, 1);
-            // Just in case!
-            head.addValue(EXTEND, true);
-        } catch (HeaderCardException e) {
-            LOG.log(Level.SEVERE, "Unable to create unknown header", e);
-        } finally {
-            Standard.context(null);
+        // We'll assume it's a primary image, until we know better...
+        // Just in case, we don't want an XTENSION key lingering around...
+        head.deleteKey(Standard.SIMPLE);
+        head.deleteKey(Standard.EXTEND);
+
+        Standard.context(null);
+
+        Cursor<String, HeaderCard> c = head.iterator();
+        c.add(HeaderCard.create(Standard.XTENSION, extensionType));
+        c.add(HeaderCard.create(Standard.BITPIX, bitpix.getHeaderValue()));
+
+        c.add(HeaderCard.create(Standard.NAXIS, dims == null ? 0 : dims.length));
+
+        if (dims != null) {
+            for (int i = 1; i <= dims.length; i++) {
+                c.add(HeaderCard.create(Standard.NAXISn.n(i), dims[dims.length - i]));
+            }
         }
+
+        c.add(HeaderCard.create(Standard.PCOUNT, pCount));
+        c.add(HeaderCard.create(Standard.GCOUNT, gCount));
     }
 
     @Override
@@ -133,6 +157,62 @@ public class UndefinedData extends Data {
     @Override
     protected long getTrueSize() {
         return byteSize;
+    }
+
+    /**
+     * Returns the FITS extension type as stored by the XTENSION keyword in the FITS header.
+     * 
+     * @return The value used for the XTENSION keyword in the FITS header
+     * 
+     * @since  1.19
+     */
+    public final String getXtension() {
+        return extensionType;
+    }
+
+    /**
+     * Returns the FITS element type as a Bitpux value.
+     * 
+     * @return The FITS Bitpix value for the type of primitive data element used by this data
+     * 
+     * @since  1.19
+     */
+    public final Bitpix getBitpix() {
+        return bitpix;
+    }
+
+    /**
+     * Returns the size of the optional parameter space as stored by the PCOUNT keyword in the FITS header.
+     * 
+     * @return The byte size of the optional parameter space accompanying the main data, as stored by the PCOUNT header
+     *             value..
+     * 
+     * @since  1.19
+     */
+    public final int getParameterByteCount() {
+        return pCount;
+    }
+
+    /**
+     * Returns the number of repeated (data + parameter) groups in this data object
+     * 
+     * @return The number of repeated data + parameter blocks, as stored by the GCOUNT header value.
+     * 
+     * @since  1.19
+     */
+    public final int getGroupCount() {
+        return gCount;
+    }
+
+    /**
+     * Returns the dimensionality of the data (if any), in Java array index order. That is, The value for NAXIS1 is the
+     * last value in the returned array
+     * 
+     * @return the regular dimensions of the data in Java index order (that is NAXIS1 is the last entry in the array),
+     *             or possibly <code>null</code> if no dimensions have been defined.
+     */
+    public final int[] getDimensions() {
+        return dims;
     }
 
     @Override
@@ -164,5 +244,13 @@ public class UndefinedData extends Data {
             throw new FitsException("IO Error on unknown data write", e);
         }
         FitsUtil.pad(o, getTrueSize());
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public UndefinedHDU toHDU() {
+        Header h = new Header();
+        fillHeader(h);
+        return new UndefinedHDU(h, this);
     }
 }

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -74,10 +74,6 @@ public class UndefinedData extends Data {
     public UndefinedData(Header h) throws FitsException {
         extensionType = h.getStringValue(Standard.XTENSION, XTENSION_UNKNOWN);
 
-        /**
-         * Just get a byte buffer to hold the data.
-         */
-        // Bug fix by Vincenzo Forzi.
         int naxis = h.getIntValue(Standard.NAXIS);
 
         dims = new int[naxis];
@@ -184,12 +180,12 @@ public class UndefinedData extends Data {
     /**
      * Returns the size of the optional parameter space as stored by the PCOUNT keyword in the FITS header.
      * 
-     * @return The byte size of the optional parameter space accompanying the main data, as stored by the PCOUNT header
-     *             value..
+     * @return The element count of the optional parameter space accompanying the main data, as stored by the PCOUNT
+     *             header value.
      * 
      * @since  1.19
      */
-    public final int getParameterByteCount() {
+    public final int getParameterCount() {
         return pCount;
     }
 

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -102,22 +102,17 @@ public class UndefinedData extends Data {
     }
 
     /**
-     * @deprecated   (<i>for internal use</i>). Users should always construct known data types. Reduce visibility to the
-     *                   package level.
-     *
-     * @param      x object to create the hdu from
+     * @deprecated                          (<i>for internal use</i>). Users should always construct known data types.
+     *                                          Reduce visibility to the package level.
+     * 
+     * @param      x                        object to create the hdu from
+     * 
+     * @throws     IllegalArgumentException If the object is not an array or contains elements that do not have a known
+     *                                          binary size.
      */
-    public UndefinedData(Object x) {
+    public UndefinedData(Object x) throws IllegalArgumentException {
         byteSize = (int) FitsEncoder.computeSize(x);
-
         dims = ArrayFuncs.getDimensions(x);
-        for (int i = 0; i < dims.length; i++) {
-            if (dims[i] < 0) {
-                dims = new int[byteSize];
-                break;
-            }
-        }
-
         data = new byte[byteSize];
         ArrayFuncs.copyInto(x, data);
     }
@@ -135,12 +130,10 @@ public class UndefinedData extends Data {
         c.add(HeaderCard.create(Standard.XTENSION, extensionType));
         c.add(HeaderCard.create(Standard.BITPIX, bitpix.getHeaderValue()));
 
-        c.add(HeaderCard.create(Standard.NAXIS, dims == null ? 0 : dims.length));
+        c.add(HeaderCard.create(Standard.NAXIS, dims.length));
 
-        if (dims != null) {
-            for (int i = 1; i <= dims.length; i++) {
-                c.add(HeaderCard.create(Standard.NAXISn.n(i), dims[dims.length - i]));
-            }
+        for (int i = 1; i <= dims.length; i++) {
+            c.add(HeaderCard.create(Standard.NAXISn.n(i), dims[dims.length - i]));
         }
 
         c.add(HeaderCard.create(Standard.PCOUNT, pCount));

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -67,9 +67,12 @@ public class UndefinedData extends Data {
     /**
      * Creates a new empty container for data of unknown type based on the provided FITS header information.
      *
-     * @param  h             The FITS header corresponding to the data segment in the HDU
+     * @param      h             The FITS header corresponding to the data segment in the HDU
      * 
-     * @throws FitsException if there wan an error accessing or interpreting the provided header information.
+     * @throws     FitsException if there wan an error accessing or interpreting the provided header information.
+     * 
+     * @deprecated               (<i>for internal use</i>). Visibility will be reduced to the package level in the
+     *                               future.
      */
     public UndefinedData(Header h) throws FitsException {
         extensionType = h.getStringValue(Standard.XTENSION, XTENSION_UNKNOWN);
@@ -99,8 +102,8 @@ public class UndefinedData extends Data {
     }
 
     /**
-     * @deprecated   (<i>for internal use</i>). Visibility will be reduced to package level. Users should always
-     *                   construct known data types. Create an UndefinedData object using the specified object.
+     * @deprecated   (<i>for internal use</i>). Users should always construct known data types. Reduce visibility to the
+     *                   package level.
      *
      * @param      x object to create the hdu from
      */
@@ -146,7 +149,7 @@ public class UndefinedData extends Data {
 
     @Override
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "intended exposure of mutable data")
-    protected Object getCurrentData() {
+    protected byte[] getCurrentData() {
         return data;
     }
 

--- a/src/main/java/nom/tam/fits/UndefinedHDU.java
+++ b/src/main/java/nom/tam/fits/UndefinedHDU.java
@@ -142,15 +142,12 @@ public class UndefinedHDU extends BasicHDU<UndefinedData> {
     /**
      * Build an image HDU using the supplied data.
      * 
-     * @deprecated               (<i>for internal use</i>) Its visibility should be reduced to package level in the
-     *                               future.
+     * @deprecated   (<i>for internal use</i>) Its visibility should be reduced to package level in the future.
      *
-     * @param      h             the header for this HDU
-     * @param      d             the data used to build the image.
-     *
-     * @throws     FitsException if there was a problem with the data.
+     * @param      h the header for this HDU
+     * @param      d the data used to build the image.
      */
-    public UndefinedHDU(Header h, UndefinedData d) throws FitsException {
+    public UndefinedHDU(Header h, UndefinedData d) {
         super(h, d);
     }
 

--- a/src/main/java/nom/tam/fits/header/NonStandard.java
+++ b/src/main/java/nom/tam/fits/header/NonStandard.java
@@ -79,6 +79,16 @@ public enum NonStandard implements IFitsHeader {
     @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
+    /**
+     * An alternative older value of the XTENSION keword in case of an image.
+     */
+    public static final String XTENSION_IUEIMAGE = "IUEIMAGE";
+
+    /**
+     * an alternative olde value of the XTENSION keword in case of an earlier version of binary table.
+     */
+    public static final String XTENSION_A3DTABLE = "A3DTABLE";
+
     NonStandard(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
     }

--- a/src/main/java/nom/tam/util/HashedList.java
+++ b/src/main/java/nom/tam/util/HashedList.java
@@ -181,8 +181,8 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
 
     /**
      * Add an element to the list at a specified position. If that element was already in the list, it is first removed
-     * from the list then added again - if it was removed from a position before the position where it was to be added,
-     * that position is decremented by one.
+     * from the list then added again (and if it was removed from a position before the position where it was to be
+     * added, that position is decremented by one).
      *
      * @param pos       The position at which the specified element is to be added. If pos is bigger than the size of
      *                      the list the element is put at the end of the list.

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -92,7 +92,7 @@ The current FITS standard (4.0) recognizes the following principal HDU / data ty
  4. **Random Groups** (_discouraged_) can contain a set of images of the same type and dimensions along with a set of 
  parameters of the same type (for example an `int[][]` image, along with a set of `int` parameters). They were never 
  widely used and the FITS 4.0 standard discourages them going forward, given that binary tables provide far superior 
- capabilities for storing the same type of data. Support for these type of HDUs is thus very basic, and aimed mainly 
+ capabilities for storing the same type of data. Support for these type of HDUs is basic, and aimed mainly 
  at providing a way to access data that was already written in this format.
 
  5. **Foreign File** can encapsulate various other files within the FITS. Foreign file HDUs are a recognised 
@@ -499,12 +499,12 @@ image and/or table HDUs we create. When everything is assembled, we write the FI
   fits.write("myfits.fits");
 ```
 
-Images can be added to the FITS at any point. For example, consider a 2D `float[][]` image we want to  add to a FITS:
+Images can be added to the FITS at any point. For example, consider a 2D `float[][]` image we want to add to a FITS:
 
 ```java
   float[][] image ...
   
-  ImageHDU imageHDU = fits.makeHDU(image);
+  ImageHDU imageHDU = Fits.makeHDU(image);
   fits.addHDU(imageHDU);
 ```
 

--- a/src/test/java/nom/tam/fits/BadData.java
+++ b/src/test/java/nom/tam/fits/BadData.java
@@ -70,7 +70,12 @@ public class BadData extends Data {
     @Override
     protected void loadData(ArrayDataInput in) {
         // TODO Auto-generated method stub
+    }
 
+    @Override
+    public BasicHDU<?> toHDU() {
+        // TODO Auto-generated method stub
+        return null;
     }
 
 }

--- a/src/test/java/nom/tam/fits/BasicHDUTest.java
+++ b/src/test/java/nom/tam/fits/BasicHDUTest.java
@@ -125,7 +125,7 @@ public class BasicHDUTest {
         ImageData im = new ImageData() {
             @Override
             public void fillHeader(Header h) throws FitsException {
-                throw new IllegalStateException("Test exception");
+                throw new FitsException("Test exception");
             }
         };
         im.toHDU(); // throws exception

--- a/src/test/java/nom/tam/fits/BasicHDUTest.java
+++ b/src/test/java/nom/tam/fits/BasicHDUTest.java
@@ -112,4 +112,29 @@ public class BasicHDUTest {
 
         fits.close();
     }
+
+    @Test
+    public void imageToHDUTest() throws Exception {
+        ImageData im = new ImageData();
+        ImageHDU hdu = im.toHDU();
+        Assert.assertEquals(im, hdu.getData());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void imageToHDUExceptionTest() throws Exception {
+        ImageData im = new ImageData() {
+            @Override
+            public void fillHeader(Header h) throws FitsException {
+                throw new IllegalStateException("Test exception");
+            }
+        };
+        im.toHDU(); // throws exception
+    }
+
+    @Test
+    public void undefinedToHDUTest() throws Exception {
+        UndefinedData ud = new UndefinedData(new int[100]);
+        UndefinedHDU hdu = ud.toHDU();
+        Assert.assertEquals(ud, hdu.getData());
+    }
 }

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -1671,4 +1671,22 @@ public class BinaryTableNewTest {
         fits.write((DataOutput) fits.getStream());
     }
 
+    @Test
+    public void toHDUTest() throws Exception {
+        BinaryTable tab = new BinaryTable();
+        BinaryTableHDU hdu = tab.toHDU();
+        Assert.assertEquals(tab, hdu.getData());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void toHDUExceptionTest() throws Exception {
+        BinaryTable tab = new BinaryTable() {
+            @Override
+            public void fillHeader(Header h) throws FitsException {
+                throw new IllegalStateException("Test exception");
+            }
+        };
+        tab.toHDU(); // throws exception
+    }
+
 }

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -1710,4 +1710,5 @@ public class BinaryTableNewTest {
         h.addValue(Standard.XTENSION, NonStandard.XTENSION_IUEIMAGE);
         new BinaryTable(h);
     }
+
 }

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -1683,7 +1683,7 @@ public class BinaryTableNewTest {
         BinaryTable tab = new BinaryTable() {
             @Override
             public void fillHeader(Header h) throws FitsException {
-                throw new IllegalStateException("Test exception");
+                throw new FitsException("Test exception");
             }
         };
         tab.toHDU(); // throws exception

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -41,6 +41,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import nom.tam.fits.BinaryTable.ColumnDesc;
+import nom.tam.fits.header.NonStandard;
 import nom.tam.fits.header.Standard;
 import nom.tam.util.ComplexValue;
 import nom.tam.util.FitsInputStream;
@@ -1689,4 +1690,24 @@ public class BinaryTableNewTest {
         tab.toHDU(); // throws exception
     }
 
+    @Test(expected = FitsException.class)
+    public void testConstructAsciiTableHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, Standard.XTENSION_ASCIITABLE);
+        new BinaryTable(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testConstructImageHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, Standard.XTENSION_IMAGE);
+        new BinaryTable(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testConstructIUEImageHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, NonStandard.XTENSION_IUEIMAGE);
+        new BinaryTable(h);
+    }
 }

--- a/src/test/java/nom/tam/fits/BitpixTest.java
+++ b/src/test/java/nom/tam/fits/BitpixTest.java
@@ -155,4 +155,18 @@ public class BitpixTest {
         Bitpix.forNumberType(BigDecimal.class);
     }
 
+    @Test
+    public void testForArrayID() throws Exception {
+        assertEquals(Bitpix.BYTE, Bitpix.forArrayID('B'));
+        assertEquals(Bitpix.SHORT, Bitpix.forArrayID('S'));
+        assertEquals(Bitpix.INTEGER, Bitpix.forArrayID('I'));
+        assertEquals(Bitpix.LONG, Bitpix.forArrayID('J'));
+        assertEquals(Bitpix.FLOAT, Bitpix.forArrayID('F'));
+        assertEquals(Bitpix.DOUBLE, Bitpix.forArrayID('D'));
+    }
+
+    @Test(expected = FitsException.class)
+    public void testForInvalidArrayID() throws Exception {
+        Bitpix.forArrayID('?');
+    }
 }

--- a/src/test/java/nom/tam/fits/DeferredTest.java
+++ b/src/test/java/nom/tam/fits/DeferredTest.java
@@ -113,7 +113,12 @@ public class DeferredTest {
         @Override
         protected void loadData(ArrayDataInput in) {
             // TODO Auto-generated method stub
+        }
 
+        @Override
+        public BasicHDU<?> toHDU() {
+            // TODO Auto-generated method stub
+            return null;
         }
     }
 }

--- a/src/test/java/nom/tam/fits/ImageProtectedTest.java
+++ b/src/test/java/nom/tam/fits/ImageProtectedTest.java
@@ -48,22 +48,19 @@ import static nom.tam.fits.header.Standard.GCOUNT;
 
 public class ImageProtectedTest {
 
-    @Test(expected = FitsException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testImageDataFail() throws Exception {
         ImageData data = new ImageData("test");
-        data.fillHeader(new Header());
     }
 
-    @Test(expected = FitsException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testImageDataFailWrongDatatype() throws Exception {
         ImageData data = new ImageData(new String[] {"test"});
-        data.fillHeader(new Header());
     }
 
-    @Test(expected = FitsException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testImageDataFailUnfilledDimention() throws Exception {
         ImageData data = new ImageData(new int[][] {null});
-        data.fillHeader(new Header());
     }
 
     @Test(expected = FitsException.class)

--- a/src/test/java/nom/tam/fits/UndefinedDataTest.java
+++ b/src/test/java/nom/tam/fits/UndefinedDataTest.java
@@ -31,6 +31,8 @@ package nom.tam.fits;
  * #L%
  */
 
+import java.io.File;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -65,4 +67,8 @@ public class UndefinedDataTest {
         Assert.assertEquals(11, d.getGroupCount());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testUknownSizeData() throws Exception {
+        new UndefinedData(new File("blah"));
+    }
 }

--- a/src/test/java/nom/tam/fits/UndefinedDataTest.java
+++ b/src/test/java/nom/tam/fits/UndefinedDataTest.java
@@ -1,0 +1,68 @@
+package nom.tam.fits;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2023 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import nom.tam.fits.header.Bitpix;
+import nom.tam.fits.header.Standard;
+
+public class UndefinedDataTest {
+
+    @Test
+    public void testInspect() throws Exception {
+        Header h = new Header();
+
+        h.addLine(HeaderCard.create(Standard.XTENSION, "TEST"));
+        h.addLine(HeaderCard.create(Standard.BITPIX, Bitpix.SHORT.getHeaderValue()));
+        h.addLine(HeaderCard.create(Standard.NAXIS, 2));
+        h.addLine(HeaderCard.create(Standard.NAXIS1, 3));
+        h.addLine(HeaderCard.create(Standard.NAXIS2, 5));
+        h.addLine(HeaderCard.create(Standard.PCOUNT, 7));
+        h.addLine(HeaderCard.create(Standard.GCOUNT, 11));
+
+        UndefinedData d = new UndefinedData(h);
+
+        Assert.assertEquals("TEST", d.getXtension());
+        Assert.assertEquals(Bitpix.SHORT, d.getBitpix());
+
+        int[] dim = d.getDimensions();
+        Assert.assertEquals(2, dim.length);
+        Assert.assertEquals(3, dim[1]);
+        Assert.assertEquals(5, dim[0]);
+
+        Assert.assertEquals(7, d.getParameterCount());
+        Assert.assertEquals(11, d.getGroupCount());
+    }
+
+}

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -1200,4 +1200,11 @@ public class AsciiTableTest {
         assertEquals(long.class, t1.getColumnType(col));
     }
 
+    @Test
+    public void toHDUTest() throws Exception {
+        AsciiTable tab = new AsciiTable();
+        AsciiTableHDU hdu = tab.toHDU();
+        Assert.assertEquals(tab, hdu.getData());
+    }
+
 }

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -59,20 +59,17 @@ import nom.tam.fits.Fits;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.FitsFactory;
 import nom.tam.fits.Header;
-import nom.tam.fits.HeaderCard;
 import nom.tam.fits.PaddingException;
 import nom.tam.fits.TableHDU;
 import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
-import nom.tam.util.Cursor;
 import nom.tam.util.FitsFile;
 import nom.tam.util.FitsInputStream;
 import nom.tam.util.FitsOutputStream;
 import nom.tam.util.SafeClose;
 import nom.tam.util.TestArrayFuncs;
-import nom.tam.util.test.ThrowAnyException;
 
 import static nom.tam.fits.header.DataDescription.TDMAXn;
 import static nom.tam.fits.header.DataDescription.TDMINn;
@@ -600,21 +597,6 @@ public class AsciiTableTest {
             public void close() throws SecurityException {
             }
         });
-
-        new AsciiTable() {
-            @Override
-            public void fillHeader(Header hdr) {
-                super.fillHeader(hdr);
-            }
-        }.fillHeader(new Header() {
-            @Override
-            public Cursor<String, HeaderCard> iterator() {
-                ThrowAnyException.throwHeaderCardException("all is broken");
-                return null;
-            }
-        });
-        Assert.assertEquals(1, logs.size());
-        Assert.assertEquals("all is broken", logs.get(0).getThrown().getMessage());
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -61,6 +61,7 @@ import nom.tam.fits.FitsFactory;
 import nom.tam.fits.Header;
 import nom.tam.fits.PaddingException;
 import nom.tam.fits.TableHDU;
+import nom.tam.fits.header.NonStandard;
 import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
@@ -715,7 +716,8 @@ public class AsciiTableTest {
     @Test
     public void testToInvalidTable() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
                 .card(Standard.NAXIS2).value(Integer.MAX_VALUE)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(4)//
@@ -744,7 +746,8 @@ public class AsciiTableTest {
     @Test
     public void testToBigTable() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
                 .card(Standard.NAXIS2).value(Integer.MAX_VALUE)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(4)//
@@ -763,7 +766,8 @@ public class AsciiTableTest {
     @Test
     public void testToBigTable2() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
                 .card(Standard.NAXIS2).value(Integer.MAX_VALUE)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(4)//
@@ -794,7 +798,8 @@ public class AsciiTableTest {
     @Test
     public void testToFailedWrite() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
                 .card(Standard.NAXIS2).value(Integer.MAX_VALUE)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(4)//
@@ -846,7 +851,8 @@ public class AsciiTableTest {
     @Test
     public void testFailingGetElementTable() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
                 .card(Standard.NAXIS2).value(Integer.MAX_VALUE)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(4)//
@@ -864,7 +870,8 @@ public class AsciiTableTest {
     @Test
     public void testFailingGetRowTable() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(Integer.MAX_VALUE)//
                 .card(Standard.NAXIS2).value(Integer.MAX_VALUE)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(4)//
@@ -882,7 +889,8 @@ public class AsciiTableTest {
     @Test
     public void testIncompatibleElement() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(1)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(1)//
                 .card(Standard.NAXIS2).value(1)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(2)//
@@ -904,7 +912,8 @@ public class AsciiTableTest {
     @Test
     public void testIllegalSetRow() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(1)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(1)//
                 .card(Standard.NAXIS2).value(1)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(2)//
@@ -930,7 +939,8 @@ public class AsciiTableTest {
     @Test
     public void testIllegalSetRow2() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(1)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(1)//
                 .card(Standard.NAXIS2).value(1)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(2)//
@@ -949,7 +959,8 @@ public class AsciiTableTest {
     @Test(expected = PaddingException.class)
     public void testFailedRead() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(1)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(1)//
                 .card(Standard.NAXIS2).value(1)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(2)//
@@ -974,7 +985,8 @@ public class AsciiTableTest {
     @Test(expected = FitsException.class)
     public void testFailedRead2() throws Exception {
         Header hdr = new Header();
-        hdr.card(Standard.NAXIS1).value(1)//
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(1)//
                 .card(Standard.NAXIS2).value(1)//
                 .card(Standard.TFIELDS).value(1)//
                 .card(Standard.TBCOLn.n(1)).value(2)//
@@ -1207,4 +1219,44 @@ public class AsciiTableTest {
         Assert.assertEquals(tab, hdu.getData());
     }
 
+    @Test
+    public void testSetPreferredI10() {
+        boolean defValue = AsciiTable.isI10PreferInt();
+
+        AsciiTable.setI10PreferInt(true);
+        Assert.assertTrue(AsciiTable.isI10PreferInt());
+
+        AsciiTable.setI10PreferInt(false);
+        Assert.assertFalse(AsciiTable.isI10PreferInt());
+
+        AsciiTable.setI10PreferInt(defValue);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testConstructBinTableHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
+        new AsciiTable(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testConstructA3DTableHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, NonStandard.XTENSION_A3DTABLE);
+        new AsciiTable(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testConstructImageHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, Standard.XTENSION_IMAGE);
+        new AsciiTable(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testConstructIUEImageHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, NonStandard.XTENSION_IUEIMAGE);
+        new AsciiTable(h);
+    }
 }

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -196,6 +196,11 @@ public class BaseFitsTest {
 
     }
 
+    @Test(expected = FitsException.class)
+    public void testFitsDeleteHduOutOfBounds() throws Exception {
+        new Fits().deleteHDU(0);
+    }
+
     @Test
     public void testFitsDeleteHduNewPrimary() throws Exception {
         Fits fits1 = makeAsciiTable();

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -329,15 +329,11 @@ public class BaseFitsTest {
 
         Cursor<String, HeaderCard> iter = header.iterator();
 
-        String[] headers = new String[header.getNumberOfCards() - 1];
+        String[] headers = new String[header.getNumberOfCards()];
         int index = 0;
         while (iter.hasNext()) {
             HeaderCard headerCard = iter.next();
-            // the EXTEND key will be deleted later on because the header is no
-            // primary header so don't use it
-            if (!headerCard.getKey().equals("EXTEND")) {
-                headers[index++] = headerCard.toString();
-            }
+            headers[index++] = headerCard.toString();
         }
         Header newHeader = new Header(headers);
         for (index = 0; index < headers.length; index++) {
@@ -576,7 +572,7 @@ public class BaseFitsTest {
 
     @Test
     public void testFitsRandomGroupDataWrite() throws Exception {
-        RandomGroupsData data = new RandomGroupsData(new Object[][] {new Object[] {new int[10], new int[10],}});
+        RandomGroupsData data = new RandomGroupsData(new Object[][] {new Object[] {new int[10], new int[10]}});
         FitsOutputStream out = new FitsOutputStream(new ByteArrayOutputStream()) {
 
             @Override
@@ -599,7 +595,7 @@ public class BaseFitsTest {
     public void testFitsRandomGroupDataRead() throws Exception {
         ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
         FitsOutputStream out = new FitsOutputStream(outBytes);
-        Object[][] dataArray = new Object[][] {new Object[] {new int[10], new int[10],}};
+        Object[][] dataArray = new Object[][] {new Object[] {new int[10], new int[10]}};
         out.writeArray(dataArray);
         out.close();
 

--- a/src/test/java/nom/tam/fits/test/ImageTest.java
+++ b/src/test/java/nom/tam/fits/test/ImageTest.java
@@ -345,4 +345,25 @@ public class ImageTest {
         Assert.assertEquals(5, h.getIntValue(Standard.NAXIS1));
     }
 
+    @Test(expected = FitsException.class)
+    public void testConstructAsciiTableHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, Standard.XTENSION_ASCIITABLE);
+        new ImageData(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testConstructBinTableHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
+        new ImageData(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testConstructA3DTableHeader() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.XTENSION, NonStandard.XTENSION_A3DTABLE);
+        new ImageData(h);
+    }
+
 }

--- a/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
+++ b/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -44,6 +45,7 @@ import nom.tam.fits.Fits;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.FitsUtil;
 import nom.tam.fits.Header;
+import nom.tam.fits.NullDataHDU;
 import nom.tam.fits.RandomGroupsData;
 import nom.tam.fits.RandomGroupsHDU;
 import nom.tam.fits.header.Bitpix;
@@ -105,7 +107,6 @@ public class RandomGroupsTest {
             BasicHDU<?>[] hdus = f.read();
 
             data = (Object[][]) hdus[0].getKernel();
-            System.err.println("### [1] " + data.length);
 
             for (int i = 0; i < data.length; i++) {
 
@@ -128,7 +129,6 @@ public class RandomGroupsTest {
             f = new Fits();
             bf = new FitsFile("target/rg2.fits", "rw");
             // Generate a FITS HDU from the kernel.
-            System.err.println("### [2] " + data.length);
             f.addHDU(RandomGroupsHDU.createFrom(data));
             f.write(bf);
 
@@ -355,5 +355,84 @@ public class RandomGroupsTest {
         Header h = hdu.getHeader();
         h.addValue(Standard.BUNIT, "m/s");
         Assert.assertEquals("m/s", hdu.getBUnit());
+    }
+
+    @Test
+    public void testRandomGroupsParameterAccess() throws Exception {
+        short[][] img = new short[7][11];
+        short[] parms = new short[] {1, 2, 3, 4, 5, 6};
+        String filename = "target/random-parameters.fits";
+
+        RandomGroupsData data = new RandomGroupsData(new Object[][] {{parms, img}});
+        RandomGroupsHDU hdu = data.toHDU();
+
+        hdu.addValue(Standard.PTYPEn.n(1), "Param A"); // --> 1 * 1 + 0 = 1
+        // Default scaling + offset
+
+        hdu.addValue(Standard.PTYPEn.n(2), "Param A");
+        hdu.addValue(Standard.PSCALn.n(2), 0.5); // --> 0.5 * 2 = 1
+
+        hdu.addValue(Standard.PTYPEn.n(3), "Param A");
+        hdu.addValue(Standard.PZEROn.n(3), -2); // --> 1 * 3 - 2 = 1
+
+        hdu.addValue(Standard.PTYPEn.n(4), "Param A");
+        hdu.addValue(Standard.PSCALn.n(4), 0.5);
+        hdu.addValue(Standard.PZEROn.n(4), -1); // --> 0.5 * 4 - 1 = 1
+
+        hdu.addValue(Standard.PTYPEn.n(5), "Param B"); // --> 1 * 5 + 0 = 5
+
+        hdu.addValue(Standard.PTYPEn.n(6), "Param B1"); // --> 1 * 16 + 0 = 6
+
+        try (Fits f = new Fits()) {
+            f.addHDU(hdu);
+            f.write(filename);
+            f.close();
+        }
+
+        try (Fits f = new Fits(filename)) {
+            hdu = (RandomGroupsHDU) f.readHDU();
+
+            Set<String> names = hdu.getParameterNames();
+            Assert.assertTrue("contains A", names.contains("Param A"));
+            Assert.assertTrue("contains B", names.contains("Param B"));
+            Assert.assertTrue("contains B1", names.contains("Param B1"));
+            Assert.assertEquals(3, names.size());
+
+            Assert.assertEquals(4.0, hdu.getParameter("Param A", 0), 1e-12);
+            Assert.assertEquals(5.0, hdu.getParameter("Param B", 0), 1e-12);
+            Assert.assertEquals(6.0, hdu.getParameter("Param B1", 0), 1e-12);
+            Assert.assertTrue("no such parameter", Double.isNaN(hdu.getParameter("blah", 0)));
+
+            short[][] im = (short[][]) hdu.getData().getImage(0);
+            Assert.assertArrayEquals(img, im);
+            f.close();
+        }
+    }
+
+    @Test(expected = FitsException.class)
+    public void testRandomGroupsInExtensionException() throws Exception {
+        short[][] img = new short[7][11];
+        short[] parms = new short[] {1, 2, 3, 4, 5, 6};
+
+        RandomGroupsData data = new RandomGroupsData(new Object[][] {{parms, img}});
+        RandomGroupsHDU hdu = data.toHDU();
+
+        try (FitsFile out = new FitsFile("target/random-extension.fits", "rw")) {
+            new NullDataHDU().write(out);
+            hdu.write(out);
+        }
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddRandomGroupsAsExtensionException() throws Exception {
+        short[][] img = new short[7][11];
+        short[] parms = new short[] {1, 2, 3, 4, 5, 6};
+
+        RandomGroupsData data = new RandomGroupsData(new Object[][] {{parms, img}});
+        RandomGroupsHDU hdu = data.toHDU();
+
+        Fits fits = new Fits();
+        fits.addHDU(new NullDataHDU());
+        fits.addHDU(hdu); // throws exception
     }
 }

--- a/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
+++ b/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
@@ -435,4 +435,28 @@ public class RandomGroupsTest {
         fits.addHDU(new NullDataHDU());
         fits.addHDU(hdu); // throws exception
     }
+
+    @Test
+    public void toHDUTest() throws Exception {
+        RandomGroupsData rg = new RandomGroupsData(new Object[][] {{new int[2], new int[10][10]}});
+        RandomGroupsHDU hdu = rg.toHDU();
+        Assert.assertEquals(rg, hdu.getData());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void toHDUEmptyTest() throws Exception {
+        RandomGroupsData rg = new RandomGroupsData();
+        rg.toHDU(); // Throws exception because of empry group
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void toHDUExceptionTest() throws Exception {
+        RandomGroupsData rg = new RandomGroupsData() {
+            @Override
+            public void fillHeader(Header h) throws FitsException {
+                throw new IllegalStateException("Test exception");
+            }
+        };
+        rg.toHDU(); // throws exception
+    }
 }

--- a/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
+++ b/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
@@ -454,7 +454,7 @@ public class RandomGroupsTest {
         RandomGroupsData rg = new RandomGroupsData() {
             @Override
             public void fillHeader(Header h) throws FitsException {
-                throw new IllegalStateException("Test exception");
+                throw new FitsException("Test exception");
             }
         };
         rg.toHDU(); // throws exception

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
@@ -93,6 +93,7 @@ public class TileCompressorProviderTest {
         private static Header emptyHeader() {
             Header header = new Header();
             try {
+                header.card(Standard.XTENSION).value(Standard.XTENSION_BINTABLE);
                 header.card(Standard.NAXIS1).value(1);
             } catch (HeaderCardException e) {
                 throw new RuntimeException();


### PR DESCRIPTION
- Introduced `ImageData.from(Object)`, essentially offering the same behavior as the constructor with the same argument. Both now check that the argument is a valid regular primitive numerical Java array, or else throw an `IllegalArgumentException`.
- Added `Data.toHDU()` implementations, to wrap data classes into HDUs with the mandatory minimal header descriptions.
- Inspection methods for `UnknownData`.
- Header order changed s.t. EXTEND comes after GCOUNT, resulting in better conformance to the FITS standard. (EXTEND is an optional keyword. As such it must come after the mandatory keywords.)
- `Data.fillHeader()` implementations to remove SIMPLE + EXTEND or XTENSION keywords depending on which types of HDUs the data may support (`ImageData` will assume primary HDU until it becomes clear it must be written as an extension).
- The FITS standard allows random groups in the primary HDU only. As such we'll throw an exception if trying to write random groups data as extensions.
- New methods to access named parameters and individual images in random groups data