### PR TITLE
Methods to help selective access to compressed table tiles.

### DIFF
--- a/src/main/java/nom/tam/fits/PaddingException.java
+++ b/src/main/java/nom/tam/fits/PaddingException.java
@@ -32,11 +32,14 @@ package nom.tam.fits;
  */
 
 /**
- * This exception is thrown if padding is missing between the end of a FITS data segment and the end-of-file. This
- * padding is required by the FITS standard, but some FITS writers may not add it. As of 1.17 our `Fits` class deals
- * seamlessly with such data, since the missing padding at the end-of-file is harmless when reading in data. It will log
- * a warning but proceed normally. However, the exception is still thrown when using low-level
- * {@link Data#read(nom.tam.util.ArrayDataInput)} to allow expert users to deal with this issue in any way they see fit.
+ * This exception is thrown if padding is missing between the end of a FITS data
+ * segment and the end-of-file. This padding is required by the FITS standard,
+ * but some FITS writers may not add it. As of 1.17 our `Fits` class deals
+ * seamlessly with such data, since the missing padding at the end-of-file is
+ * harmless when reading in data. It will log a warning but proceed normally.
+ * However, the exception is still thrown when using low-level
+ * {@link Data#read(nom.tam.util.ArrayDataInput)} to allow expert users to deal
+ * with this issue in any way they see fit.
  */
 public class PaddingException extends FitsException {
 

--- a/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
@@ -37,11 +37,14 @@ import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.image.tile.operation.buffer.TileBuffer;
 
 /**
- * (<i>for internal use</i>) Base support for blank (<code>null</code>) in compressed images. In regular images specific
- * values (such as {@link Double#NaN} or a specific integer value) may be used to indicate missing data. However,
- * because of e.g. quantization or lossy compression, these specific values may not be recovered exactly when
- * compressing / decompressing images. Hence, there is a need to demark <code>null</code> values differently in
- * copmressed images. This class provides support for that purpose.
+ * (<i>for internal use</i>) Base support for blank (<code>null</code>) in
+ * compressed images. In regular images specific values (such as
+ * {@link Double#NaN} or a specific integer value) may be used to indicate
+ * missing data. However, because of e.g. quantization or lossy compression,
+ * these specific values may not be recovered exactly when compressing /
+ * decompressing images. Hence, there is a need to demark <code>null</code>
+ * values differently in copmressed images. This class provides support for that
+ * purpose.
  */
 public class AbstractNullPixelMask {
 
@@ -61,17 +64,22 @@ public class AbstractNullPixelMask {
     private final ICompressorControl compressorControl;
 
     /**
-     * Creates a new pixel mask got a given image tile and designated null value.
+     * Creates a new pixel mask got a given image tile and designated null
+     * value.
      * 
-     * @param  tileBuffer            the buffer containing the tile data
-     * @param  tileIndex             the tile index
-     * @param  nullValue             the integer value representing <code>null</code> or invalid data
-     * @param  compressorControl     The class managing the compression
-     * 
-     * @throws IllegalStateException if the compressorControl argument is <code>null</code>
+     * @param tileBuffer
+     *            the buffer containing the tile data
+     * @param tileIndex
+     *            the tile index
+     * @param nullValue
+     *            the integer value representing <code>null</code> or invalid
+     *            data
+     * @param compressorControl
+     *            The class managing the compression
+     * @throws IllegalStateException
+     *             if the compressorControl argument is <code>null</code>
      */
-    protected AbstractNullPixelMask(TileBuffer tileBuffer, int tileIndex, long nullValue,
-            ICompressorControl compressorControl) throws IllegalStateException {
+    protected AbstractNullPixelMask(TileBuffer tileBuffer, int tileIndex, long nullValue, ICompressorControl compressorControl) throws IllegalStateException {
         this.tileBuffer = tileBuffer;
         this.tileIndex = tileIndex;
         this.nullValue = nullValue;
@@ -84,9 +92,9 @@ public class AbstractNullPixelMask {
     /**
      * Returns a byte array containing the mask
      * 
-     * @return     the byte array containing the pixel mask for the tile.
-     * 
-     * @deprecated (<i>for internal use</i>) Visibility may be reduced to package level in the future.
+     * @return the byte array containing the pixel mask for the tile.
+     * @deprecated (<i>for internal use</i>) Visibility may be reduced to package
+     *             level in the future.
      */
     public byte[] getMaskBytes() {
         if (mask == null) {
@@ -102,14 +110,16 @@ public class AbstractNullPixelMask {
     /**
      * Sets data for a new mask as a flattened buffer of data.
      * 
-     * @param mask the buffer containing the mask data in flattened format.
+     * @param mask
+     *            the buffer containing the mask data in flattened format.
      */
     public void setMask(ByteBuffer mask) {
         this.mask = mask;
     }
 
     /**
-     * Returns the object that manages the compression, and which therefore handles the masking
+     * Returns the object that manages the compression, and which therefore
+     * handles the masking
      * 
      * @return the object that manages the compression.
      */
@@ -127,7 +137,8 @@ public class AbstractNullPixelMask {
     }
 
     /**
-     * Returns the value that represents a <code>null</code> or an undefined data point.
+     * Returns the value that represents a <code>null</code> or an undefined
+     * data point.
      * 
      * @return the value that demarks an undefined datum.
      */
@@ -154,11 +165,13 @@ public class AbstractNullPixelMask {
     }
 
     /**
-     * Creates an internal buffer for holding the mask data, for the specified number of points.
+     * Creates an internal buffer for holding the mask data, for the specified
+     * number of points.
      * 
-     * @param  remaining the number of points the mask should accomodate.
-     * 
-     * @return           the internal buffer that may store the mask data for the specified number of data points.
+     * @param remaining
+     *            the number of points the mask should accomodate.
+     * @return the internal buffer that may store the mask data for the specified
+     *         number of data points.
      */
     protected ByteBuffer initializedMask(int remaining) {
         if (mask == null) {

--- a/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
+++ b/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
@@ -294,9 +294,9 @@ public class CompressedTableTest {
                 .fromBinaryTableHDU((BinaryTableHDU) fitsUncompressed.getHDU(1), tileSize).compress();
         compressedTable.compress();
 
-        BinaryTableHDU hdu = compressedTable.asBinaryTableHDU(1, 3);
+        BinaryTableHDU hdu = compressedTable.asBinaryTableHDU(1);
 
-        Assert.assertEquals(2 * tileSize, hdu.getNRows());
+        Assert.assertEquals(tileSize, hdu.getNRows());
 
         BinaryTableHDU hdu0 = (BinaryTableHDU) fitsUncompressed.getHDU(1);
 

--- a/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
+++ b/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
@@ -13,8 +13,10 @@ import org.junit.Test;
 import nom.tam.fits.BinaryTable;
 import nom.tam.fits.BinaryTableHDU;
 import nom.tam.fits.Fits;
+import nom.tam.fits.FitsException;
 import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.Standard;
 import nom.tam.fits.util.BlackBoxImages;
@@ -405,6 +407,30 @@ public class CompressedTableTest {
                 .fromBinaryTableHDU((BinaryTableHDU) fitsUncompressed.getHDU(1), tileSize).compress();
         compressedTable.compress();
         compressedTable.getColumnData(0, 1, compressedTable.getNRows() + 1);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testB12TableDecompressNoZTILELEN() throws Exception {
+        Fits fitsUncompressed = new Fits("src/test/resources/nom/tam/table/comp/bt12.fits");
+        int tileSize = 5;
+
+        CompressedTableHDU compressedTable = CompressedTableHDU
+                .fromBinaryTableHDU((BinaryTableHDU) fitsUncompressed.getHDU(1), tileSize).compress();
+        compressedTable.compress();
+        compressedTable.getHeader().deleteKey(Compression.ZTILELEN);
+        compressedTable.getTileRows(); // Throws exception...
+    }
+
+    @Test(expected = FitsException.class)
+    public void testB12TableDecompressInvalidZTILELEN() throws Exception {
+        Fits fitsUncompressed = new Fits("src/test/resources/nom/tam/table/comp/bt12.fits");
+        int tileSize = 5;
+
+        CompressedTableHDU compressedTable = CompressedTableHDU
+                .fromBinaryTableHDU((BinaryTableHDU) fitsUncompressed.getHDU(1), tileSize).compress();
+        compressedTable.compress();
+        compressedTable.addValue(Compression.ZTILELEN, 0);
+        compressedTable.getTileRows(); // Throws exception...
     }
 
     @Test

--- a/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
+++ b/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
@@ -444,4 +444,37 @@ public class CompressedTableTest {
         Assert.assertNull(compressedTable.getColumnData(0, 1, 1));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testB12TableDecompressInvalidTileFrom() throws Exception {
+        Fits fitsUncompressed = new Fits("src/test/resources/nom/tam/table/comp/bt12.fits");
+        int tileSize = 5;
+
+        CompressedTableHDU compressedTable = CompressedTableHDU
+                .fromBinaryTableHDU((BinaryTableHDU) fitsUncompressed.getHDU(1), tileSize).compress();
+        compressedTable.compress();
+        compressedTable.asBinaryTableHDU(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testB12TableDecompressInvalidTileTo() throws Exception {
+        Fits fitsUncompressed = new Fits("src/test/resources/nom/tam/table/comp/bt12.fits");
+        int tileSize = 5;
+
+        CompressedTableHDU compressedTable = CompressedTableHDU
+                .fromBinaryTableHDU((BinaryTableHDU) fitsUncompressed.getHDU(1), tileSize).compress();
+        compressedTable.compress();
+        compressedTable.asBinaryTableHDU(0, compressedTable.getTileCount() + 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testB12TableDecompressEmptyTileRange() throws Exception {
+        Fits fitsUncompressed = new Fits("src/test/resources/nom/tam/table/comp/bt12.fits");
+        int tileSize = 5;
+
+        CompressedTableHDU compressedTable = CompressedTableHDU
+                .fromBinaryTableHDU((BinaryTableHDU) fitsUncompressed.getHDU(1), tileSize).compress();
+        compressedTable.compress();
+        compressedTable.asBinaryTableHDU(0, 0);
+    }
+
 }


### PR DESCRIPTION
Added

- `int CompressedTableHDU.getTileRows()` method to inquire how many table rows are compressed into a tile, without the user having to know about or deal with the low-level compression keywords.
- `int CompressedTableHDU.getTileCount()` method that make it easier and more transparent for users to figure out how many compressed tiles are available.
- `BinaryTableHDU asBinaryTableHDU(int tile)` for decompressing just a single table tile.