### PR TITLE
HeaderCardException subclasses

### DIFF
--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -2518,7 +2518,7 @@ public class Header implements FitsElement {
     }
 
     /**
-     * Find the end of a set of keywords describing a column or axis (or anything else terminated by an index. This
+     * Find the end of a set of keywords describing a column or axis (or anything else terminated by an index). This
      * routine leaves the header ready to add keywords after any existing keywords with the index specified. The user
      * should specify a prefix to a keyword that is guaranteed to be present.
      */

--- a/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
+++ b/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
@@ -32,14 +32,16 @@
 package nom.tam.fits;
 
 /**
- * The keyword is a HIERARCH-style long FITS keyword but the library does not
- * have the hierarch support enabled at present.
+ * The keyword is a HIERARCH-style long FITS keyword but the library does not have the hierarch support enabled at
+ * present.
  * 
  * @author Attila Kovacs
- * @see FitsFactory#setUseHierarch(boolean)
- * @since 1.16
+ * 
+ * @see    FitsFactory#setUseHierarch(boolean)
+ * 
+ * @since  1.16
  */
-public class HierarchNotEnabledException extends FitsException {
+public class HierarchNotEnabledException extends HeaderCardException {
 
     /**
      *
@@ -51,11 +53,10 @@ public class HierarchNotEnabledException extends FitsException {
     }
 
     /**
-     * Instantiates a new exception for a HIERARCH-style header keyword, when
-     * support for the hierarch convention is not enabled.
+     * Instantiates a new exception for a HIERARCH-style header keyword, when support for the hierarch convention is not
+     * enabled.
      * 
-     * @param key
-     *            the HIERARCH-style FITS keyword.
+     * @param key the HIERARCH-style FITS keyword.
      */
     public HierarchNotEnabledException(String key) {
         super(getMessage(key));

--- a/src/main/java/nom/tam/fits/LongStringsNotEnabledException.java
+++ b/src/main/java/nom/tam/fits/LongStringsNotEnabledException.java
@@ -39,7 +39,7 @@ package nom.tam.fits;
  * @see FitsFactory#setLongStringsEnabled(boolean)
  * @since 1.16
  */
-public class LongStringsNotEnabledException extends FitsException {
+public class LongStringsNotEnabledException extends HeaderCardException {
 
     /**
      *

--- a/src/main/java/nom/tam/fits/LongValueException.java
+++ b/src/main/java/nom/tam/fits/LongValueException.java
@@ -40,7 +40,7 @@ package nom.tam.fits;
  * @author Attila Kovacs
  * @since 1.16
  */
-public class LongValueException extends FitsException {
+public class LongValueException extends HeaderCardException {
 
     /**
      *

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -661,11 +661,11 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
     }
 
     /**
-     * Set the cursor in the header to point either before the TFORM value or after the column metadat
+     * Set the cursor in the header to point either before the TFORMn value or after the column metadata
      *
      * @param      col   The 0-based index of the column
      * @param      after True if the cursor should be placed after the existing column metadata or false if the cursor
-     *                       is to be placed before the TFORM value. If no corresponding TFORM is found, the cursoe will
+     *                       is to be placed before the TFORM value. If no corresponding TFORM is found, the cursor will
      *                       be placed at the end of current header.
      * 
      * @deprecated       (<i>for internal use</i>) Will have private access in the future.

--- a/src/main/java/nom/tam/fits/UnclosedQuoteException.java
+++ b/src/main/java/nom/tam/fits/UnclosedQuoteException.java
@@ -39,7 +39,7 @@ package nom.tam.fits;
  * @see FitsFactory#setAllowHeaderRepairs(boolean)
  * @since 1.16
  */
-public class UnclosedQuoteException extends FitsException {
+public class UnclosedQuoteException extends HeaderCardException {
 
     /**
      *

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -143,17 +143,24 @@ FITS.
 <a name="deprecated-methods"></a>
 ## Compatibility with prior releases
 
-We strive to maintain backwards compatibility with earlier releases of this library, and to an overwhelming extent 
-we continue to deliver on that. However, in a few corner cases we had no choice but to change the API and behavior 
+We strive to maintain API compatibility with earlier releases of this library, and to an overwhelming extent 
+we continue to deliver on that. However, in a few corner cases we had no choice but to change the API and/or behavior 
 slightly to fix bugs, nagging inconsistencies, or non-compliance to the FITS standard. Such changes are generally 
 rare, and typically affect some of the more obscure features of the library -- often classes and methods that probably 
 should never have been expossed to users in the first place. Most typical users (and use cases) of this library will 
 never see a difference, but some of the more advanced users may find changes that would require some small 
 modifications to their application in how they use __nom-tam-fits__ with recent releases. If you find yourself to be 
 one of the ones affected, please know that the decision to 'break' previously existing functionality was not taken 
-lightly, and was done only because it was inavoidable on order to make the library function better overall.
+lightly, and was done only because it was inavoidable in order to make the library function better overall.
 
-Starting with version __1.16__, we started deprecating some of the older API, either because methods were 
+Note, that as of __1.16__ we offer only API compatibility to earlier releases, but not binary compatilibility. In 
+practical terms it means that you cannot simply drop-in replace you JAR file, from say version __1.15.2__ to 
+__1.19.0__. Instead, you are expected to (re)compile your application with the JAR version of this library that you 
+intend to use. This is because some method signatures have changed to use an encompassing argument type, such as 
+`Number` instead of the previously separate `byte`, `short`, `int`, `long`, `float`, `double` methods. (These 
+otherwise changes harmless API changes improve consistency across numerical types.)
+
+Starting with version __1.16__, we also started deprecating some of the older API, either because methods were 
 ill-conceived, confusing, or generaly unsafe to use; or because they were internals of the library that should never 
 have been exposed to users in the first place. Rest assured, the deprecations do not cripple the intended 
 functionality of the library. If anything they make the library less confusing and safer to use. The Javadoc API 
@@ -161,6 +168,8 @@ documentation mentions alternatives for the methods that were deprecated, as app
 works, you should still be able to compile your old code with deprecations enabled in the compiler options. Rest 
 assured, all deprecated methods, no matter how ill-conceived or dodgy they may be, will be supported in all
 future releases prior to version __2.0__ of the library.
+
+
 
 
 -----------------------------------------------------------------------------

--- a/src/test/java/nom/tam/fits/test/HeaderCardExceptionsTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardExceptionsTest.java
@@ -190,13 +190,7 @@ public class HeaderCardExceptionsTest {
     @Test(expected = LongValueException.class)
     public void testLongValueException1() throws Throwable {
         FitsFactory.setUseHierarch(true);
-        try {
-            new HeaderCard("HIERARCH.AAA.BBB.CCC.DDD.EEE.FFF.GGG.HHH.III.JJJ.KKK.LLL.MMM.NNN.OOO", 1234567890123456789L);
-        } catch (HeaderCardException e) {
-            if (e.getCause() != null) {
-                throw e.getCause();
-            }
-        }
+        new HeaderCard("HIERARCH.AAA.BBB.CCC.DDD.EEE.FFF.GGG.HHH.III.JJJ.KKK.LLL.MMM.NNN.OOO", 1234567890123456789L);
     }
 
     @Test(expected = LongValueException.class)


### PR DESCRIPTION
Make the following soft exceptions subclasses of `HeaderCardException`:

- `LongValueException`
- `HierarchNotEnabledException`
- `LongStringsNotEnabledException`
- `UnclosedQuoteException`

since all of these are header card specific to begin with...