### PR TITLE
Added missing AsciiTable targeted creation method

### DIFF
--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -233,7 +233,7 @@ public class AsciiTable extends AbstractTableData {
     }
 
     /**
-     * Create an ASCII table from existing data in column-major format order.
+     * Creates an ASCII table from existing data in column-major format order.
      *
      * @param  columns       array of columns. The data for scalar entries is a primive array. For all else, the entry
      *                           is an <code>Object[]</code> array of sorts.
@@ -245,7 +245,6 @@ public class AsciiTable extends AbstractTableData {
      * 
      * @throws FitsException if the argument is not a suitable representation of FITS data in columns
      * 
-     * @see                  #fromColumnMajor(Object[])
      * @see                  BinaryTable#fromColumnMajor(Object[])
      * 
      * @since                1.19
@@ -441,6 +440,9 @@ public class AsciiTable extends AbstractTableData {
         return nFields;
     }
 
+    /**
+     * Beware that adding rows to ASCII tables may be very inefficient. Avoid addding more than a few rows if you can.
+     */
     @Override
     public int addRow(Object[] newRow) throws FitsException {
         try {
@@ -531,6 +533,10 @@ public class AsciiTable extends AbstractTableData {
         nFields -= len;
     }
 
+    /**
+     * Beware that repeatedly deleting rows from ASCII tables may be very inefficient. Avoid calling this more than once
+     * (or a few times) if you can.
+     */
     @Override
     public void deleteRows(int start, int len) throws FitsException {
         if (nRows == 0 || start < 0 || start >= nRows || len <= 0) {

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -255,7 +255,11 @@ public class AsciiTable extends AbstractTableData {
     public static AsciiTable fromColumnMajor(Object[] columns) throws FitsException {
         AsciiTable t = new AsciiTable();
         for (Object element : columns) {
-            t.addColumn(element);
+            try {
+                t.addColumn(element);
+            } catch (IllegalArgumentException e) {
+                throw new FitsException(e.getMessage(), e);
+            }
         }
         return t;
     }

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -254,11 +254,11 @@ public class AsciiTable extends AbstractTableData {
      */
     public static AsciiTable fromColumnMajor(Object[] columns) throws FitsException {
         AsciiTable t = new AsciiTable();
-        for (Object element : columns) {
+        for (int i = 0; i < columns.length; i++) {
             try {
-                t.addColumn(element);
-            } catch (IllegalArgumentException e) {
-                throw new FitsException(e.getMessage(), e);
+                t.addColumn(columns[i]);
+            } catch (Exception e) {
+                throw new FitsException("col[" + i + "]: " + e.getMessage(), e);
             }
         }
         return t;

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -233,6 +233,60 @@ public class AsciiTable extends AbstractTableData {
     }
 
     /**
+     * Create an ASCII table from existing data in column-major format order.
+     *
+     * @param  columns       array of columns. The data for scalar entries is a primive array. For all else, the entry
+     *                           is an <code>Object[]</code> array of sorts.
+     * 
+     * @return               a new ASCII table with the data. The tables data may be partially independent from the
+     *                           argument. Modifications to the table data, or that to the argument have undefined
+     *                           effect on the other object. If it is important to decouple them, you can use a
+     *                           {@link ArrayFuncs#deepClone(Object)} of your original data as an argument.
+     * 
+     * @throws FitsException if the argument is not a suitable representation of FITS data in columns
+     * 
+     * @see                  #fromColumnMajor(Object[])
+     * @see                  BinaryTable#fromColumnMajor(Object[])
+     * 
+     * @since                1.19
+     */
+    public static AsciiTable fromColumnMajor(Object[] columns) throws FitsException {
+        AsciiTable t = new AsciiTable();
+        for (Object element : columns) {
+            t.addColumn(element);
+        }
+        return t;
+    }
+
+    /**
+     * Create an ASCII table from existing table data in row-major format. That is the first array index is the row
+     * index while the second array index is the column index;
+     *
+     * @param  table         Row / column array. Scalars elements are wrapped in arrays of 1, s.t. a single
+     *                           <code>int</code> elements is stored as <code>int[1]</code> at its
+     *                           <code>[row][col]</code> index.
+     * 
+     * @return               a new ASCII table with the data. The tables data may be partially independent from the
+     *                           argument. Modifications to the table data, or that to the argument have undefined
+     *                           effect on the other object. If it is important to decouple them, you can use a
+     *                           {@link ArrayFuncs#deepClone(Object)} of your original data as an argument.
+     *
+     * @throws FitsException if the argument is not a suitable representation of FITS data in rows.
+     * 
+     * @see                  #fromColumnMajor(Object[])
+     * @see                  BinaryTable#fromRowMajor(Object[][])
+     * 
+     * @since                1.19
+     */
+    public static AsciiTable fromRowMajor(Object[][] table) throws FitsException {
+        AsciiTable tab = new AsciiTable();
+        for (Object[] row : table) {
+            tab.addRow(row);
+        }
+        return tab;
+    }
+
+    /**
      * Checks if the integer value of a specific key requires <code>long</code> value type to store.
      *
      * @param  h   the header

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -259,34 +259,6 @@ public class AsciiTable extends AbstractTableData {
     }
 
     /**
-     * Create an ASCII table from existing table data in row-major format. That is the first array index is the row
-     * index while the second array index is the column index;
-     *
-     * @param  table         Row / column array. Scalars elements are wrapped in arrays of 1, s.t. a single
-     *                           <code>int</code> elements is stored as <code>int[1]</code> at its
-     *                           <code>[row][col]</code> index.
-     * 
-     * @return               a new ASCII table with the data. The tables data may be partially independent from the
-     *                           argument. Modifications to the table data, or that to the argument have undefined
-     *                           effect on the other object. If it is important to decouple them, you can use a
-     *                           {@link ArrayFuncs#deepClone(Object)} of your original data as an argument.
-     *
-     * @throws FitsException if the argument is not a suitable representation of FITS data in rows.
-     * 
-     * @see                  #fromColumnMajor(Object[])
-     * @see                  BinaryTable#fromRowMajor(Object[][])
-     * 
-     * @since                1.19
-     */
-    public static AsciiTable fromRowMajor(Object[][] table) throws FitsException {
-        AsciiTable tab = new AsciiTable();
-        for (Object[] row : table) {
-            tab.addRow(row);
-        }
-        return tab;
-    }
-
-    /**
      * Checks if the integer value of a specific key requires <code>long</code> value type to store.
      *
      * @param  h   the header
@@ -492,7 +464,7 @@ public class AsciiTable extends AbstractTableData {
             buffer = null;
             return nRows;
         } catch (Exception e) {
-            throw new FitsException("Error addnig row:" + e.getMessage(), e);
+            throw new FitsException("Error adding row:" + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -61,7 +61,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * ASCII table data. ASCII tables are meant for human readability without any special tools. However, they are far less
  * flexible or compact than {@link BinaryTable}. As such, users are generally discouraged from using this type of table
- * to represent FITS table data.
+ * to represent FITS table data. This class only supports scalar entries of type <code>int</code>, <code>long</code>,
+ * <code>float</code>, <code>double</code>, or else <code>String</code> types.
  * 
  * @see AsciiTableHDU
  * @see BinaryTable
@@ -235,8 +236,10 @@ public class AsciiTable extends AbstractTableData {
     /**
      * Creates an ASCII table from existing data in column-major format order.
      *
-     * @param  columns       array of columns. The data for scalar entries is a primive array. For all else, the entry
-     *                           is an <code>Object[]</code> array of sorts.
+     * @param  columns       The data for scalar-valued columns. Each column must be an array of <code>int[]</code>,
+     *                           <code>long[]</code>, <code>float[]</code>, <code>double[]</code>, or else
+     *                           <code>String[]</code>, containing the same number of elements in each column (the
+     *                           number of rows).
      * 
      * @return               a new ASCII table with the data. The tables data may be partially independent from the
      *                           argument. Modifications to the table data, or that to the argument have undefined
@@ -345,10 +348,17 @@ public class AsciiTable extends AbstractTableData {
     }
 
     @Override
-    public int addColumn(Object newCol) throws FitsException {
+    public int addColumn(Object newCol) throws FitsException, IllegalArgumentException {
+        if (newCol == null) {
+            throw new FitsException("data is null");
+        }
+
+        if (!newCol.getClass().isArray()) {
+            throw new IllegalArgumentException("Not an array: " + newCol.getClass().getName());
+        }
+
         int maxLen = 1;
         if (newCol instanceof String[]) {
-
             String[] sa = (String[]) newCol;
             for (String element : sa) {
                 if (element != null && element.length() > maxLen) {
@@ -364,7 +374,8 @@ public class AsciiTable extends AbstractTableData {
         } else if (newCol instanceof float[]) {
             maxLen = FLOAT_MAX_LENGTH;
         } else {
-            throw new FitsException("Adding invalid type to ASCII table");
+            throw new FitsException(
+                    "No AsciiTable support for elements of " + newCol.getClass().getComponentType().getName());
         }
         addColumn(newCol, maxLen);
 
@@ -375,23 +386,46 @@ public class AsciiTable extends AbstractTableData {
     }
 
     /**
-     * This version of addColumn allows the user to override the default length associated with each column type.
+     * Adds an ASCII table column with the specified ASCII text width for storing its elements.
      *
-     * @param  newCol        The new column data
-     * @param  length        the requested length for the column
+     * @param  newCol                   The new column data, which must be one of: <code>int[]</code>,
+     *                                      <code>long[]</code>, <code>float[]</code>, <code>double[]</code>, or else
+     *                                      <code>String[]</code>. If the table already contains data, the length of the
+     *                                      array must match the number of rows already contained in the table.
+     * @param  width                    the ASCII text width of the for the column entries (without the string
+     *                                      termination).
      *
-     * @return               the number of columns after this one is added.
+     * @return                          the number of columns after this one is added.
      *
-     * @throws FitsException if the operation failed
+     * @throws IllegalArgumentException if the column data is not an array or the specified text <code>width</code> is
+     *                                      &le;1.
+     * @throws FitsException            if the column us of an unsupported data type or if the number of entries does
+     *                                      not match the number of rows already contained in the table.
+     * 
+     * @see                             #addColumn(Object)
      */
-    public int addColumn(Object newCol, int length) throws FitsException {
+    public int addColumn(Object newCol, int width) throws FitsException, IllegalArgumentException {
+        if (width < 1) {
+            throw new IllegalArgumentException("Illegal ASCII column width: " + width);
+        }
+
+        if (!newCol.getClass().isArray()) {
+            throw new IllegalArgumentException("Not an array: " + newCol.getClass().getName());
+        }
 
         if (nFields > 0 && Array.getLength(newCol) != nRows) {
-            throw new FitsException("New column has different number of rows");
+            throw new FitsException(
+                    "Mismatched number of rows: expected " + nRows + ", got " + Array.getLength(newCol) + "rows.");
         }
 
         if (nFields == 0) {
             nRows = Array.getLength(newCol);
+        }
+
+        Class<?> type = ArrayFuncs.getBaseClass(newCol);
+        if (type != int.class && type != long.class && type != float.class && type != double.class
+                && type != String.class) {
+            throw new FitsException("No AsciiTable support for elements of " + type.getName());
         }
 
         Object[] newData = new Object[nFields + 1];
@@ -414,10 +448,10 @@ public class AsciiTable extends AbstractTableData {
 
         newData[nFields] = newCol;
         offsets[nFields] = rowLen + 1;
-        lengths[nFields] = length;
+        lengths[nFields] = width;
         types[nFields] = ArrayFuncs.getBaseClass(newCol);
 
-        rowLen += length + 1;
+        rowLen += width + 1;
         if (isNull != null) {
             boolean[] newIsNull = new boolean[nRows * (nFields + 1)];
             // Fix the null pointers.

--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -97,13 +97,7 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
      */
     @Deprecated
     public static AsciiTable encapsulate(Object o) throws FitsException {
-
-        Object[] oo = (Object[]) o;
-        AsciiTable d = new AsciiTable();
-        for (Object element : oo) {
-            d.addColumn(element);
-        }
-        return d;
+        return AsciiTable.fromColumnMajor((Object[]) o);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -87,7 +87,8 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
     }
 
     /**
-     * @deprecated               (<i>for internal use</i>) Will reduce visibility in the future
+     * @deprecated               (<i>for internal use</i>) Use {@link AsciiTable#fromColumnMajor(Object[])} instead.
+     *                               Will reduce visibility in the future
      *
      * @return                   a ASCII table data structure from an array of objects representing the columns.
      *

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -1383,7 +1383,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
      *                               <code>int</code> elements is stored as <code>int[1]</code> at its
      *                               <code>[row][col]</code> index.
      *
-     * @throws     FitsException if the data for the columns could not be used as columns
+     * @throws     FitsException if the argument is not a suitable representation of data in rows.
      * 
      * @deprecated               The constructor is ambiguous, use {@link #fromRowMajor(Object[][])} instead. You can
      *                               have a column-major array that has no scalar primitives which would also be an
@@ -1397,7 +1397,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
     }
 
     /**
-     * Create a binary table from existing table data int row-major format. That is the first array index is the row
+     * Create a binary table from existing table data in row-major format. That is the first array index is the row
      * index while the second array index is the column index;
      *
      * @param  table         Row / column array. Scalars elements are wrapped in arrays of 1, s.t. a single
@@ -1409,7 +1409,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
      *                           effect on the other object. If it is important to decouple them, you can use a
      *                           {@link ArrayFuncs#deepClone(Object)} of your original data as an argument.
      *
-     * @throws FitsException if the data for the columns could not be used as columns
+     * @throws FitsException if the argument is not a suitable representation of FITS data in rows.
      * 
      * @see                  #fromColumnMajor(Object[])
      * 
@@ -1455,7 +1455,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
      *                           effect on the other object. If it is important to decouple them, you can use a
      *                           {@link ArrayFuncs#deepClone(Object)} of your original data as an argument.
      * 
-     * @throws FitsException if the data for the columns could not be used as columns
+     * @throws FitsException if the argument is not a suitable representation of FITS data in rows.
      * 
      * @see                  #fromColumnMajor(Object[])
      * 

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -1397,7 +1397,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
     }
 
     /**
-     * Create a binary table from existing table data in row-major format. That is the first array index is the row
+     * Creates a binary table from existing table data in row-major format. That is the first array index is the row
      * index while the second array index is the column index;
      *
      * @param  table         Row / column array. Scalars elements are wrapped in arrays of 1, s.t. a single
@@ -1445,7 +1445,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
     }
 
     /**
-     * Create a binary table from existing data in column-major format order.
+     * Creates a binary table from existing data in column-major format order.
      *
      * @param  columns       array of columns. The data for scalar entries is a primive array. For all else, the entry
      *                           is an <code>Object[]</code> array of sorts.

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -107,7 +107,9 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
     }
 
     /**
-     * @deprecated               (<i>for internal use</i>) Will reduce visibility in the future.
+     * @deprecated               (<i>for internal use</i>) Use {@link BinaryTable#fromColumnMajor(Object[])} or
+     *                               {@link BinaryTable#fromRowMajor(Object[][])} instead. Will reduce visibility in the
+     *                               future.
      *
      * @return                   Encapsulate data in a BinaryTable data type
      *

--- a/src/main/java/nom/tam/fits/ImageHDU.java
+++ b/src/main/java/nom/tam/fits/ImageHDU.java
@@ -66,16 +66,18 @@ public class ImageHDU extends BasicHDU<ImageData> {
     }
 
     /**
-     * @deprecated               (<i>for internal use</i>) Will reduce visibility in the future
+     * @deprecated                          (<i>for internal use</i>) Will reduce visibility in the future
      *
-     * @return                   Encapsulate an object as an ImageHDU.
+     * @return                              Encapsulate an object as an ImageHDU.
      *
-     * @param      o             object to encapsulate
+     * @param      o                        object to encapsulate
      *
-     * @throws     FitsException if the operation failed
+     * @throws     FitsException            <i>does not actually throw this exception</i>
+     * @throws     IllegalArgumentException if the data is not a regular primitive numerical array suitable for an
+     *                                          image.
      */
     @Deprecated
-    public static ImageData encapsulate(Object o) throws FitsException {
+    public static ImageData encapsulate(Object o) throws IllegalArgumentException, FitsException {
         return new ImageData(o);
     }
 

--- a/src/main/java/nom/tam/fits/ImageHDU.java
+++ b/src/main/java/nom/tam/fits/ImageHDU.java
@@ -66,7 +66,8 @@ public class ImageHDU extends BasicHDU<ImageData> {
     }
 
     /**
-     * @deprecated                          (<i>for internal use</i>) Will reduce visibility in the future
+     * @deprecated                          (<i>for internal use</i>) Use {@link ImageData#from(Object)} instead. Will
+     *                                          reduce visibility in the future
      *
      * @return                              Encapsulate an object as an ImageHDU.
      *

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -1261,27 +1261,11 @@ public class AsciiTableTest {
     }
 
     @Test
-    public void testFromRowMajor() throws Exception {
-        Object[][] rows = {new Object[] {new int[1], new float[1]}, new Object[] {new int[1], new float[1]},
-                new Object[] {new int[1], new float[1]}};
-        AsciiTable tab = AsciiTable.fromRowMajor(rows);
-        assertEquals(3, tab.getNRows());
-        assertEquals(2, tab.getNCols());
-    }
-
-    @Test
     public void testFromColumnMajor() throws Exception {
         Object[] cols = new Object[] {new int[3], new float[3]};
         AsciiTable tab = AsciiTable.fromColumnMajor(cols);
         assertEquals(3, tab.getNRows());
         assertEquals(2, tab.getNCols());
-    }
-
-    @Test(expected = FitsException.class)
-    public void testFromRowMajorException() throws Exception {
-        Object[][] rows = {new Object[] {new int[1], new float[2]}, new Object[] {new int[1], new float[2]},
-                new Object[] {new int[1], new float[2]}};
-        AsciiTable.fromRowMajor(rows); // ASCII tables can't store arrays...
     }
 
     @Test(expected = FitsException.class)

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -1273,4 +1273,88 @@ public class AsciiTableTest {
         Object[] cols = new Object[] {new int[3], new float[3][2]};
         AsciiTable.fromColumnMajor(cols); // ASCII tables can't store arrays...
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddColumnNotAnArrayException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn("blah");
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddBooleanColumnException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new boolean[3]);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddByteColumnException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new byte[3]);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddShortColumnException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new short[3]);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddWrongTypeColumnException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new Integer[3]);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddColumnWrongRowsException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new int[4]);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddColumnWidthNotAnArrayException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn("blah", 10);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddBooleanColumnWidthException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new boolean[3], 10);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddByteColumnWidthException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new byte[3], 10);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddShortColumnWidthException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new short[3], 10);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testAddWrongTypeColumnWidthException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new Integer[3], 10);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddColumnInvalidWidthException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        tab.addColumn(new int[3], 0);
+    }
 }

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -1357,4 +1357,10 @@ public class AsciiTableTest {
         AsciiTable tab = AsciiTable.fromColumnMajor(cols);
         tab.addColumn(new int[3], 0);
     }
+
+    @Test(expected = FitsException.class)
+    public void testFromColumnMajorRecastException() throws Exception {
+        Object[] cols = new Object[] {new int[3], "blah"};
+        AsciiTable.fromColumnMajor(cols); /// addColumn("blah") throws IllegalArgumentException, recast to FitsException
+    }
 }

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -1259,4 +1259,34 @@ public class AsciiTableTest {
         h.addValue(Standard.XTENSION, NonStandard.XTENSION_IUEIMAGE);
         new AsciiTable(h);
     }
+
+    @Test
+    public void testFromRowMajor() throws Exception {
+        Object[][] rows = {new Object[] {new int[1], new float[1]}, new Object[] {new int[1], new float[1]},
+                new Object[] {new int[1], new float[1]}};
+        AsciiTable tab = AsciiTable.fromRowMajor(rows);
+        assertEquals(3, tab.getNRows());
+        assertEquals(2, tab.getNCols());
+    }
+
+    @Test
+    public void testFromColumnMajor() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        assertEquals(3, tab.getNRows());
+        assertEquals(2, tab.getNCols());
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromRowMajorException() throws Exception {
+        Object[][] rows = {new Object[] {new int[1], new float[2]}, new Object[] {new int[1], new float[2]},
+                new Object[] {new int[1], new float[2]}};
+        AsciiTable.fromRowMajor(rows); // ASCII tables can't store arrays...
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromColumnMajorException() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3][2]};
+        AsciiTable.fromColumnMajor(cols); // ASCII tables can't store arrays...
+    }
 }


### PR DESCRIPTION
- Added static `AsciiTable.fromColumnMajor(Object[])` to replace deprecated `AsciiTableHDU.encapsulate(Object)` method.
- Added sanity checks to `AsciiTable.addColumn()` methods
- Some Javadoc updates to provide more elpful documentation on tables.


