### PR TITLE
Fix constructor throw vulnerabilities by declaring finalize() final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,6 @@
         <version>3.6.3</version>
         <configuration>
           <source>8</source>
-          <aggregate>false</aggregate>
           <failOnError>true</failOnError>
           <doclint>all,-missing</doclint>
         </configuration>
@@ -432,7 +431,7 @@
                        we know we exposse some internal data of our classes -->
           <!-- Skip warnings for CT_CONSTRUCTOR_THROW, a vulnerability
 ￼               when throwing exceptions in constructors -->
-          <omitVisitors>FindReturnRef,ConstructorThrow</omitVisitors>
+          <omitVisitors>FindReturnRef</omitVisitors>
         </configuration>
       </plugin>
       <plugin>
@@ -529,7 +528,6 @@
         <configuration>
           <source>8</source>
           <failOnError>false</failOnError>
-          <aggregate>false</aggregate>
           <doctitle>
             ${project.name} ${project.version} Public User API
           </doctitle>
@@ -624,7 +622,7 @@
                we know we exposse some internal data of our classes -->
           <!-- Skip warnings for CT_CONSTRUCTOR_THROW, a vulnerability
                when throwing exceptions in constructors -->
-          <omitVisitors>FindReturnRef,ConstructorThrow</omitVisitors>
+          <omitVisitors>FindReturnRef</omitVisitors>
         </configuration>
       </plugin>
       <plugin>
@@ -760,7 +758,6 @@
             <configuration>
               <source>8</source>
               <failOnError>false</failOnError>
-              <aggregate>false</aggregate>
               <doctitle>
                 ${project.name} ${project.version} Public User API
               </doctitle>

--- a/pom.xml
+++ b/pom.xml
@@ -429,8 +429,6 @@
         <configuration>
           <!-- Skip bug warnings for EI_EXPOSE_REP and EI_EXPOSE_REP2
                        we know we exposse some internal data of our classes -->
-          <!-- Skip warnings for CT_CONSTRUCTOR_THROW, a vulnerability
-￼               when throwing exceptions in constructors -->
           <omitVisitors>FindReturnRef</omitVisitors>
         </configuration>
       </plugin>
@@ -620,8 +618,6 @@
         <configuration>
           <!-- Skip bug warnings for EI_EXPOSE_REP and EI_EXPOSE_REP2
                we know we exposse some internal data of our classes -->
-          <!-- Skip warnings for CT_CONSTRUCTOR_THROW, a vulnerability
-               when throwing exceptions in constructors -->
           <omitVisitors>FindReturnRef</omitVisitors>
         </configuration>
       </plugin>

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -232,6 +232,12 @@ public class AsciiTable extends AbstractTableData {
         }
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Checks if the integer value of a specific key requires <code>long</code> value type to store.
      *

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -213,6 +213,12 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
             setBoxedShape(dim);
         }
 
+        @Override
+        protected final void finalize() {
+            // final to protect against vulnerability when throwing an exception in the constructor
+            // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+        }
+
         /**
          * Recalculate the FITS element count based on the shape of the data
          */
@@ -1449,6 +1455,12 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
         for (Object element : columns) {
             addColumn(element);
         }
+    }
+
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
     }
 
     /**

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -519,6 +519,12 @@ public class Fits implements Closeable {
         LOG.log(Level.INFO, "compression ignored, will be autodetected. was set to " + compressed);
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Creates a new empty HDU for the given data type.
      * 

--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -199,6 +199,12 @@ public class FitsDate implements Comparable<FitsDate> {
         }
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     private static int getInt(Matcher match, int groupIndex) {
         String value = match.group(groupIndex);
         if (value != null) {

--- a/src/main/java/nom/tam/fits/FitsHeap.java
+++ b/src/main/java/nom/tam/fits/FitsHeap.java
@@ -77,7 +77,7 @@ public class FitsHeap implements FitsElement {
      *
      * @throws IllegalArgumentException if the size argument is negative.
      */
