### PR TITLE
Various fixes and javadoc updates to constructors that throw exceptions.

### DIFF
--- a/src/main/java/nom/tam/fits/FitsHeap.java
+++ b/src/main/java/nom/tam/fits/FitsHeap.java
@@ -77,7 +77,7 @@ public class FitsHeap implements FitsElement {
      *
      * @throws IllegalArgumentException if the size argument is negative.
      */
-    FitsHeap(int size) {
+    FitsHeap(int size) throws IllegalArgumentException {
         if (size < 0) {
             throw new IllegalArgumentException("Illegal size for FITS heap: " + size);
         }

--- a/src/main/java/nom/tam/fits/PaddingException.java
+++ b/src/main/java/nom/tam/fits/PaddingException.java
@@ -32,14 +32,11 @@ package nom.tam.fits;
  */
 
 /**
- * This exception is thrown if padding is missing between the end of a FITS data
- * segment and the end-of-file. This padding is required by the FITS standard,
- * but some FITS writers may not add it. As of 1.17 our `Fits` class deals
- * seamlessly with such data, since the missing padding at the end-of-file is
- * harmless when reading in data. It will log a warning but proceed normally.
- * However, the exception is still thrown when using low-level
- * {@link Data#read(nom.tam.util.ArrayDataInput)} to allow expert users to deal
- * with this issue in any way they see fit.
+ * This exception is thrown if padding is missing between the end of a FITS data segment and the end-of-file. This
+ * padding is required by the FITS standard, but some FITS writers may not add it. As of 1.17 our `Fits` class deals
+ * seamlessly with such data, since the missing padding at the end-of-file is harmless when reading in data. It will log
+ * a warning but proceed normally. However, the exception is still thrown when using low-level
+ * {@link Data#read(nom.tam.util.ArrayDataInput)} to allow expert users to deal with this issue in any way they see fit.
  */
 public class PaddingException extends FitsException {
 
@@ -48,7 +45,7 @@ public class PaddingException extends FitsException {
      */
     private static final long serialVersionUID = 8716484905278318366L;
 
-    PaddingException(String msg, Exception cause) throws FitsException {
+    PaddingException(String msg, Exception cause) {
         super(msg, cause);
     }
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderCardAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderCardAccess.java
@@ -67,10 +67,13 @@ public class HeaderCardAccess implements IHeaderAccess {
      * the selected card if and only if the keyword matches that of the card's keyword.
      * </p>
      * 
-     * @param headerCard the FITS keyword of the card we will provide access to
-     * @param value      the initial string value for the card (assuming the keyword allows string values).
+     * @param  headerCard               the FITS keyword of the card we will provide access to
+     * @param  value                    the initial string value for the card (assuming the keyword allows string
+     *                                      values).
+     * 
+     * @throws IllegalArgumentException if the header card could not be created
      */
-    public HeaderCardAccess(IFitsHeader headerCard, String value) {
+    public HeaderCardAccess(IFitsHeader headerCard, String value) throws IllegalArgumentException {
         try {
             this.headerCard = new HeaderCard(headerCard.key(), value, null);
         } catch (HeaderCardException e) {

--- a/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
@@ -111,7 +111,7 @@ public final class FitsCheckSum {
     private static class Checksum {
         private long h, l;
 
-        Checksum(long prior) throws IllegalArgumentException {
+        Checksum(long prior) {
             h = (prior >>> SHIFT_2_BYTES) & MASK_2_BYTES;
             l = prior & MASK_2_BYTES;
         }

--- a/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
@@ -37,14 +37,11 @@ import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.image.tile.operation.buffer.TileBuffer;
 
 /**
- * (<i>for internal use</i>) Base support for blank (<code>null</code>) in
- * compressed images. In regular images specific values (such as
- * {@link Double#NaN} or a specific integer value) may be used to indicate
- * missing data. However, because of e.g. quantization or lossy compression,
- * these specific values may not be recovered exactly when compressing /
- * decompressing images. Hence, there is a need to demark <code>null</code>
- * values differently in copmressed images. This class provides support for that
- * purpose.
+ * (<i>for internal use</i>) Base support for blank (<code>null</code>) in compressed images. In regular images specific
+ * values (such as {@link Double#NaN} or a specific integer value) may be used to indicate missing data. However,
+ * because of e.g. quantization or lossy compression, these specific values may not be recovered exactly when
+ * compressing / decompressing images. Hence, there is a need to demark <code>null</code> values differently in
+ * copmressed images. This class provides support for that purpose.
  */
 public class AbstractNullPixelMask {
 
@@ -64,20 +61,17 @@ public class AbstractNullPixelMask {
     private final ICompressorControl compressorControl;
 
     /**
-     * Creates a new pixel mask got a given image tile and designated null
-     * value.
+     * Creates a new pixel mask got a given image tile and designated null value.
      * 
-     * @param tileBuffer
-     *            the buffer containing the tile data
-     * @param tileIndex
-     *            the tile index
-     * @param nullValue
-     *            the integer value representing <code>null</code> or invalid
-     *            data
-     * @param compressorControl
-     *            The class managing the compression
+     * @param  tileBuffer            the buffer containing the tile data
+     * @param  tileIndex             the tile index
+     * @param  nullValue             the integer value representing <code>null</code> or invalid data
+     * @param  compressorControl     The class managing the compression
+     * 
+     * @throws IllegalStateException if the compressorControl argument is <code>null</code>
      */
-    protected AbstractNullPixelMask(TileBuffer tileBuffer, int tileIndex, long nullValue, ICompressorControl compressorControl) {
+    protected AbstractNullPixelMask(TileBuffer tileBuffer, int tileIndex, long nullValue,
+            ICompressorControl compressorControl) throws IllegalStateException {
         this.tileBuffer = tileBuffer;
         this.tileIndex = tileIndex;
         this.nullValue = nullValue;
@@ -90,9 +84,9 @@ public class AbstractNullPixelMask {
     /**
      * Returns a byte array containing the mask
      * 
-     * @return the byte array containing the pixel mask for the tile.
-     * @deprecated (<i>for internal use</i>) Visibility may be reduced to
-     *             package level in the future.
+     * @return     the byte array containing the pixel mask for the tile.
+     * 
+     * @deprecated (<i>for internal use</i>) Visibility may be reduced to package level in the future.
      */
     public byte[] getMaskBytes() {
         if (mask == null) {
@@ -108,16 +102,14 @@ public class AbstractNullPixelMask {
     /**
      * Sets data for a new mask as a flattened buffer of data.
      * 
-     * @param mask
-     *            the buffer containing the mask data in flattened format.
+     * @param mask the buffer containing the mask data in flattened format.
      */
     public void setMask(ByteBuffer mask) {
         this.mask = mask;
     }
 
     /**
-     * Returns the object that manages the compression, and which therefore
-     * handles the masking
+     * Returns the object that manages the compression, and which therefore handles the masking
      * 
      * @return the object that manages the compression.
      */
@@ -135,8 +127,7 @@ public class AbstractNullPixelMask {
     }
 
     /**
-     * Returns the value that represents a <code>null</code> or an undefined
-     * data point.
+     * Returns the value that represents a <code>null</code> or an undefined data point.
      * 
      * @return the value that demarks an undefined datum.
      */
@@ -163,13 +154,11 @@ public class AbstractNullPixelMask {
     }
 
     /**
-     * Creates an internal buffer for holding the mask data, for the specified
-     * number of points.
+     * Creates an internal buffer for holding the mask data, for the specified number of points.
      * 
-     * @param remaining
-     *            the number of points the mask should accomodate.
-     * @return the internal buffer that may store the mask data for the
-     *         specified number of data points.
+     * @param  remaining the number of points the mask should accomodate.
+     * 
+     * @return           the internal buffer that may store the mask data for the specified number of data points.
      */
     protected ByteBuffer initializedMask(int remaining) {
         if (mask == null) {


### PR DESCRIPTION
spotbugs exposed potential vulnerabilities with constructors that throw exceptions. These aren't really issues with the nom-tam-fits library as the vulnerability does not expose sensitive information. However, in looking through the list, a few constructors did not declare the runtime exception they might throw, while in some cases the throwing of exceptions was completely unwarranted and should be removed.  So, taking this opportunity to clean up a little. Specifically:

- The constructor of `PaddingException` indicated it may throw a `FitsException` but of course it does not. (It extends `FitsException`). So removed the mistaken declaration.
- The constructor of `FitsCheckSum.Checksum` also indicated a runtime exception that may be thrown, but in fact it does not do that, so also removed from the declaration.