### PR TITLE
Demote FitsException to a runtime exception

### DIFF
--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -882,9 +882,11 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
     /**
      * Print out some information about this HDU.
      *
-     * @param stream the printstream to write the info on
+     * @param  stream        the printstream to write the info on
+     * 
+     * @throws FitsException if the HDU is malformed
      */
-    public abstract void info(PrintStream stream);
+    public abstract void info(PrintStream stream) throws FitsException;
 
     @Override
     @SuppressWarnings({"unchecked", "deprecation"})

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -283,9 +283,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
         /**
          * Sets the maximum length of string elements in this column.
          *
-         * @param  len                   The fixed string length in bytes.
-         * 
-         * @throws IllegalStateException if this is not a String column.
+         * @param len The fixed string length in bytes.
          */
         private void setStringLength(int len) {
             stringLength = len;

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -1280,38 +1280,33 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
      * constructor, you should assume that it will not use anything beyond what's available in any generic vanilla
      * column table.
      *
-     * @param      tab                   the column table to create the binary table from. It must be a regular column
-     *                                       table that contains regular data of scalar or fixed 1D arrays only (not
-     *                                       heap pointers). No information beyond what a generic vanilla column table
-     *                                       provides will be used. Column tables don't store imensions for their
-     *                                       elements, and don't have variable-sized entries. Thus, if the table was the
-     *                                       used in another binary table to store flattened multidimensional data,
-     *                                       we'll detect that data as 1D arrays. Andm if the table was used to store
-     *                                       heap pointers for variable length arrays, we'll detect these as regular
-     *                                       <code>int[2]</code> or <code>long[2]</code> values.
+     * @param      tab           the column table to create the binary table from. It must be a regular column table
+     *                               that contains regular data of scalar or fixed 1D arrays only (not heap pointers).
+     *                               No information beyond what a generic vanilla column table provides will be used.
+     *                               Column tables don't store imensions for their elements, and don't have
+     *                               variable-sized entries. Thus, if the table was the used in another binary table to
+     *                               store flattened multidimensional data, we'll detect that data as 1D arrays. Andm if
+     *                               the table was used to store heap pointers for variable length arrays, we'll detect
+     *                               these as regular <code>int[2]</code> or <code>long[2]</code> values.
      * 
-     * @deprecated                       DO NOT USE -- it will be removed in the future.
+     * @deprecated               DO NOT USE -- it will be removed in the future.
      * 
-     * @throws     IllegalStateException if the table could not be copied and threw a
-     *                                       {@link nom.tam.util.TableException}, which is preserved as the cause.
+     * @throws     FitsException if the table could not be copied and threw a {@link nom.tam.util.TableException}, which
+     *                               is preserved as the cause.
      * 
-     * @see                              #copy()
+     * @see                      #copy()
      */
-    public BinaryTable(ColumnTable<?> tab) throws IllegalStateException {
+    public BinaryTable(ColumnTable<?> tab) throws FitsException {
         this();
 
-        try {
-            table = new ColumnTable<>();
-            nRow = tab.getNRows();
-            columns = new ArrayList<>();
+        table = new ColumnTable<>();
+        nRow = tab.getNRows();
+        columns = new ArrayList<>();
 
-            for (int i = 0; i < tab.getNCols(); i++) {
-                int n = tab.getElementSize(i);
-                ColumnDesc c = new ColumnDesc(tab.getElementClass(i), n > 1 ? new int[] {n} : SINGLETON_SHAPE);
-                addFlattenedColumn(tab.getColumn(i), nRow, c, true);
-            }
-        } catch (FitsException e) {
-            throw new IllegalStateException(e.getMessage(), e);
+        for (int i = 0; i < tab.getNCols(); i++) {
+            int n = tab.getElementSize(i);
+            ColumnDesc c = new ColumnDesc(tab.getElementClass(i), n > 1 ? new int[] {n} : SINGLETON_SHAPE);
+            addFlattenedColumn(tab.getColumn(i), nRow, c, true);
         }
     }
 
@@ -2167,19 +2162,14 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
     }
 
     /**
-     * @deprecated                       (<i>for internal use</i>) It may be private in the future.
+     * @deprecated               (<i>for internal use</i>) It may be private in the future.
      * 
-     * @return                           An array with flattened data, in which each column's data is represented by a
-     *                                       1D array
+     * @return                   An array with flattened data, in which each column's data is represented by a 1D array
      * 
-     * @throws     IllegalStateException if the reading of the data failed.
+     * @throws     FitsException if the reading of the data failed.
      */
-    public Object[] getFlatColumns() throws IllegalStateException {
-        try {
-            ensureData();
-        } catch (FitsException e) {
-            throw new IllegalStateException("Reading of data failed: " + e.getMessage(), e);
-        }
+    public Object[] getFlatColumns() throws FitsException {
+        ensureData();
         return table.getColumns();
     }
 
@@ -3530,13 +3520,9 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
      *                 it would make a better private method in there.. `
      */
     protected void addByteVaryingColumn() {
-        try {
-            ColumnDesc c = ColumnDesc.createForVariableSize(byte.class);
-            columns.add(c);
-            table.addColumn(c.newInstance(nRow), c.getTableBaseCount());
-        } catch (FitsException e) {
-            // Should not happen
-        }
+        ColumnDesc c = ColumnDesc.createForVariableSize(byte.class);
+        columns.add(c);
+        table.addColumn(c.newInstance(nRow), c.getTableBaseCount());
     }
 
     /**
@@ -3877,13 +3863,9 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
     }
 
     @Override
-    public BinaryTableHDU toHDU() throws IllegalStateException {
+    public BinaryTableHDU toHDU() throws FitsException {
         Header h = new Header();
-        try {
-            fillHeader(h);
-        } catch (FitsException e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
+        fillHeader(h);
         return new BinaryTableHDU(h, this);
     }
 }

--- a/src/main/java/nom/tam/fits/Data.java
+++ b/src/main/java/nom/tam/fits/Data.java
@@ -438,9 +438,9 @@ public abstract class Data implements FitsElement {
      * Returns an approprotae HDU object that encapsulates this FITS data, and contains the minimal mandatory header
      * description for that data.
      * 
-     * @throws IllegalStateException If the data cannot be converted to an HDU for some reason.
+     * @throws FitsException If the data cannot be converted to an HDU for some reason.
      * 
-     * @return                       a HDU object ocntaining the data and its minimal required header description
+     * @return               a HDU object ocntaining the data and its minimal required header description
      */
-    public abstract BasicHDU<?> toHDU() throws IllegalStateException;
+    public abstract BasicHDU<?> toHDU() throws FitsException;
 }

--- a/src/main/java/nom/tam/fits/FitsException.java
+++ b/src/main/java/nom/tam/fits/FitsException.java
@@ -32,9 +32,10 @@ package nom.tam.fits;
  */
 
 /**
- * When we cannot deal with some FITS data as expected. Originally it was a hard exception, that you had no choice by to
- * catch. Since 1.19, it has been demoted to a softer, runtime exception. This is a back compatible change, which gives
- * more freedom to programmers on dealing with these (or not).
+ * When we cannot deal with some FITS data as expected. Originally it was a hard
+ * exception, that you had no choice by to catch. Since 1.19, it has been
+ * demoted to a softer, runtime exception. This is a back compatible change,
+ * which gives more freedom to programmers on dealing with these (or not).
  */
 public class FitsException extends IllegalStateException {
 
@@ -46,18 +47,24 @@ public class FitsException extends IllegalStateException {
     /**
      * Instantiates this exception with the designated message string.
      * 
-     * @param msg a human readable message that describes what in fact caused the exception
+     * @param msg
+     *            a human readable message that describes what in fact caused
+     *            the exception
      */
     public FitsException(String msg) {
         super(msg);
     }
 
     /**
-     * Instantiates this exception with the designated message string, when it was triggered by some other type of
-     * exception
+     * Instantiates this exception with the designated message string, when it
+     * was triggered by some other type of exception
      * 
-     * @param msg    a human readable message that describes what in fact caused the exception
-     * @param reason the original exception (or other throwable) that triggered this exception.
+     * @param msg
+     *            a human readable message that describes what in fact caused
+     *            the exception
+     * @param reason
+     *            the original exception (or other throwable) that triggered
+     *            this exception.
      */
     public FitsException(String msg, Throwable reason) {
         super(msg, reason);

--- a/src/main/java/nom/tam/fits/FitsException.java
+++ b/src/main/java/nom/tam/fits/FitsException.java
@@ -32,12 +32,11 @@ package nom.tam.fits;
  */
 
 /**
- * A hard exception for when we cannot deal with some FITS data as expected. In
- * retrospect it would have been better to make this a softer runtime exception,
- * but this goes back to the beginning of this library so it is here to stay.
- * You have no choice but to catch these an deal with them all the time.
+ * When we cannot deal with some FITS data as expected. Originally it was a hard exception, that you had no choice by to
+ * catch. Since 1.19, it has been demoted to a softer, runtime exception. This is a back compatible change, which gives
+ * more freedom to programmers on dealing with these (or not).
  */
-public class FitsException extends Exception {
+public class FitsException extends IllegalStateException {
 
     /**
      *
@@ -47,24 +46,18 @@ public class FitsException extends Exception {
     /**
      * Instantiates this exception with the designated message string.
      * 
-     * @param msg
-     *            a human readable message that describes what in fact caused
-     *            the exception
+     * @param msg a human readable message that describes what in fact caused the exception
      */
     public FitsException(String msg) {
         super(msg);
     }
 
     /**
-     * Instantiates this exception with the designated message string, when it
-     * was triggered by some other type of exception
+     * Instantiates this exception with the designated message string, when it was triggered by some other type of
+     * exception
      * 
-     * @param msg
-     *            a human readable message that describes what in fact caused
-     *            the exception
-     * @param reason
-     *            the original exception (or other throwable) that triggered
-     *            this exception.
+     * @param msg    a human readable message that describes what in fact caused the exception
+     * @param reason the original exception (or other throwable) that triggered this exception.
      */
     public FitsException(String msg, Throwable reason) {
         super(msg, reason);

--- a/src/main/java/nom/tam/fits/FitsException.java
+++ b/src/main/java/nom/tam/fits/FitsException.java
@@ -36,7 +36,7 @@ package nom.tam.fits;
  * catch. Since 1.19, it has been demoted to a softer, runtime exception. This is a back compatible change, which gives
  * more freedom to programmers on dealing with these (or not).
  */
-public class FitsException extends Exception {
+public class FitsException extends IllegalStateException {
 
     /**
      *

--- a/src/main/java/nom/tam/fits/FitsException.java
+++ b/src/main/java/nom/tam/fits/FitsException.java
@@ -32,10 +32,9 @@ package nom.tam.fits;
  */
 
 /**
- * A hard exception for when we cannot deal with some FITS data as expected. In
- * retrospect it would have been better to make this a softer runtime exception,
- * but this goes back to the beginning of this library so it is here to stay.
- * You have no choice but to catch these an deal with them all the time.
+ * When we cannot deal with some FITS data as expected. Originally it was a hard exception, that you had no choice by to
+ * catch. Since 1.19, it has been demoted to a softer, runtime exception. This is a back compatible change, which gives
+ * more freedom to programmers on dealing with these (or not).
  */
 public class FitsException extends Exception {
 
@@ -47,24 +46,18 @@ public class FitsException extends Exception {
     /**
      * Instantiates this exception with the designated message string.
      * 
-     * @param msg
-     *            a human readable message that describes what in fact caused
-     *            the exception
+     * @param msg a human readable message that describes what in fact caused the exception
      */
     public FitsException(String msg) {
         super(msg);
     }
 
     /**
-     * Instantiates this exception with the designated message string, when it
-     * was triggered by some other type of exception
+     * Instantiates this exception with the designated message string, when it was triggered by some other type of
+     * exception
      * 
-     * @param msg
-     *            a human readable message that describes what in fact caused
-     *            the exception
-     * @param reason
-     *            the original exception (or other throwable) that triggered
-     *            this exception.
+     * @param msg    a human readable message that describes what in fact caused the exception
+     * @param reason the original exception (or other throwable) that triggered this exception.
      */
     public FitsException(String msg, Throwable reason) {
         super(msg, reason);

--- a/src/main/java/nom/tam/fits/FitsException.java
+++ b/src/main/java/nom/tam/fits/FitsException.java
@@ -32,11 +32,12 @@ package nom.tam.fits;
  */
 
 /**
- * When we cannot deal with some FITS data as expected. Originally it was a hard exception, that you had no choice by to
- * catch. Since 1.19, it has been demoted to a softer, runtime exception. This is a back compatible change, which gives
- * more freedom to programmers on dealing with these (or not).
+ * A hard exception for when we cannot deal with some FITS data as expected. In
+ * retrospect it would have been better to make this a softer runtime exception,
+ * but this goes back to the beginning of this library so it is here to stay.
+ * You have no choice but to catch these an deal with them all the time.
  */
-public class FitsException extends IllegalStateException {
+public class FitsException extends Exception {
 
     /**
      *
@@ -46,18 +47,24 @@ public class FitsException extends IllegalStateException {
     /**
      * Instantiates this exception with the designated message string.
      * 
-     * @param msg a human readable message that describes what in fact caused the exception
+     * @param msg
+     *            a human readable message that describes what in fact caused
+     *            the exception
      */
     public FitsException(String msg) {
         super(msg);
     }
 
     /**
-     * Instantiates this exception with the designated message string, when it was triggered by some other type of
-     * exception
+     * Instantiates this exception with the designated message string, when it
+     * was triggered by some other type of exception
      * 
-     * @param msg    a human readable message that describes what in fact caused the exception
-     * @param reason the original exception (or other throwable) that triggered this exception.
+     * @param msg
+     *            a human readable message that describes what in fact caused
+     *            the exception
+     * @param reason
+     *            the original exception (or other throwable) that triggered
+     *            this exception.
      */
     public FitsException(String msg, Throwable reason) {
         super(msg, reason);

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -2473,13 +2473,7 @@ public class Header implements FitsElement {
             }
         }
         // End cannot have a comment
-
-        try {
-            iter.add(HeaderCard.createCommentStyleCard(END.key(), null));
-        } catch (HeaderCardException e) {
-            // Cannot happen.
-        }
-
+        iter.add(HeaderCard.createCommentStyleCard(END.key(), null));
     }
 
     /**

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -1753,27 +1753,22 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * This method was designed for use internally. It is 'safe' (not save!) in the sense that the runtime exception it
      * may throw does not need to be caught.
      *
-     * @param      key                   keyword
-     * @param      comment               optional comment, or <code>null</code>
-     * @param      hasValue              does this card have a (<code>null</code>) value field? If <code>true</code> a
-     *                                       null value of type <code>String.class</code> is assumed (for backward
-     *                                       compatibility).
+     * @param      key                 keyword
+     * @param      comment             optional comment, or <code>null</code>
+     * @param      hasValue            does this card have a (<code>null</code>) value field? If <code>true</code> a
+     *                                     null value of type <code>String.class</code> is assumed (for backward
+     *                                     compatibility).
      *
-     * @return                           the new HeaderCard
+     * @return                         the new HeaderCard
      *
-     * @throws     IllegalStateException if the card could not be created for some reason (noted as the cause).
+     * @throws     HeaderCardException if the card could not be created for some reason (noted as the cause).
      *
-     * @deprecated                       This was to be used internally only, without public visibility. It will become
-     *                                       unexposed to users in a future release...
+     * @deprecated                     This was to be used internally only, without public visibility. It will become
+     *                                     unexposed to users in a future release...
      */
     @Deprecated
-    public static HeaderCard saveNewHeaderCard(String key, String comment, boolean hasValue) throws IllegalStateException {
-        try {
-            return new HeaderCard(key, null, comment, hasValue ? String.class : null);
-        } catch (HeaderCardException e) {
-            LOG.log(Level.SEVERE, "Impossible Exception for internal card creation:" + key, e);
-            throw new IllegalStateException(e);
-        }
+    public static HeaderCard saveNewHeaderCard(String key, String comment, boolean hasValue) throws HeaderCardException {
+        return new HeaderCard(key, null, comment, hasValue ? String.class : null);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
+++ b/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
@@ -39,7 +39,7 @@ package nom.tam.fits;
  * @see FitsFactory#setUseHierarch(boolean)
  * @since 1.16
  */
-public class HierarchNotEnabledException extends IllegalStateException {
+public class HierarchNotEnabledException extends FitsException {
 
     /**
      *

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -390,13 +390,9 @@ public class ImageData extends Data {
 
     @Override
     @SuppressWarnings("deprecation")
-    public ImageHDU toHDU() throws IllegalStateException {
+    public ImageHDU toHDU() throws FitsException {
         Header h = new Header();
-        try {
-            fillHeader(h);
-        } catch (FitsException e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
+        fillHeader(h);
         return new ImageHDU(h, this);
     }
 }

--- a/src/main/java/nom/tam/fits/LongStringsNotEnabledException.java
+++ b/src/main/java/nom/tam/fits/LongStringsNotEnabledException.java
@@ -39,7 +39,7 @@ package nom.tam.fits;
  * @see FitsFactory#setLongStringsEnabled(boolean)
  * @since 1.16
  */
-public class LongStringsNotEnabledException extends IllegalStateException {
+public class LongStringsNotEnabledException extends FitsException {
 
     /**
      *

--- a/src/main/java/nom/tam/fits/LongValueException.java
+++ b/src/main/java/nom/tam/fits/LongValueException.java
@@ -40,7 +40,7 @@ package nom.tam.fits;
  * @author Attila Kovacs
  * @since 1.16
  */
-public class LongValueException extends IllegalStateException {
+public class LongValueException extends FitsException {
 
     /**
      *

--- a/src/main/java/nom/tam/fits/NullData.java
+++ b/src/main/java/nom/tam/fits/NullData.java
@@ -59,14 +59,10 @@ public final class NullData extends ImageData {
         head.setBitpix(Bitpix.INTEGER);
         head.setNaxes(0);
 
-        try {
-            // Just in case!
-            head.addValue(EXTEND, true);
-            head.addValue(GCOUNT, 1);
-            head.addValue(PCOUNT, 0);
-        } catch (HeaderCardException e) {
-            // we don't really care...
-        }
+        // Just in case!
+        head.addValue(EXTEND, true);
+        head.addValue(GCOUNT, 1);
+        head.addValue(PCOUNT, 0);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -246,13 +246,9 @@ public class RandomGroupsData extends Data {
 
     @SuppressWarnings("deprecation")
     @Override
-    public RandomGroupsHDU toHDU() throws IllegalStateException {
+    public RandomGroupsHDU toHDU() throws FitsException {
         Header h = new Header();
-        try {
-            fillHeader(h);
-        } catch (FitsException e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
+        fillHeader(h);
         return new RandomGroupsHDU(h, this);
     }
 

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -280,15 +280,12 @@ public class RandomGroupsHDU extends BasicHDU<RandomGroupsData> {
     /**
      * Create an HDU from the given header and data.
      * 
-     * @deprecated                       (<i>for internal use</i>) Its visibility should be reduced to package level in
-     *                                       the future.
+     * @deprecated        (<i>for internal use</i>) Its visibility should be reduced to package level in the future.
      *
-     * @param      header                header to use
-     * @param      data                  data to use
-     * 
-     * @throws     IllegalStateException if the header does not contain a valid BITPIX value.
+     * @param      header header to use
+     * @param      data   data to use
      */
-    public RandomGroupsHDU(Header header, RandomGroupsData data) throws IllegalStateException {
+    public RandomGroupsHDU(Header header, RandomGroupsData data) {
         super(header, data);
 
         if (header == null) {

--- a/src/main/java/nom/tam/fits/UnclosedQuoteException.java
+++ b/src/main/java/nom/tam/fits/UnclosedQuoteException.java
@@ -39,7 +39,7 @@ package nom.tam.fits;
  * @see FitsFactory#setAllowHeaderRepairs(boolean)
  * @since 1.16
  */
-public class UnclosedQuoteException extends IllegalStateException {
+public class UnclosedQuoteException extends FitsException {
 
     /**
      *

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
@@ -33,7 +33,6 @@ package nom.tam.fits.compression.provider.param.api;
 
 import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
-import nom.tam.fits.HeaderCardBuilder;
 import nom.tam.fits.HeaderCardException;
 
 /**
@@ -54,8 +53,6 @@ import nom.tam.fits.HeaderCardException;
 public class HeaderAccess implements IHeaderAccess {
 
     private final Header header;
-
-    private HeaderCardBuilder builder;
 
     /**
      * <p>

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
@@ -44,7 +44,13 @@ import nom.tam.fits.header.IFitsHeader;
  * least until the next major code revision (major version 2 at the earliest). So this class provides an alternative
  * access to headers converting any <code>HeaderCardException</code>s to {@link IllegalArgumentException}.
  * 
- * @see Header
+ * @see        Header
+ * 
+ * @deprecated This class serves no purpose since 1.19. Will remove in some future. Prior to 1.19 {@link Header} threw
+ *                 hard {@link HeaderCardException}, and this class was added so we can convert these into soft
+ *                 {@link IllegalArgumentException} instead. However, now that we demoted
+ *                 <code>HeaderCardException</code> to be soft exceptions itself, there is no reason to convert. It just
+ *                 adds confusion.
  */
 public class HeaderAccess implements IHeaderAccess {
 
@@ -64,8 +70,20 @@ public class HeaderAccess implements IHeaderAccess {
         this.header = header;
     }
 
+    /**
+     * Returns the header that this class is providing access to.
+     * 
+     * @return the Header that we access through this class
+     * 
+     * @since  1.19
+     */
     @Override
-    public void addValue(IFitsHeader key, int value) {
+    public final Header getHeader() {
+        return header;
+    }
+
+    @Override
+    public void addValue(IFitsHeader key, int value) throws IllegalArgumentException {
         try {
             card(key).value(value);
         } catch (HeaderCardException e) {
@@ -74,7 +92,7 @@ public class HeaderAccess implements IHeaderAccess {
     }
 
     @Override
-    public void addValue(IFitsHeader key, String value) {
+    public void addValue(IFitsHeader key, String value) throws IllegalArgumentException {
         try {
             card(key).value(value);
         } catch (HeaderCardException e) {

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
@@ -35,7 +35,6 @@ import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
 import nom.tam.fits.HeaderCardBuilder;
 import nom.tam.fits.HeaderCardException;
-import nom.tam.fits.header.IFitsHeader;
 
 /**
  * (<i>for internal use</i>) Access to FITS header values with runtime exceptions only. Regular header access throws
@@ -80,42 +79,6 @@ public class HeaderAccess implements IHeaderAccess {
     @Override
     public final Header getHeader() {
         return header;
-    }
-
-    @Override
-    public void addValue(IFitsHeader key, int value) throws IllegalArgumentException {
-        try {
-            card(key).value(value);
-        } catch (HeaderCardException e) {
-            throw new IllegalArgumentException("header card could not be created: " + e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public void addValue(IFitsHeader key, String value) throws IllegalArgumentException {
-        try {
-            card(key).value(value);
-        } catch (HeaderCardException e) {
-            throw new IllegalArgumentException("header card could not be created " + e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public HeaderCard findCard(IFitsHeader key) {
-        return header.getCard(key);
-    }
-
-    @Override
-    public HeaderCard findCard(String key) {
-        return header.getCard(key);
-    }
-
-    private HeaderCardBuilder card(IFitsHeader key) {
-        if (builder == null) {
-            builder = header.card(key);
-            return builder;
-        }
-        return builder.card(key);
     }
 
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderCardAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderCardAccess.java
@@ -39,19 +39,25 @@ import nom.tam.fits.header.IFitsHeader;
 
 /**
  * <p>
- * (<i>for internal use</i>) Access to a specific FITS header card with runtime exceptions only. Regular modifications
- * to {@link HeaderCard} may throw {@link HeaderCardException}s, which are hard exceptions. They really should have been
- * softer runtime exceptions from the start, but unfortunately that was choice this library made a very long time ago,
- * and we therefore stick to it, at least until the next major code revision (major version 2 at the earliest). So this
- * class provides an alternative access to a header card converting any <code>HeaderCardException</code>s to
- * {@link IllegalArgumentException}.
+ * (<i>for internal use / no longer used</i>) Access to a specific FITS header card with runtime exceptions only.
+ * Regular modifications to {@link HeaderCard} may throw {@link HeaderCardException}s, which are hard exceptions. They
+ * really should have been softer runtime exceptions from the start, but unfortunately that was choice this library made
+ * a very long time ago, and we therefore stick to it, at least until the next major code revision (major version 2 at
+ * the earliest). So this class provides an alternative access to a header card converting any
+ * <code>HeaderCardException</code>s to {@link IllegalArgumentException}.
  * </p>
  * <p>
  * Unlike {@link HeaderAccess} this class operates on single cards. Methods that specify a keywords are applied to the
  * selected card if and only if the keyword matches that of the card's keyword.
  * </p>
  * 
- * @see Header
+ * @see        Header
+ * 
+ * @deprecated This class serves no purpose since 1.19. Will remove in some future. Prior to 1.19 {@link Header} threw
+ *                 hard {@link HeaderCardException}, and this class was added so we can convert these into soft
+ *                 {@link IllegalArgumentException} instead. However, now that we demoted
+ *                 <code>HeaderCardException</code> to be soft exceptions itself, there is no reason to convert. It just
+ *                 adds confusion.
  */
 public class HeaderCardAccess implements IHeaderAccess {
 
@@ -76,6 +82,24 @@ public class HeaderCardAccess implements IHeaderAccess {
         } catch (HeaderCardException e) {
             throw new IllegalArgumentException("header card could not be created");
         }
+    }
+
+    @Override
+    public final Header getHeader() {
+        Header header = new Header();
+        header.addLine(headerCard);
+        return header;
+    }
+
+    /**
+     * Returns the header card that this class is providing access to.
+     * 
+     * @return the Header card that we access through this class
+     * 
+     * @since  1.19
+     */
+    public final HeaderCard getHeaderCard() {
+        return headerCard;
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressHeaderParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressHeaderParameter.java
@@ -1,5 +1,8 @@
 package nom.tam.fits.compression.provider.param.api;
 
+import nom.tam.fits.Header;
+import nom.tam.fits.HeaderCardException;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -32,24 +35,47 @@ package nom.tam.fits.compression.provider.param.api;
  */
 
 /**
- * (<i>for internal use</i>) Compression parameter that must be stored along the
- * header meta data of the hdu.
+ * (<i>for internal use</i>) Compression parameter that must be stored along the header meta data of the hdu.
  */
 public interface ICompressHeaderParameter extends ICompressParameter {
 
     /**
      * get the value from the header and set it in the compression option.
      * 
-     * @param header
-     *            the header of the hdu
+     * @param      header the header of the hdu
+     * 
+     * @deprecated        Use {@link #getValueFromHeader(Header)} instead.
      */
-    void getValueFromHeader(IHeaderAccess header);
+    default void getValueFromHeader(IHeaderAccess header) {
+        getValueFromHeader(header.getHeader());
+    }
 
     /**
      * Get the parameter value from the option and set it into the fits header.
      * 
-     * @param header
-     *            the header to add the parameter.
+     * @param      header the header to add the parameter.
+     * 
+     * @deprecated        Use {@link #setValueInHeader(Header)} instead
      */
-    void setValueInHeader(IHeaderAccess header);
+    default void setValueInHeader(IHeaderAccess header) {
+        setValueInHeader(header.getHeader());
+    }
+
+    /**
+     * get the value from the header and set it in the compression option.
+     * 
+     * @param  header              the header of the hdu
+     * 
+     * @throws HeaderCardException if there was a problem accessing the header
+     */
+    void getValueFromHeader(Header header) throws HeaderCardException;
+
+    /**
+     * Get the parameter value from the option and set it into the fits header.
+     * 
+     * @param  header              the header to add the parameter.
+     * 
+     * @throws HeaderCardException if there was a problem accessing the header
+     */
+    void setValueInHeader(Header header) throws HeaderCardException;
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameters.java
@@ -3,6 +3,7 @@ package nom.tam.fits.compression.provider.param.api;
 import nom.tam.fits.BinaryTable;
 import nom.tam.fits.BinaryTableHDU;
 import nom.tam.fits.FitsException;
+import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.provider.param.base.CompressParameters;
@@ -87,20 +88,49 @@ public interface ICompressParameters {
     /**
      * extract the option values that are represented by headers from the hdu header.
      *
-     * @param header the header to extract the option values.
+     * @param      header the header to extract the option values.
+     * 
+     * @deprecated        Use {@link #getValuesFromHeader(Header)} instead.
      */
-    void getValuesFromHeader(IHeaderAccess header);
+    default void getValuesFromHeader(IHeaderAccess header) {
+        getValuesFromHeader(header.getHeader());
+    }
 
     /**
      * initialize the column based options of the compression algorithm from the binary table.
      *
-     * @param  header        the header of the hdu
-     * @param  binaryTable   the table of the hdu
-     * @param  size          the column size
+     * @param      header        the header of the hdu
+     * @param      binaryTable   the table of the hdu
+     * @param      size          the column size
      *
-     * @throws FitsException if the column could not be initialized
+     * @throws     FitsException if the column could not be initialized
+     * 
+     * @deprecated               Use {@link #initializeColumns(Header, BinaryTable, int)} instead
      */
-    void initializeColumns(IHeaderAccess header, BinaryTable binaryTable, int size) throws FitsException;
+    default void initializeColumns(IHeaderAccess header, BinaryTable binaryTable, int size) throws FitsException {
+        initializeColumns(header.getHeader(), binaryTable, size);
+    }
+
+    /**
+     * extract the option values that are represented by headers from the hdu header.
+     *
+     * @param  header              the header to extract the option values.
+     * 
+     * @throws HeaderCardException if there was an issue accessing the header
+     */
+    void getValuesFromHeader(Header header) throws HeaderCardException;
+
+    /**
+     * initialize the column based options of the compression algorithm from the binary table.
+     *
+     * @param  header              the header of the hdu
+     * @param  binaryTable         the table of the hdu
+     * @param  size                the column size
+     *
+     * @throws HeaderCardException if there was an issue accessing the header
+     * @throws FitsException       if the column could not be initialized
+     */
+    void initializeColumns(Header header, BinaryTable binaryTable, int size) throws HeaderCardException, FitsException;
 
     /**
      * initialize the column based parameter to the specified column length.
@@ -130,10 +160,22 @@ public interface ICompressParameters {
     /**
      * set the options values, that are hdu based, into the header.
      *
+     * @param      header              the header to set the option value
+     *
+     * @throws     HeaderCardException if the header could not be set.
+     * 
+     * @deprecated                     Use {@link #setValuesInHeader(Header)} instead
+     */
+    default void setValuesInHeader(IHeaderAccess header) throws HeaderCardException {
+        setValuesInHeader(header == null ? null : header.getHeader());
+    }
+
+    /**
+     * set the options values, that are hdu based, into the header.
+     *
      * @param  header              the header to set the option value
      *
      * @throws HeaderCardException if the header could not be set.
      */
-    void setValuesInHeader(IHeaderAccess header) throws HeaderCardException;
-
+    void setValuesInHeader(Header header) throws HeaderCardException;
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/IHeaderAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/IHeaderAccess.java
@@ -56,8 +56,23 @@ import nom.tam.fits.header.IFitsHeader;
  * </p>
  * 
  * @see Header
+ * @deprecated This internal interface serves no purpose since 1.19. Will remove
+ *             in some future. Prior to 1.19 {@link Header} threw hard
+ *             {@link HeaderCardException}, and this class was added so we can
+ *             convert these into soft {@link IllegalArgumentException} instead.
+ *             However, now that we demoted <code>HeaderCardException</code> to
+ *             be soft exceptions itself, there is no reason to convert. It just
+ *             adds confusion.
  */
 public interface IHeaderAccess {
+
+    /**
+     * Returns the header that this class is providing access to.
+     * 
+     * @return the Header that we access through this class
+     * @since 1.19
+     */
+    Header getHeader();
 
     /**
      * Sets a new integer value for the specified FITS keyword, adding it to the
@@ -69,6 +84,7 @@ public interface IHeaderAccess {
      *            the integer value to assign to the keyword
      * @throws IllegalArgumentException
      *             if the value could not be set as requested.
+     * @deprecated Just add values to the header directly
      */
     void addValue(IFitsHeader key, int value) throws IllegalArgumentException;
 
@@ -82,6 +98,7 @@ public interface IHeaderAccess {
      *            the string value to assign to the keyword
      * @throws IllegalArgumentException
      *             if the value could not be set as requested.
+     * @deprecated Just add values to the header directly
      */
     void addValue(IFitsHeader key, String value) throws IllegalArgumentException;
 
@@ -92,8 +109,9 @@ public interface IHeaderAccess {
      * 
      * @param key
      *            the standard or conventional FITS header keyword
-     * @return the matching FITS header card, or <code>null</code> if there is
-     *         no such card within out grasp.
+     * @return the matching FITS header card, or <code>null</code> if there is no
+     *         such card within out grasp.
+     * @deprecated Use {@link Header#getCard(IFitsHeader)} instead.
      */
     HeaderCard findCard(IFitsHeader key);
 
@@ -104,8 +122,9 @@ public interface IHeaderAccess {
      * 
      * @param key
      *            the FITS header keyword
-     * @return the matching FITS header card, or <code>null</code> if there is
-     *         no such card within out grasp.
+     * @return the matching FITS header card, or <code>null</code> if there is no
+     *         such card within out grasp.
+     * @deprecated Use {@link Header#getCard(String)} instead.
      */
     HeaderCard findCard(String key);
 

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/IHeaderAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/IHeaderAccess.java
@@ -39,30 +39,25 @@ import nom.tam.fits.header.IFitsHeader;
 
 /**
  * <p>
- * (<i>for internal use</i>) Interface for accessing FITS header values with
- * runtime exceptions only. Regular header access throws
- * {@link HeaderCardException}s, which are hard exceptions. They really should
- * have been softer runtime exceptions from the start, but unfortunately that
- * was choice this library made a very long time ago, and we therefore stick to
- * it, at least until the next major code revision (major version 2 at the
- * earliest). So this class provides an alternative access to headers converting
- * any <code>HeaderCardException</code>s to {@link IllegalArgumentException}.
+ * (<i>for internal use</i>) Interface for accessing FITS header values with runtime exceptions only. Regular header
+ * access throws {@link HeaderCardException}s, which are hard exceptions. They really should have been softer runtime
+ * exceptions from the start, but unfortunately that was choice this library made a very long time ago, and we therefore
+ * stick to it, at least until the next major code revision (major version 2 at the earliest). So this class provides an
+ * alternative access to headers converting any <code>HeaderCardException</code>s to {@link IllegalArgumentException}.
  * </p>
  * <p>
- * This is really just a rusty rail implementation, and rather incopmlete at it
- * too. It has very limited support for header access, geared very specifically
- * towards supporting the compression classes of this library, and not mean for
+ * This is really just a rusty rail implementation, and rather incopmlete at it too. It has very limited support for
+ * header access, geared very specifically towards supporting the compression classes of this library, and not mean for
  * use beyond.
  * </p>
  * 
- * @see Header
- * @deprecated This internal interface serves no purpose since 1.19. Will remove
- *             in some future. Prior to 1.19 {@link Header} threw hard
- *             {@link HeaderCardException}, and this class was added so we can
- *             convert these into soft {@link IllegalArgumentException} instead.
- *             However, now that we demoted <code>HeaderCardException</code> to
- *             be soft exceptions itself, there is no reason to convert. It just
- *             adds confusion.
+ * @see        Header
+ * 
+ * @deprecated This internal interface serves no purpose since 1.19. Will remove in some future. Prior to 1.19
+ *                 {@link Header} threw hard {@link HeaderCardException}, and this class was added so we can convert
+ *                 these into soft {@link IllegalArgumentException} instead. However, now that we demoted
+ *                 <code>HeaderCardException</code> to be soft exceptions itself, there is no reason to convert. It just
+ *                 adds confusion.
  */
 public interface IHeaderAccess {
 
@@ -70,62 +65,65 @@ public interface IHeaderAccess {
      * Returns the header that this class is providing access to.
      * 
      * @return the Header that we access through this class
-     * @since 1.19
+     * 
+     * @since  1.19
      */
     Header getHeader();
 
     /**
-     * Sets a new integer value for the specified FITS keyword, adding it to the
-     * FITS header if necessary.
+     * Sets a new integer value for the specified FITS keyword, adding it to the FITS header if necessary.
      * 
-     * @param key
-     *            the standard or conventional FITS header keyword
-     * @param value
-     *            the integer value to assign to the keyword
-     * @throws IllegalArgumentException
-     *             if the value could not be set as requested.
-     * @deprecated Just add values to the header directly
+     * @param      key                      the standard or conventional FITS header keyword
+     * @param      value                    the integer value to assign to the keyword
+     * 
+     * @throws     IllegalArgumentException if the value could not be set as requested.
+     * 
+     * @deprecated                          Just add values to the header directly
      */
-    void addValue(IFitsHeader key, int value) throws IllegalArgumentException;
+    default void addValue(IFitsHeader key, int value) throws IllegalArgumentException {
+        getHeader().addValue(key, value);
+    }
 
     /**
-     * Sets a new string value for the specified FITS keyword, adding it to the
-     * FITS header if necessary.
+     * Sets a new string value for the specified FITS keyword, adding it to the FITS header if necessary.
      * 
-     * @param key
-     *            the standard or conventional FITS header keyword
-     * @param value
-     *            the string value to assign to the keyword
-     * @throws IllegalArgumentException
-     *             if the value could not be set as requested.
-     * @deprecated Just add values to the header directly
+     * @param      key                      the standard or conventional FITS header keyword
+     * @param      value                    the string value to assign to the keyword
+     * 
+     * @throws     IllegalArgumentException if the value could not be set as requested.
+     * 
+     * @deprecated                          Just add values to the header directly
      */
-    void addValue(IFitsHeader key, String value) throws IllegalArgumentException;
+    default void addValue(IFitsHeader key, String value) throws IllegalArgumentException {
+        getHeader().addValue(key, value);
+    }
 
     /**
-     * Returns the FITS header card for the given FITS keyword. It does not set
-     * a mark in the header for new additions, making it more similar to
-     * {@link Header#getCard(IFitsHeader)}.
+     * Returns the FITS header card for the given FITS keyword. It does not set a mark in the header for new additions,
+     * making it more similar to {@link Header#getCard(IFitsHeader)}.
      * 
-     * @param key
-     *            the standard or conventional FITS header keyword
-     * @return the matching FITS header card, or <code>null</code> if there is no
-     *         such card within out grasp.
-     * @deprecated Use {@link Header#getCard(IFitsHeader)} instead.
+     * @param      key the standard or conventional FITS header keyword
+     * 
+     * @return         the matching FITS header card, or <code>null</code> if there is no such card within out grasp.
+     * 
+     * @deprecated     Use {@link Header#getCard(IFitsHeader)} instead.
      */
-    HeaderCard findCard(IFitsHeader key);
+    default HeaderCard findCard(IFitsHeader key) {
+        return getHeader().findCard(key);
+    }
 
     /**
-     * Returns the FITS header card for the given FITS keyword. It does not set
-     * a mark in the header for new additions, making it more similar to
-     * {@link Header#getCard(String)}.
+     * Returns the FITS header card for the given FITS keyword. It does not set a mark in the header for new additions,
+     * making it more similar to {@link Header#getCard(String)}.
      * 
-     * @param key
-     *            the FITS header keyword
-     * @return the matching FITS header card, or <code>null</code> if there is no
-     *         such card within out grasp.
-     * @deprecated Use {@link Header#getCard(String)} instead.
+     * @param      key the FITS header keyword
+     * 
+     * @return         the matching FITS header card, or <code>null</code> if there is no such card within out grasp.
+     * 
+     * @deprecated     Use {@link Header#getCard(String)} instead.
      */
-    HeaderCard findCard(String key);
+    default HeaderCard findCard(String key) {
+        return getHeader().findCard(key);
+    }
 
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
@@ -1,6 +1,8 @@
 package nom.tam.fits.compression.provider.param.base;
 
+import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.provider.param.api.ICompressHeaderParameter;
 import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 
@@ -51,23 +53,55 @@ public abstract class CompressHeaderParameter<OPTION> extends CompressParameter<
         super(name, option);
     }
 
+    /**
+     * @deprecated Use {@link #findZVal(Header)} instead.
+     */
     public HeaderCard findZVal(IHeaderAccess header) {
+        return findZVal(header.getHeader());
+    }
+
+    /**
+     * @deprecated Use {@link #nextFreeZVal(Header)} instead.
+     */
+    public int nextFreeZVal(IHeaderAccess header) {
+        return nextFreeZVal(header.getHeader());
+    }
+
+    /**
+     * Finds the ZVAL header value corresponding to this compression parameter
+     * 
+     * @param  header              The compressed HDU header
+     * 
+     * @return                     the header card containing the ZVAL for this compression parameter
+     * 
+     * @throws HeaderCardException if there was an issue accessing the header
+     */
+    public HeaderCard findZVal(Header header) throws HeaderCardException {
         int nval = 1;
-        HeaderCard card = header.findCard(ZNAMEn.n(nval));
+        HeaderCard card = header.getCard(ZNAMEn.n(nval));
         while (card != null) {
             if (card.getValue().equals(getName())) {
-                return header.findCard(ZVALn.n(nval));
+                return header.getCard(ZVALn.n(nval));
             }
-            card = header.findCard(ZNAMEn.n(++nval));
+            card = header.getCard(ZNAMEn.n(++nval));
         }
         return null;
     }
 
-    public int nextFreeZVal(IHeaderAccess header) {
+    /**
+     * Finds next unused ZNAME / ZVAL index in the header, that we can use to store this parameter
+     * 
+     * @param  header              The compressed HDU header
+     * 
+     * @return                     the ZNAME / ZVAL index we might use to store a new parameter
+     * 
+     * @throws HeaderCardException if there was an issue accessing the header
+     */
+    public int nextFreeZVal(Header header) throws HeaderCardException {
         int nval = 1;
-        HeaderCard card = header.findCard(ZNAMEn.n(nval));
+        HeaderCard card = header.getCard(ZNAMEn.n(nval));
         while (card != null) {
-            card = header.findCard(ZNAMEn.n(++nval));
+            card = header.getCard(ZNAMEn.n(++nval));
         }
         return nval;
     }

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
@@ -9,7 +9,6 @@ import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.provider.param.api.ICompressColumnParameter;
 import nom.tam.fits.compression.provider.param.api.ICompressHeaderParameter;
 import nom.tam.fits.compression.provider.param.api.ICompressParameters;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 
 /*
  * #%L
@@ -110,11 +109,6 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
         for (ICompressColumnParameter parameter : columnParameters()) {
             parameter.setValueInColumn(index);
         }
-    }
-
-    @Deprecated
-    private Object getNullableColumn(IHeaderAccess header, BinaryTable binaryTable, String columnName) {
-        return getNullableColumn(header.getHeader(), binaryTable, columnName);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
@@ -3,6 +3,7 @@ package nom.tam.fits.compression.provider.param.base;
 import nom.tam.fits.BinaryTable;
 import nom.tam.fits.BinaryTableHDU;
 import nom.tam.fits.FitsException;
+import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.provider.param.api.ICompressColumnParameter;
@@ -49,6 +50,7 @@ import static nom.tam.fits.header.Standard.TTYPEn;
  * 
  * @see CompressParameter
  */
+@SuppressWarnings("deprecation")
 public abstract class CompressParameters implements ICompressParameters, Cloneable {
 
     @Override
@@ -82,14 +84,15 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
     }
 
     @Override
-    public void getValuesFromHeader(IHeaderAccess header) {
+    public void getValuesFromHeader(Header header) throws HeaderCardException {
         for (ICompressHeaderParameter compressionParameter : headerParameters()) {
             compressionParameter.getValueFromHeader(header);
         }
     }
 
     @Override
-    public void initializeColumns(IHeaderAccess header, BinaryTable binaryTable, int size) throws FitsException {
+    public void initializeColumns(Header header, BinaryTable binaryTable, int size)
+            throws HeaderCardException, FitsException {
         for (ICompressColumnParameter parameter : columnParameters()) {
             parameter.setColumnData(getNullableColumn(header, binaryTable, parameter.getName()), size);
         }
@@ -109,17 +112,22 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
         }
     }
 
+    @Deprecated
+    private Object getNullableColumn(IHeaderAccess header, BinaryTable binaryTable, String columnName) {
+        return getNullableColumn(header.getHeader(), binaryTable, columnName);
+    }
+
     @Override
-    public void setValuesInHeader(IHeaderAccess header) throws HeaderCardException {
+    public void setValuesInHeader(Header header) throws HeaderCardException {
         for (ICompressHeaderParameter parameter : headerParameters()) {
             parameter.setValueInHeader(header);
         }
     }
 
-    private Object getNullableColumn(IHeaderAccess header, BinaryTable binaryTable, String columnName)
-            throws FitsException {
+    private Object getNullableColumn(Header header, BinaryTable binaryTable, String columnName)
+            throws HeaderCardException, FitsException {
         for (int i = 1; i <= binaryTable.getNCols(); i++) {
-            HeaderCard card = header.findCard(TTYPEn.n(i));
+            HeaderCard card = header.getCard(TTYPEn.n(i));
             if (card != null) {
                 if (card.getValue().trim().equals(columnName)) {
                     return binaryTable.getColumn(i - 1);

--- a/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressScaleParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressScaleParameter.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.compression.provider.param.hcompress;
 
+import nom.tam.fits.Header;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -32,8 +34,8 @@ package nom.tam.fits.compression.provider.param.hcompress;
  */
 
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressorOption;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
 import nom.tam.fits.header.Compression;
 
@@ -50,7 +52,7 @@ public final class HCompressScaleParameter extends CompressHeaderParameter<HComp
     }
 
     @Override
-    public void getValueFromHeader(IHeaderAccess header) {
+    public void getValueFromHeader(Header header) throws HeaderCardException {
         HeaderCard value = findZVal(header);
         if (value != null) {
             getOption().setScale(value.getValue(Double.class, 0.0));
@@ -58,7 +60,7 @@ public final class HCompressScaleParameter extends CompressHeaderParameter<HComp
     }
 
     @Override
-    public void setValueInHeader(IHeaderAccess header) {
+    public void setValueInHeader(Header header) throws HeaderCardException {
         int zvalIndex = nextFreeZVal(header);
         header.addValue(Compression.ZNAMEn.n(zvalIndex), getName());
         header.addValue(Compression.ZVALn.n(zvalIndex), getOption().getScale());

--- a/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressSmoothParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressSmoothParameter.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.compression.provider.param.hcompress;
 
+import nom.tam.fits.Header;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -32,8 +34,8 @@ package nom.tam.fits.compression.provider.param.hcompress;
  */
 
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressorOption;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
 import nom.tam.fits.header.Compression;
 
@@ -50,7 +52,7 @@ public final class HCompressSmoothParameter extends CompressHeaderParameter<HCom
     }
 
     @Override
-    public void getValueFromHeader(IHeaderAccess header) {
+    public void getValueFromHeader(Header header) throws HeaderCardException {
         HeaderCard value = findZVal(header);
         if (value != null) {
             getOption().setSmooth(value.getValue(Integer.class, 0) != 0);
@@ -58,7 +60,7 @@ public final class HCompressSmoothParameter extends CompressHeaderParameter<HCom
     }
 
     @Override
-    public void setValueInHeader(IHeaderAccess header) {
+    public void setValueInHeader(Header header) throws HeaderCardException {
         int zvalIndex = nextFreeZVal(header);
         header.addValue(Compression.ZNAMEn.n(zvalIndex), getName());
         header.addValue(Compression.ZVALn.n(zvalIndex), getOption().isSmooth() ? 1 : 0);

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankParameter.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.compression.provider.param.quant;
 
+import nom.tam.fits.Header;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -32,8 +34,8 @@ package nom.tam.fits.compression.provider.param.quant;
  */
 
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
 import nom.tam.fits.header.Compression;
 
@@ -47,19 +49,19 @@ final class ZBlankParameter extends CompressHeaderParameter<QuantizeOption> {
     }
 
     @Override
-    public void getValueFromHeader(IHeaderAccess header) {
+    public void getValueFromHeader(Header header) throws HeaderCardException {
         if (getOption() == null) {
             return;
         }
 
-        HeaderCard card = header.findCard(getName());
+        HeaderCard card = header.getCard(getName());
         if (card != null) {
             getOption().setBNull(card.getValue(Integer.class, getOption().getBNull()));
         }
     }
 
     @Override
-    public void setValueInHeader(IHeaderAccess header) {
+    public void setValueInHeader(Header header) throws HeaderCardException {
         if (getOption() == null) {
             return;
         }

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.compression.provider.param.quant;
 
+import nom.tam.fits.Header;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -32,8 +34,8 @@ package nom.tam.fits.compression.provider.param.quant;
  */
 
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
 import nom.tam.fits.header.Compression;
 
@@ -81,17 +83,17 @@ final class ZDither0Parameter extends CompressHeaderParameter<QuantizeOption> {
     }
 
     @Override
-    public void getValueFromHeader(IHeaderAccess header) {
+    public void getValueFromHeader(Header header) throws HeaderCardException {
         if (getOption() == null) {
             return;
         }
 
-        HeaderCard card = header.findCard(Compression.ZDITHER0);
+        HeaderCard card = header.getCard(Compression.ZDITHER0);
         getOption().setSeed(card == null ? 1L : card.getValue(Long.class, 1L));
     }
 
     @Override
-    public void setValueInHeader(IHeaderAccess header) {
+    public void setValueInHeader(Header header) throws HeaderCardException {
         if (getOption() == null) {
             return;
         }

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZQuantizeParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZQuantizeParameter.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.compression.provider.param.quant;
 
+import nom.tam.fits.Header;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -32,8 +34,8 @@ package nom.tam.fits.compression.provider.param.quant;
  */
 
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
 import nom.tam.fits.header.Compression;
 
@@ -47,12 +49,12 @@ final class ZQuantizeParameter extends CompressHeaderParameter<QuantizeOption> {
     }
 
     @Override
-    public void getValueFromHeader(IHeaderAccess header) {
+    public void getValueFromHeader(Header header) throws HeaderCardException {
         if (getOption() == null) {
             return;
         }
 
-        HeaderCard card = header.findCard(getName());
+        HeaderCard card = header.getCard(getName());
         String value = card != null ? card.getValue() : null;
 
         getOption().setDither(false);
@@ -67,7 +69,7 @@ final class ZQuantizeParameter extends CompressHeaderParameter<QuantizeOption> {
     }
 
     @Override
-    public void setValueInHeader(IHeaderAccess header) {
+    public void setValueInHeader(Header header) throws HeaderCardException {
         if (getOption() == null) {
             return;
         }

--- a/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBlockSizeParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBlockSizeParameter.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.compression.provider.param.rice;
 
+import nom.tam.fits.Header;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -32,6 +34,7 @@ package nom.tam.fits.compression.provider.param.rice;
  */
 
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
@@ -40,6 +43,7 @@ import nom.tam.fits.header.Compression;
 /**
  * (<i>for internal use</i>) The block size value for the Rice compression as recorded in the FITS header.
  */
+@SuppressWarnings("deprecation")
 public final class RiceBlockSizeParameter extends CompressHeaderParameter<RiceCompressOption> {
 
     /**
@@ -51,6 +55,7 @@ public final class RiceBlockSizeParameter extends CompressHeaderParameter<RiceCo
         super(Compression.BLOCKSIZE, riceCompressOption);
     }
 
+    @Deprecated
     @Override
     public void getValueFromHeader(IHeaderAccess header) {
         HeaderCard value = super.findZVal(header);
@@ -61,8 +66,26 @@ public final class RiceBlockSizeParameter extends CompressHeaderParameter<RiceCo
         }
     }
 
+    @Deprecated
     @Override
     public void setValueInHeader(IHeaderAccess header) {
+        int zvalIndex = nextFreeZVal(header);
+        header.addValue(Compression.ZNAMEn.n(zvalIndex), getName());
+        header.addValue(Compression.ZVALn.n(zvalIndex), getOption().getBlockSize());
+    }
+
+    @Override
+    public void getValueFromHeader(Header header) throws HeaderCardException {
+        HeaderCard value = super.findZVal(header);
+        if (value != null) {
+            getOption().setBlockSize(value.getValue(Integer.class, getOption().getBlockSize()));
+        } else {
+            getOption().setBlockSize(RiceCompressOption.DEFAULT_RICE_BLOCKSIZE);
+        }
+    }
+
+    @Override
+    public void setValueInHeader(Header header) throws HeaderCardException {
         int zvalIndex = nextFreeZVal(header);
         header.addValue(Compression.ZNAMEn.n(zvalIndex), getName());
         header.addValue(Compression.ZVALn.n(zvalIndex), getOption().getBlockSize());

--- a/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBlockSizeParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBlockSizeParameter.java
@@ -36,14 +36,12 @@ import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
 import nom.tam.fits.header.Compression;
 
 /**
  * (<i>for internal use</i>) The block size value for the Rice compression as recorded in the FITS header.
  */
-@SuppressWarnings("deprecation")
 public final class RiceBlockSizeParameter extends CompressHeaderParameter<RiceCompressOption> {
 
     /**
@@ -53,25 +51,6 @@ public final class RiceBlockSizeParameter extends CompressHeaderParameter<RiceCo
     @SuppressWarnings("javadoc")
     public RiceBlockSizeParameter(RiceCompressOption riceCompressOption) {
         super(Compression.BLOCKSIZE, riceCompressOption);
-    }
-
-    @Deprecated
-    @Override
-    public void getValueFromHeader(IHeaderAccess header) {
-        HeaderCard value = super.findZVal(header);
-        if (value != null) {
-            getOption().setBlockSize(value.getValue(Integer.class, getOption().getBlockSize()));
-        } else {
-            getOption().setBlockSize(RiceCompressOption.DEFAULT_RICE_BLOCKSIZE);
-        }
-    }
-
-    @Deprecated
-    @Override
-    public void setValueInHeader(IHeaderAccess header) {
-        int zvalIndex = nextFreeZVal(header);
-        header.addValue(Compression.ZNAMEn.n(zvalIndex), getName());
-        header.addValue(Compression.ZVALn.n(zvalIndex), getOption().getBlockSize());
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBytePixParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBytePixParameter.java
@@ -36,14 +36,12 @@ import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
 import nom.tam.fits.header.Compression;
 
 /**
  * (<i>for internal use</i>) The BYTEPIX value for the Rice compression as recorded in the FITS header.
  */
-@SuppressWarnings("deprecation")
 public final class RiceBytePixParameter extends CompressHeaderParameter<RiceCompressOption> {
 
     /**
@@ -53,25 +51,6 @@ public final class RiceBytePixParameter extends CompressHeaderParameter<RiceComp
     @SuppressWarnings("javadoc")
     public RiceBytePixParameter(RiceCompressOption riceCompressOption) {
         super(Compression.BYTEPIX, riceCompressOption);
-    }
-
-    @Deprecated
-    @Override
-    public void getValueFromHeader(IHeaderAccess header) {
-        HeaderCard value = findZVal(header);
-        if (value != null) {
-            getOption().setBytePix(value.getValue(Integer.class, getOption().getBytePix()));
-        } else {
-            getOption().setBytePix(RiceCompressOption.DEFAULT_RICE_BYTEPIX);
-        }
-    }
-
-    @Deprecated
-    @Override
-    public void setValueInHeader(IHeaderAccess header) {
-        int zvalIndex = nextFreeZVal(header);
-        header.addValue(Compression.ZNAMEn.n(zvalIndex), getName());
-        header.addValue(Compression.ZVALn.n(zvalIndex), getOption().getBytePix());
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBytePixParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBytePixParameter.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.compression.provider.param.rice;
 
+import nom.tam.fits.Header;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -32,6 +34,7 @@ package nom.tam.fits.compression.provider.param.rice;
  */
 
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
 import nom.tam.fits.compression.provider.param.base.CompressHeaderParameter;
@@ -40,6 +43,7 @@ import nom.tam.fits.header.Compression;
 /**
  * (<i>for internal use</i>) The BYTEPIX value for the Rice compression as recorded in the FITS header.
  */
+@SuppressWarnings("deprecation")
 public final class RiceBytePixParameter extends CompressHeaderParameter<RiceCompressOption> {
 
     /**
@@ -51,6 +55,7 @@ public final class RiceBytePixParameter extends CompressHeaderParameter<RiceComp
         super(Compression.BYTEPIX, riceCompressOption);
     }
 
+    @Deprecated
     @Override
     public void getValueFromHeader(IHeaderAccess header) {
         HeaderCard value = findZVal(header);
@@ -61,8 +66,26 @@ public final class RiceBytePixParameter extends CompressHeaderParameter<RiceComp
         }
     }
 
+    @Deprecated
     @Override
     public void setValueInHeader(IHeaderAccess header) {
+        int zvalIndex = nextFreeZVal(header);
+        header.addValue(Compression.ZNAMEn.n(zvalIndex), getName());
+        header.addValue(Compression.ZVALn.n(zvalIndex), getOption().getBytePix());
+    }
+
+    @Override
+    public void getValueFromHeader(Header header) throws HeaderCardException {
+        HeaderCard value = findZVal(header);
+        if (value != null) {
+            getOption().setBytePix(value.getValue(Integer.class, getOption().getBytePix()));
+        } else {
+            getOption().setBytePix(RiceCompressOption.DEFAULT_RICE_BYTEPIX);
+        }
+    }
+
+    @Override
+    public void setValueInHeader(Header header) throws HeaderCardException {
         int zvalIndex = nextFreeZVal(header);
         header.addValue(Compression.ZNAMEn.n(zvalIndex), getName());
         header.addValue(Compression.ZVALn.n(zvalIndex), getOption().getBytePix());

--- a/src/main/java/nom/tam/image/compression/tile/TileDecompressorInitialisation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileDecompressorInitialisation.java
@@ -1,7 +1,7 @@
 package nom.tam.image.compression.tile;
 
 import nom.tam.fits.FitsException;
-import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
+import nom.tam.fits.Header;
 import nom.tam.image.tile.operation.ITileOperationInitialisation;
 import nom.tam.image.tile.operation.TileArea;
 
@@ -48,14 +48,14 @@ final class TileDecompressorInitialisation implements ITileOperationInitialisati
 
     private final Object[] gzipCompressed;
 
-    private final IHeaderAccess header;
+    private final Header header;
 
     private final TiledImageCompressionOperation imageTilesOperation;
 
     private int compressedOffset = 0;
 
     protected TileDecompressorInitialisation(TiledImageCompressionOperation imageTilesOperation, Object[] uncompressed,
-            Object[] compressed, Object[] gzipCompressed, IHeaderAccess header) {
+            Object[] compressed, Object[] gzipCompressed, Header header) {
         this.imageTilesOperation = imageTilesOperation;
         this.uncompressed = uncompressed;
         this.compressed = compressed;

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -18,7 +18,6 @@ import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.fits.compression.provider.CompressorProvider;
 import nom.tam.fits.compression.provider.param.api.HeaderAccess;
-import nom.tam.fits.compression.provider.param.api.HeaderCardAccess;
 import nom.tam.fits.header.Compression;
 import nom.tam.image.compression.tile.mask.ImageNullPixelMask;
 import nom.tam.image.tile.operation.AbstractTiledImageOperation;
@@ -147,8 +146,9 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
             getCompressorControl();
             compressOptions = compressorControl.option();
             if (quantAlgorithm != null) {
-                compressOptions.getCompressionParameters()
-                        .getValuesFromHeader(new HeaderCardAccess(ZQUANTIZ, quantAlgorithm));
+                Header h = new Header();
+                h.addLine(HeaderCard.create(ZQUANTIZ, quantAlgorithm));
+                compressOptions.getCompressionParameters().getValuesFromHeader(h);
             }
             compressOptions.getCompressionParameters().initializeColumns(getNumberOfTileOperations());
         }
@@ -267,7 +267,7 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
                 getNullableColumn(header, Object[].class, UNCOMPRESSED_DATA_COLUMN), //
                 getNullableColumn(header, Object[].class, COMPRESSED_DATA_COLUMN), //
                 getNullableColumn(header, Object[].class, GZIP_COMPRESSED_DATA_COLUMN), //
-                new HeaderAccess(header)));
+                header));
         byte[][] nullPixels = getNullableColumn(header, byte[][].class, NULL_PIXEL_MASK_COLUMN);
         if (nullPixels != null) {
             preserveNulls(0L, header.getStringValue(ZMASKCMP)).setColumn(nullPixels);

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -239,12 +239,14 @@ public final class ArrayFuncs {
     /**
      * Curl an input array up into a multi-dimensional array.
      *
-     * @param  input  The one dimensional array to be curled.
-     * @param  dimens The desired dimensions
+     * @param  input                 The one dimensional array to be curled.
+     * @param  dimens                The desired dimensions
      *
-     * @return        The curled array.
+     * @return                       The curled array.
+     * 
+     * @throws IllegalStateException if the size of the input does not match the specified dimensions.
      */
-    public static Object curl(Object input, int... dimens) {
+    public static Object curl(Object input, int... dimens) throws IllegalStateException {
         if (input == null) {
             return null;
         }

--- a/src/main/java/nom/tam/util/BufferEncoder.java
+++ b/src/main/java/nom/tam/util/BufferEncoder.java
@@ -127,7 +127,7 @@ public abstract class BufferEncoder extends FitsEncoder {
      * @throws IllegalStateException if there was an IO error flushing the conversion buffer or writing the new byte
      *                                   after it.
      */
-    protected void writeUncheckedByte(byte b) {
+    protected void writeUncheckedByte(byte b) throws IllegalStateException {
         try {
             flush();
             write(b);

--- a/src/test/java/nom/tam/fits/compression/provider/CompressionProviderTest.java
+++ b/src/test/java/nom/tam/fits/compression/provider/CompressionProviderTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.algorithm.api.ICompressorControl;
+import nom.tam.fits.compression.provider.param.api.HeaderAccess;
 import nom.tam.fits.compression.provider.param.api.ICompressParameters;
 
 public class CompressionProviderTest {
@@ -46,7 +47,7 @@ public class CompressionProviderTest {
         ICompressorControl compressor = CompressorProvider.findCompressorControl(null, "GZIP_1", byte.class);
         ICompressOption option = compressor.option();
         Assert.assertFalse(option.isLossyCompression());
-        option.setParameters(null); // nothinh should happen ;-)
+        option.setParameters(null); // nothing should happen ;-)
         Assert.assertNull(option.unwrap(String.class));
         Assert.assertSame(option, option.unwrap(ICompressOption.class));
     }
@@ -57,9 +58,9 @@ public class CompressionProviderTest {
         ICompressOption option = compressor.option();
         ICompressParameters parameters = option.getCompressionParameters();
 
-        parameters.addColumnsToTable(null);// nothinh should happen ;-)
+        parameters.addColumnsToTable(null);// nothing should happen ;-)
         Assert.assertSame(parameters, parameters.copy(option));
-        parameters.setValuesInColumn(10000);// nothinh should happen ;-)
-        parameters.setValuesInHeader(null);// nothinh should happen ;-)
+        parameters.setValuesInColumn(10000);// nothing should happen ;-)
+        parameters.setValuesInHeader((HeaderAccess) null);// nothing should happen ;-)
     }
 }

--- a/src/test/java/nom/tam/image/compression/HeaderAccessTest.java
+++ b/src/test/java/nom/tam/image/compression/HeaderAccessTest.java
@@ -1,0 +1,136 @@
+package nom.tam.image.compression;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2023 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import nom.tam.fits.Header;
+import nom.tam.fits.HeaderCard;
+import nom.tam.fits.compression.algorithm.hcompress.HCompressorOption;
+import nom.tam.fits.compression.provider.param.api.HeaderAccess;
+import nom.tam.fits.compression.provider.param.api.HeaderCardAccess;
+import nom.tam.fits.compression.provider.param.api.ICompressHeaderParameter;
+import nom.tam.fits.compression.provider.param.hcompress.HCompressParameters;
+import nom.tam.fits.header.Standard;
+
+@SuppressWarnings("deprecation")
+public class HeaderAccessTest {
+
+    @Test
+    public void testIHeaderAccessDefaultMethods() throws Exception {
+        Header h = new Header();
+        HeaderAccess ha = new HeaderAccess(h);
+
+        ha.addValue(Standard.BITPIX, 32);
+        ha.addValue(Standard.XTENSION, "Test");
+
+        HeaderCard c = ha.findCard(Standard.BITPIX);
+        Assert.assertNotNull(c);
+        Assert.assertEquals(Standard.BITPIX.key(), c.getKey());
+        Assert.assertEquals(32, (int) c.getValue(Integer.class, -1));
+
+        c = ha.findCard(Standard.XTENSION);
+        Assert.assertNotNull(c);
+        Assert.assertEquals(Standard.XTENSION.key(), c.getKey());
+        Assert.assertEquals("Test", c.getValue());
+    }
+
+    @Test
+    public void testIHeaderCardAccess() throws Exception {
+        HeaderCardAccess ha = new HeaderCardAccess(Standard.AUTHOR, "Test");
+
+        Header h = ha.getHeader();
+        Assert.assertNotNull(h);
+        Assert.assertEquals(1, h.getNumberOfCards());
+        Assert.assertTrue(h.containsKey(Standard.AUTHOR));
+
+        Assert.assertEquals(Standard.AUTHOR.key(), ha.getHeaderCard().getKey());
+        Assert.assertEquals("Test", ha.getHeaderCard().getValue());
+
+        ha.addValue(Standard.BITPIX, 32);
+        Assert.assertNull(ha.findCard(Standard.BITPIX));
+
+        ha.addValue(Standard.XTENSION, 32);
+        Assert.assertNull(ha.findCard(Standard.XTENSION));
+    }
+
+    @Test
+    public void testCompressParameter() throws Exception {
+
+        Header h = new Header();
+        HeaderAccess ha = new HeaderAccess(h);
+
+        final HCompressorOption o1 = new HCompressorOption();
+        o1.setScale(2);
+        o1.setSmooth(true);
+
+        final HCompressorOption o2 = new HCompressorOption();
+        o2.setScale(3);
+        o2.setSmooth(false);
+
+        class AccessibleParms extends HCompressParameters {
+            public AccessibleParms(HCompressorOption o) {
+                super(o);
+            }
+
+            @Override
+            public ICompressHeaderParameter[] headerParameters() {
+                return super.headerParameters();
+            }
+        }
+
+        AccessibleParms hp1 = new AccessibleParms(o1);
+        AccessibleParms hp2 = new AccessibleParms(o2);
+
+        // Write o1 parameters into the header, and read them back into o2 individually
+        hp1.setValuesInHeader(ha);
+        for (ICompressHeaderParameter p2 : hp2.headerParameters()) {
+            p2.getValueFromHeader(ha);
+        }
+
+        Assert.assertEquals(2, o2.getScale());
+        Assert.assertTrue(o2.isSmooth());
+
+        o2.setScale(3);
+        o2.setSmooth(false);
+
+        // Write a different o1 into header individually, and read them back into o2 together
+        for (ICompressHeaderParameter p2 : hp2.headerParameters()) {
+            p2.setValueInHeader(ha);
+        }
+        hp1.getValuesFromHeader(ha);
+
+        Assert.assertEquals(3, o1.getScale());
+        Assert.assertFalse(o1.isSmooth());
+    }
+}

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
@@ -14,7 +14,6 @@ import nom.tam.fits.BinaryTable;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.FitsFactory;
 import nom.tam.fits.Header;
-import nom.tam.fits.HeaderCard;
 import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.algorithm.api.ICompressor;
@@ -22,7 +21,6 @@ import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 import nom.tam.fits.compression.provider.CompressorProvider;
 import nom.tam.fits.compression.provider.TileCompressorAlternativProvider;
-import nom.tam.fits.compression.provider.param.api.HeaderAccess;
 import nom.tam.fits.compression.provider.param.api.HeaderCardAccess;
 import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.IFitsHeader;
@@ -300,30 +298,6 @@ public class TileCompressorProviderTest {
         };
         tileDecompressor.setCompressed(new byte[10], null);
         tileDecompressor.run();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void headerAccessExceptionIntTest() throws Exception {
-        HeaderAccess headerAccess = new HeaderAccess(new Header() {
-
-            @Override
-            public void addLine(HeaderCard fcard) {
-                ThrowAnyException.throwHeaderCardException("");
-            }
-        });
-        headerAccess.addValue(ZBITPIX, 32);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void headerAccessExceptionStringTest() throws Exception {
-        HeaderAccess headerAccess = new HeaderAccess(new Header() {
-
-            @Override
-            public void addLine(HeaderCard fcard) {
-                ThrowAnyException.throwHeaderCardException("");
-            }
-        });
-        headerAccess.addValue(ZCMPTYPE, "XXX");
     }
 
     @Test

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
@@ -264,7 +264,7 @@ public class TileCompressorProviderTest {
                 null, //
                 null, //
                 null, //
-                new HeaderAccess(header)));
+                header));
         // lets see if we can call the no loss function with no errors even if
         // it has no effect.
         operationsOfImage.forceNoLoss(1, 1, 10, 10);


### PR DESCRIPTION
Since the inception of this library `FitsException` was a hard exception that forced programmers to deal with it. However, it is much more similar to Java's `IllegalStateException` in concept and nature -- which is a soft runtime exception. Therefore, let's change `FitsException` (and its derivatives such as `HeaderCardExcepton`) to be a FITS-specific subclass of `IllegalStateException` going forward.

The change is entirely backward compatible from a developer's point of view. The `catch` blocks that were necessary before still work the same, only they are now optional.

As a result of the change the internal `nom.fits.compression.provider.param.api.IHeaderAccess` interface, its subclasses and usage have become obsoleted and unnecessary. These have been marked as deprecated to be removed in a future release (such as 2.0).