-    FitsHeap(int size) {
+    FitsHeap(int size) throws IllegalArgumentException {
         if (size < 0) {
             throw new IllegalArgumentException("Illegal size for FITS heap: " + size);
         }
@@ -87,6 +87,12 @@ public class FitsHeap implements FitsElement {
         setData(data);
         encoder = new FitsEncoder(store);
         decoder = new FitsDecoder(store);
+    }
+
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
     }
 
     /**

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -273,6 +273,12 @@ public class Header implements FitsElement {
         }
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * <p>
      * Preallocates a minimum header card space. When written to a stream, the header will be large enough to hold at

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -490,6 +490,12 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         this.type = type;
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Sets all components of the card to the specified values. For internal use only.
      *

--- a/src/main/java/nom/tam/fits/HeaderCardParser.java
+++ b/src/main/java/nom/tam/fits/HeaderCardParser.java
@@ -136,6 +136,12 @@ class HeaderCardParser {
         parseComment();
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Returns the keyword component of the parsed header line. If the processing of HIERARCH keywords is enabled, it
      * may be a `HIERARCH` style long key with the components separated by dots (e.g.

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -153,6 +153,12 @@ public class ImageData extends Data {
     }
 
     @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
+    @Override
     protected void loadData(ArrayDataInput in) throws IOException, FitsException {
         if (tiler != null) {
             dataArray = tiler.getCompleteImage();

--- a/src/main/java/nom/tam/fits/PaddingException.java
+++ b/src/main/java/nom/tam/fits/PaddingException.java
@@ -48,7 +48,8 @@ public class PaddingException extends FitsException {
      */
     private static final long serialVersionUID = 8716484905278318366L;
 
-    PaddingException(String msg, Exception cause) throws FitsException {
+    PaddingException(String msg, Exception cause) {
         super(msg, cause);
     }
+
 }

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -121,6 +121,12 @@ public class RandomGroupsData extends Data {
         }
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Returns the Java class of the the parameter and data array elements.
      *

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -299,6 +299,12 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
     }
 
     @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
