### PR TITLE
Work around Windows issue with read-only files on network shares.

### DIFF
--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -908,18 +908,21 @@ public class Fits implements Closeable {
     @Deprecated
     protected void randomInit(File file) throws FitsException {
 
-        String permissions = "r";
         if (!file.exists() || !file.canRead()) {
             throw new FitsException("Non-existent or unreadable file");
         }
-        if (file.canWrite()) {
-            permissions += "w";
-        }
         try {
-            dataStr = new FitsFile(file, permissions);
+            // Attempt to open the file for reading and writing.
+            dataStr = new FitsFile(file, "rw");
             ((FitsFile) dataStr).seek(0);
         } catch (IOException e) {
-            throw new FitsException("Unable to open file " + file.getPath(), e);
+            try {
+                // If that fails, try read-only.
+                dataStr = new FitsFile(file, "r");
+                ((FitsFile) dataStr).seek(0);
+            } catch (IOException e2) {
+                throw new FitsException("Unable to open file " + file.getPath(), e2);
+            }
         }
     }
 

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -1380,6 +1380,11 @@ public class BaseFitsTest {
     public void testReadOnlyFile() throws Exception {
         String fileName = "target/ReadOnly.fits";
 
+        File file = new File(fileName);
+        if (file.exists()) {
+            file.delete();
+        }
+
         // Create a trivial FITS file.
         FitsFile fitsFile = null;
         try {
@@ -1389,7 +1394,6 @@ public class BaseFitsTest {
         }
 
         // Make the test file read-only.
-        File file = new File(fileName);
         Assert.assertTrue(file.exists());
         Assert.assertTrue(file.setReadOnly());
         // Create a Fits object from the read-only file.

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -1376,6 +1376,26 @@ public class BaseFitsTest {
         hdu.getBlankValue(); // throws FitsException
     }
 
+    @Test
+    public void testReadOnlyFile() throws Exception {
+        String fileName = "target/ReadOnly.fits";
+
+        // Create a trivial FITS file.
+        FitsFile fitsFile = null;
+        try {
+            fitsFile = new FitsFile(fileName, "rw");
+        } finally {
+            SafeClose.close(fitsFile);
+        }
+
+        // Make the test file read-only.
+        File file = new File(fileName);
+        Assert.assertTrue(file.exists());
+        Assert.assertTrue(file.setReadOnly());
+        // Create a Fits object from the read-only file.
+        Fits fits = new Fits(fileName);
+    }
+
     private static class TestRandomAccessFileIO extends java.io.RandomAccessFile implements RandomAccessFileIO {
         final String name;
 


### PR DESCRIPTION
This MR resolves #495.

On Windows, ``File::canWrite()`` can incorrectly return ``true`` for read-only files on network shares. This can cause ``Fits::randomInit()`` to attempt to open the read-only file in ``rw`` mode, which throws an exception because the file is not actually writable.

This MR modifies ``Fits::randomInit()`` to first attempt to open the named file in ``rw`` mode. If that fails, it then attempts to open it in read-only mode, as before.