+    @Override
     public void info(PrintStream stream) {
 
         stream.println("Random Groups HDU");

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -118,6 +118,12 @@ public class UndefinedData extends Data {
     }
 
     @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
+    @Override
     protected void fillHeader(Header head) {
         // We'll assume it's a primary image, until we know better...
         // Just in case, we don't want an XTENSION key lingering around...

--- a/src/main/java/nom/tam/fits/compress/CloseIS.java
+++ b/src/main/java/nom/tam/fits/compress/CloseIS.java
@@ -78,11 +78,13 @@ public class CloseIS extends FilterInputStream {
     /**
      * Instantiates a new thread that will watch and close the input stream whenever the process using it compeletes.
      * 
-     * @param proc       The process that is using the input stream
-     * @param compressed the compressed input stream that is used by the process.
+     * @param  proc                 The process that is using the input stream
+     * @param  compressed           the compressed input stream that is used by the process.
+     * 
+     * @throws NullPointerException if the compressed argument is <code>null</code>.
      */
     @SuppressWarnings("resource")
-    public CloseIS(Process proc, final InputStream compressed) {
+    public CloseIS(Process proc, final InputStream compressed) throws NullPointerException {
         super(new BufferedInputStream(proc.getInputStream(), CompressionManager.ONE_MEGABYTE));
         if (compressed == null) {
             throw new NullPointerException();
@@ -134,6 +136,12 @@ public class CloseIS extends FilterInputStream {
             }
         });
         start();
+    }
+
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
     }
 
     /**

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
@@ -255,6 +255,12 @@ public abstract class RiceCompressor<T extends Buffer> implements ICompressor<T>
         bBits = 1 << fsBits;
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * <p>
      * undo mapping and differencing Note that some of these operations will overflow the unsigned int arithmetic --

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderCardAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderCardAccess.java
@@ -67,15 +67,24 @@ public class HeaderCardAccess implements IHeaderAccess {
      * the selected card if and only if the keyword matches that of the card's keyword.
      * </p>
      * 
-     * @param headerCard the FITS keyword of the card we will provide access to
-     * @param value      the initial string value for the card (assuming the keyword allows string values).
+     * @param  headerCard               the FITS keyword of the card we will provide access to
+     * @param  value                    the initial string value for the card (assuming the keyword allows string
+     *                                      values).
+     * 
+     * @throws IllegalArgumentException if the header card could not be created
      */
-    public HeaderCardAccess(IFitsHeader headerCard, String value) {
+    public HeaderCardAccess(IFitsHeader headerCard, String value) throws IllegalArgumentException {
         try {
             this.headerCard = new HeaderCard(headerCard.key(), value, null);
         } catch (HeaderCardException e) {
             throw new IllegalArgumentException("header card could not be created");
         }
+    }
+
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/hierarch/BlanksDotHierarchKeyFormatter.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/BlanksDotHierarchKeyFormatter.java
@@ -69,6 +69,12 @@ public class BlanksDotHierarchKeyFormatter implements IHierarchKeyFormatter {
     }
 
     @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
+    @Override
     public void append(String key, FitsLineAppender buffer) {
         buffer.append(toHeaderString(key));
     }

--- a/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
@@ -111,7 +111,7 @@ public final class FitsCheckSum {
     private static class Checksum {
         private long h, l;
 
-        Checksum(long prior) throws IllegalArgumentException {
+        Checksum(long prior) {
             h = (prior >>> SHIFT_2_BYTES) & MASK_2_BYTES;
             l = prior & MASK_2_BYTES;
         }
@@ -147,6 +147,12 @@ public final class FitsCheckSum {
         PipeWriter(FitsElement data, PipedInputStream in) throws IOException {
             this.data = data;
             out = new PipedOutputStream(in);
+        }
+
+        @Override
+        protected final void finalize() {
+            // final to protect against vulnerability when throwing an exception in the constructor
+            // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
         }
 
         @Override

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDecompressor.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDecompressor.java
@@ -64,6 +64,12 @@ public class BinaryTableTileDecompressor extends BinaryTableTile {
     }
 
     @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
+    @Override
     public void run() {
         if (is == null) {
             ByteBuffer unCompressedBytes = ByteBuffer.wrap(new byte[getUncompressedSizeInBytes()]);

--- a/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
@@ -37,14 +37,11 @@ import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.image.tile.operation.buffer.TileBuffer;
 
 /**
- * (<i>for internal use</i>) Base support for blank (<code>null</code>) in
- * compressed images. In regular images specific values (such as
- * {@link Double#NaN} or a specific integer value) may be used to indicate
- * missing data. However, because of e.g. quantization or lossy compression,
- * these specific values may not be recovered exactly when compressing /
- * decompressing images. Hence, there is a need to demark <code>null</code>
- * values differently in copmressed images. This class provides support for that
- * purpose.
+ * (<i>for internal use</i>) Base support for blank (<code>null</code>) in compressed images. In regular images specific
+ * values (such as {@link Double#NaN} or a specific integer value) may be used to indicate missing data. However,
+ * because of e.g. quantization or lossy compression, these specific values may not be recovered exactly when
+ * compressing / decompressing images. Hence, there is a need to demark <code>null</code> values differently in
+ * copmressed images. This class provides support for that purpose.
  */
 public class AbstractNullPixelMask {
 
@@ -64,20 +61,17 @@ public class AbstractNullPixelMask {
     private final ICompressorControl compressorControl;
 
     /**
-     * Creates a new pixel mask got a given image tile and designated null
-     * value.
+     * Creates a new pixel mask got a given image tile and designated null value.
      * 
-     * @param tileBuffer
-     *            the buffer containing the tile data
-     * @param tileIndex
-     *            the tile index
-     * @param nullValue
-     *            the integer value representing <code>null</code> or invalid
-     *            data
-     * @param compressorControl
-     *            The class managing the compression
+     * @param  tileBuffer            the buffer containing the tile data
+     * @param  tileIndex             the tile index
+     * @param  nullValue             the integer value representing <code>null</code> or invalid data
+     * @param  compressorControl     The class managing the compression
+     * 
+     * @throws IllegalStateException if the compressorControl argument is <code>null</code>
      */
-    protected AbstractNullPixelMask(TileBuffer tileBuffer, int tileIndex, long nullValue, ICompressorControl compressorControl) {
+    protected AbstractNullPixelMask(TileBuffer tileBuffer, int tileIndex, long nullValue,
+            ICompressorControl compressorControl) throws IllegalStateException {
         this.tileBuffer = tileBuffer;
         this.tileIndex = tileIndex;
         this.nullValue = nullValue;
@@ -87,12 +81,18 @@ public class AbstractNullPixelMask {
         }
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Returns a byte array containing the mask
      * 
-     * @return the byte array containing the pixel mask for the tile.
-     * @deprecated (<i>for internal use</i>) Visibility may be reduced to
-     *             package level in the future.
+     * @return     the byte array containing the pixel mask for the tile.
+     * 
+     * @deprecated (<i>for internal use</i>) Visibility may be reduced to package level in the future.
      */
     public byte[] getMaskBytes() {
         if (mask == null) {
@@ -108,16 +108,14 @@ public class AbstractNullPixelMask {
     /**
      * Sets data for a new mask as a flattened buffer of data.
      * 
-     * @param mask
-     *            the buffer containing the mask data in flattened format.
+     * @param mask the buffer containing the mask data in flattened format.
      */
     public void setMask(ByteBuffer mask) {
         this.mask = mask;
     }
 
     /**
-     * Returns the object that manages the compression, and which therefore
-     * handles the masking
+     * Returns the object that manages the compression, and which therefore handles the masking
      * 
      * @return the object that manages the compression.
      */
@@ -135,8 +133,7 @@ public class AbstractNullPixelMask {
     }
 
     /**
-     * Returns the value that represents a <code>null</code> or an undefined
-     * data point.
+     * Returns the value that represents a <code>null</code> or an undefined data point.
      * 
      * @return the value that demarks an undefined datum.
      */
@@ -163,13 +160,11 @@ public class AbstractNullPixelMask {
     }
 
     /**
-     * Creates an internal buffer for holding the mask data, for the specified
-     * number of points.
+     * Creates an internal buffer for holding the mask data, for the specified number of points.
      * 
-     * @param remaining
-     *            the number of points the mask should accomodate.
-     * @return the internal buffer that may store the mask data for the
-     *         specified number of data points.
+     * @param  remaining the number of points the mask should accomodate.
+     * 
+     * @return           the internal buffer that may store the mask data for the specified number of data points.
      */
     protected ByteBuffer initializedMask(int remaining) {
         if (mask == null) {

--- a/src/main/java/nom/tam/util/BufferedFileIO.java
+++ b/src/main/java/nom/tam/util/BufferedFileIO.java
@@ -108,6 +108,12 @@ class BufferedFileIO implements InputReader, OutputWriter, Flushable, Closeable 
         writeAhead = false;
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Sets a new position in the file for subsequent reading or writing.
      * 

--- a/src/main/java/nom/tam/util/ByteArrayIO.java
+++ b/src/main/java/nom/tam/util/ByteArrayIO.java
@@ -91,6 +91,12 @@ public class ByteArrayIO implements ReadWriteAccess {
         isGrowable = true;
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Returns a copy of this byte array with an IO interface, including a deep copy of the buffered data.
      *

--- a/src/main/java/nom/tam/util/ColumnTable.java
+++ b/src/main/java/nom/tam/util/ColumnTable.java
@@ -98,6 +98,12 @@ public class ColumnTable<T> implements DataTable, Cloneable {
         }
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Checks if the table is empty (contains no data and no column definitions)
      * 

--- a/src/main/java/nom/tam/util/ComplexValue.java
+++ b/src/main/java/nom/tam/util/ComplexValue.java
@@ -236,6 +236,12 @@ public class ComplexValue {
         }
     }
 
+    @Override
+    protected final void finalize() {
+        // final to protect against vulnerability when throwing an exception in the constructor
+        // See CT_CONSTRUCTOR_THROW in spotbugs for mode explanation.
+    }
+
     /**
      * Converts this comlex value to its string representation using up to the specified number of characters only. The
      * precision may be reduced as necessary to ensure that the representation fits in the allotted space.


### PR DESCRIPTION
The latest maven spotbug plugin exposed a bunch of vulnerabilities with classes that may throw an exception from their constructors. In principle a program may extend these classes, and override the `finalize()` method to expoit the partially initialized state of the classes involved. In the context of the the nom-tam-fits library there is no sensitive data that could be exposed in this way, so it's not really a vilnerability in the true sense.

Also, the easiest fix for it would be to declare the `finalize()` method of these classes `final` in order to prevent intercepting partially initialized data. However the `finalize()` method has been deprecated since Java 9. Thus, that approach to tending to the issue is not future proof itself.

We'll just keep the Spotbug detectors for this type of problem disabled. Some related fixes are in PR #518.

