### PR TITLE
Standardized WCS keywords etc.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -21,7 +21,6 @@
 	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-commons.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-engine.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-launcher.jar"/>
-	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-reporting.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-runner.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-suite-api.jar"/>
 	<classpathentry kind="lib" path="/usr/share/java/junit5/junit-platform-suite-commons.jar"/>

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -45,15 +45,15 @@ import nom.tam.util.ByteParser;
 import nom.tam.util.Cursor;
 import nom.tam.util.FormatException;
 
-import static nom.tam.fits.header.DataDescription.TDMAXn;
-import static nom.tam.fits.header.DataDescription.TDMINn;
-import static nom.tam.fits.header.DataDescription.TLMAXn;
-import static nom.tam.fits.header.DataDescription.TLMINn;
 import static nom.tam.fits.header.Standard.NAXIS1;
 import static nom.tam.fits.header.Standard.NAXIS2;
 import static nom.tam.fits.header.Standard.TBCOLn;
+import static nom.tam.fits.header.Standard.TDMAXn;
+import static nom.tam.fits.header.Standard.TDMINn;
 import static nom.tam.fits.header.Standard.TFIELDS;
 import static nom.tam.fits.header.Standard.TFORMn;
+import static nom.tam.fits.header.Standard.TLMAXn;
+import static nom.tam.fits.header.Standard.TLMINn;
 import static nom.tam.fits.header.Standard.TNULLn;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -94,6 +94,7 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
      *                           happen, but we keep the possibility open to it).
      * 
      * @see                  BinaryTable#toHDU()
+     * 
      * @since                1.18
      */
     public static BinaryTableHDU wrap(BinaryTable tab) throws FitsException {

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -1389,11 +1389,16 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @param  key                      The standard or conventional FITS keyword
      * @param  type                     The type we want to use with that key
      *
-     * @throws IllegalArgumentException if the keyword does not support the given value type.
+     * @throws IllegalArgumentException if the keyword does not support the given value type, or if the keyword contains
+     *                                      an unfilled index.
      *
      * @since                           1.16
      */
     private static boolean checkType(IFitsHeader key, VALUE type) throws IllegalArgumentException {
+        if (key.key().contains("n")) {
+            throw new IllegalArgumentException("Unfilled index(es) in keyword " + key.key());
+        }
+
         if (key.valueType() == type || key.valueType() == VALUE.ANY) {
             return true;
         }

--- a/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
+++ b/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
@@ -32,14 +32,12 @@
 package nom.tam.fits;
 
 /**
- * The keyword is a HIERARCH-style long FITS keyword but the library does not have the hierarch support enabled at
- * present.
+ * The keyword is a HIERARCH-style long FITS keyword but the library does not
+ * have the hierarch support enabled at present.
  * 
  * @author Attila Kovacs
- * 
- * @see    FitsFactory#setUseHierarch(boolean)
- * 
- * @since  1.16
+ * @see FitsFactory#setUseHierarch(boolean)
+ * @since 1.16
  */
 public class HierarchNotEnabledException extends HeaderCardException {
 
@@ -53,10 +51,11 @@ public class HierarchNotEnabledException extends HeaderCardException {
     }
 
     /**
-     * Instantiates a new exception for a HIERARCH-style header keyword, when support for the hierarch convention is not
-     * enabled.
+     * Instantiates a new exception for a HIERARCH-style header keyword, when
+     * support for the hierarch convention is not enabled.
      * 
-     * @param key the HIERARCH-style FITS keyword.
+     * @param key
+     *            the HIERARCH-style FITS keyword.
      */
     public HierarchNotEnabledException(String key) {
         super(getMessage(key));

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -661,7 +661,7 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
     }
 
     /**
-     * Set the cursor in the header to point either before the TFORM value or after the column metadat
+     * Set the cursor in the header to point either before the TFORM value or after the column metadata
      *
      * @param      col   The 0-based index of the column
      * @param      after True if the cursor should be placed after the existing column metadata or false if the cursor

--- a/src/main/java/nom/tam/fits/header/Checksum.java
+++ b/src/main/java/nom/tam/fits/header/Checksum.java
@@ -70,7 +70,6 @@ public enum Checksum implements IFitsHeader {
      */
     DATASUM(HDU.ANY, VALUE.STRING, "checksum of the data records");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     Checksum(HDU hdu, VALUE valueType, String comment) {
@@ -78,33 +77,7 @@ public enum Checksum implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/Compression.java
+++ b/src/main/java/nom/tam/fits/header/Compression.java
@@ -406,7 +406,6 @@ public enum Compression implements IFitsHeader {
      */
     public static final String SMOOTH = "SMOOTH";
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     private final IFitsHeader uncompressedKey;
@@ -421,8 +420,8 @@ public enum Compression implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
+    public final IFitsHeader impl() {
+        return key;
     }
 
     /**
@@ -433,32 +432,6 @@ public enum Compression implements IFitsHeader {
      */
     public IFitsHeader getUncompressedKey() {
         return uncompressedKey;
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -187,7 +187,6 @@ public enum DataDescription implements IFitsHeader {
      */
     TSORTKEY(SOURCE.HEASARC, HDU.TABLE, VALUE.STRING, "defines the sort order of a table");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     DataDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
@@ -195,33 +194,7 @@ public enum DataDescription implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -144,12 +144,16 @@ public enum DataDescription implements IFitsHeader {
      * The value field of this indexed keyword shall contain a floating point number specifying the maximum valid
      * physical value represented in column n of the table, exclusive of any special values. This keyword may only be
      * used in 'TABLE' or 'BINTABLE' extensions and is analogous to the DATAMAX keyword used for FITS images.
+     * 
+     * @deprecated Use {@link Standard#TDMAXn} instead.
      */
     TDMAXn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "maximum value in the column"),
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the minimum valid
      * physical value represented in column n of the table, exclusive of any special values. This keyword may only be
      * used in 'TABLE' or 'BINTABLE' extensions and is analogous to the DATAMIN keyword used for FITS images.
+     * 
+     * @deprecated Use {@link Standard#TDMINn} instead.
      */
     TDMINn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "minimum value in the column"),
     /**
@@ -163,6 +167,8 @@ public enum DataDescription implements IFitsHeader {
      * that are greater than this legal maximum value but the interpretation of such values is not defined here. The
      * value of this keyword is typically used as the maxinum value when constructing a histogram of the values in the
      * column. This keyword may only be used in 'TABLE' or 'BINTABLE' extensions.
+     * 
+     * @deprecated Use {@link Standard#TLMAXn} instead.
      */
     TLMAXn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "maximum legal value in the column"),
     /**
@@ -171,6 +177,8 @@ public enum DataDescription implements IFitsHeader {
      * that are less than this legal minimum value but the interpretation of such values is not defined here. The value
      * of this keyword is typically used as the mininum value when constructing a histogram of the values in the column.
      * This keyword may only be used in 'TABLE' or 'BINTABLE' extensions.
+     * 
+     * @deprecated Use {@link Standard#TLMINn} instead.
      */
     TLMINn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "minimum legal value in the column"),
     /**

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -1,0 +1,419 @@
+package nom.tam.fits.header;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+/**
+ * Date-time related standard FITS keywords.
+ * 
+ * @author Attila Kovacs
+ *
+ * @see    WCS
+ * 
+ * @since  1.19
+ */
+public enum DateTime implements IFitsHeader {
+
+    /**
+     * The date on which the HDU was created, in the format specified in the FITS Standard. The old date format was
+     * 'yy/mm/dd' and may be used only for dates from 1900 through 1999. the new Y2K compliant date format is
+     * 'yyyy-mm-dd' or 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    DATE(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "date of file creation"),
+
+    /**
+     * The date of the observation, in the format specified in the FITS Standard. The old date format was 'yy/mm/dd' and
+     * may be used only for dates from 1900 through 1999. The new Y2K compliant date format is 'yyyy-mm-dd' or
+     * 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    DATE_OBS("DATE-OBS", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "date of observation"),
+
+    /**
+     * The date of the observation for the given column index, in the format specified in the FITS Standard. The old
+     * date format was 'yy/mm/dd' and may be used only for dates from 1900 through 1999. The new Y2K compliant date
+     * format is 'yyyy-mm-dd' or 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    DOBSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "date of observation for column"),
+
+    /**
+     * The average date of the observation, in the format specified in the FITS Standard. The old date format was
+     * 'yy/mm/dd' and may be used only for dates from 1900 through 1999. The new Y2K compliant date format is
+     * 'yyyy-mm-dd' or 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    DATE_AVG("DATE-AVG", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "mean date of observation"),
+
+    /**
+     * Avearge date of the observation for the given column index, in the format specified in the FITS Standard. The old
+     * date format was 'yy/mm/dd' and may be used only for dates from 1900 through 1999. The new Y2K compliant date
+     * format is 'yyyy-mm-dd' or 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    DAVGn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "mean date of observation for column"),
+
+    /**
+     * The start date of the observation, in the format specified in the FITS Standard. The old date format was
+     * 'yy/mm/dd' and may be used only for dates from 1900 through 1999. The new Y2K compliant date format is
+     * 'yyyy-mm-dd' or 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    DATE_BEG("DATE-BEG", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "start of observation"),
+
+    /**
+     * The end date of the observation, in the format specified in the FITS Standard. The old date format was 'yy/mm/dd'
+     * and may be used only for dates from 1900 through 1999. The new Y2K compliant date format is 'yyyy-mm-dd' or
+     * 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    DATE_END("DATE-END", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "end of observation"),
+
+    /**
+     * The reference date of the observation, in the format specified in the FITS Standard. The old date format was
+     * 'yy/mm/dd' and may be used only for dates from 1900 through 1999. The new Y2K compliant date format is
+     * 'yyyy-mm-dd' or 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    DATEREF(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Reference date"),
+
+    /**
+     * [day] Modified Julian Date of observation
+     * 
+     * @since 1.19
+     */
+    MJD_OBS("MJD-OBS", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[day] Modified Julian Date of observation"),
+
+    /**
+     * [day] Modified Julian Date of observation for the given column index
+     * 
+     * @since 1.19
+     */
+    MJDOBn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[day] MJD of observation for column"),
+
+    /**
+     * [day] Average Modified Julian Date of observation
+     * 
+     * @since 1.19
+     */
+    MJD_AVG("MJD-AVG", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[day] mean Modified Julian Date of observation"),
+
+    /**
+     * [day] Average Modified Julian Date of observation for the given column index
+     * 
+     * @since 1.19
+     */
+    MJDAn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[day] mean MJD of observation for column"),
+
+    /**
+     * [day] Modified Julian Date of the start of observation
+     * 
+     * @since 1.19
+     */
+    MJD_BEG("MJD-BEG", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[day] Modified Julian Date of start of observation"),
+
+    /**
+     * [day] Average Modified Julian Date of the end of observation
+     * 
+     * @since 1.19
+     */
+    MJD_END("MJD-END", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[day] Modified Julian Date of start of observation"),
+
+    /**
+     * [day] Reference Modified Julian Date
+     * 
+     * @since 1.19
+     */
+    MJDREF(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[day] reference Modified Julian Date"),
+
+    /**
+     * [day] Reference Julian Date
+     * 
+     * @since 1.19
+     */
+    JDREF(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[day] reference Julian Date"),
+
+    /**
+     * The start time of the observation, in the format specified in the FITS Standard, in the format HH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    TSTART(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "start time of observation"),
+
+    /**
+     * The end time of the observation, in the format specified in the FITS Standard, in the format HH:MM:SS[.sss]'.
+     * 
+     * @since 1.19
+     */
+    TSTOP(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "end time of observation"),
+
+    /**
+     * [yr] Besselian epoch of observation
+     * 
+     * @since 1.19
+     */
+    BEPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Besselian epoch of observation"),
+
+    /**
+     * [yr] Julian epoch of observation
+     * 
+     * @since 1.19
+     */
+    JEPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Julian epoch of observation"),
+
+    /**
+     * [s] Net exposure duration
+     * 
+     * @since 1.19
+     */
+    XPOSURE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Net exposure duration"),
+
+    /**
+     * [s] Wall clock exposure duration
+     * 
+     * @since 1.19
+     */
+    TELAPSE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Wall-clock exposure duration"),
+
+    /**
+     * Time reference system name
+     * 
+     * @since 1.19
+     */
+    TIMESYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time scale"),
+
+    /**
+     * Time reference position, e.g. 'TOPOCENT'
+     * 
+     * @since 1.19
+     */
+    TREFPOS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time reference position"),
+
+    /**
+     * Time reference position for given column index, e.g. 'TOPOCENT'
+     * 
+     * @since 1.19
+     */
+    TRPOSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "Time reference position in column"),
+
+    /**
+     * Pointer to time reference direction
+     * 
+     * @since 1.19
+     */
+    TREFDIR(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time reference direction"),
+
+    /**
+     * Time reference direction for given column index, e.g. 'TOPOCENT'
+     * 
+     * @since 1.19
+     */
+    TRDIRn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "Time reference direction in column"),
+
+    /**
+     * Solar system ephemeris used, e.g. 'DE-405'.
+     * 
+     * @since 1.19
+     */
+    PLEPHEM(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Solar system ephemeris"),
+
+    /**
+     * Time unit name
+     * 
+     * @since 1.19
+     */
+    TIMEUNIT(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time unit"),
+
+    /**
+     * [s] Precision time offset
+     * 
+     * @since 1.19
+     */
+    TIMEOFFS(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Time offset"),
+
+    /**
+     * [s] Systematic time error
+     * 
+     * @since 1.19
+     */
+    TIMESYER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Systematic time error"),
+
+    /**
+     * [s] Random time error
+     * 
+     * @since 1.19
+     */
+    TIMERDER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Random time error"),
+
+    /**
+     * [s] Time resolution
+     * 
+     * @since 1.19
+     */
+    TIMEDEL(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Time resolution"),
+
+    /**
+     * Time location within pixel, between 0.0 and 1.0 (default 0.5).
+     * 
+     * @since 1.19
+     */
+    TIMEPIXR(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Time location in pixel");
+
+    /** International Atomic Time (TAI) timescale value. */
+    public static final String TIMESCALE_TAI = "TAI";
+
+    /** Terrestrial Time (TT) timescale value. */
+    public static final String TIMESCALE_TT = "TT";
+
+    /** Terrestrial Dynamical Time (TDT) timescale value. */
+    public static final String TIMESCALE_TDT = "TDT";
+
+    /** Ephemeris Time (ET) timescale value. */
+    public static final String TIMESCALE_ET = "ET";
+
+    /** @deprecated DEprecated by the FITS standard, use {@link #TIMESCALE_TAI} instead. */
+    public static final String TIMESCALE_IAT = "IAT";
+
+    /** Earth rotation time (UT1) timescale value. */
+    public static final String TIMESCALE_UT1 = "UT1";
+
+    /** Universal Coordinated Time (UTC) timescale value. */
+    public static final String TIMESCALE_UTC = "UTC";
+
+    /**
+     * @deprecated Greenwih Mean time (GMT) timescale value; deprecated by the FITS standard, use {@link #TIMESCALE_UTC}
+     *                 instead.
+     */
+    public static final String TIMESCALE_GMT = "GMT";
+
+    /** Global Positioning System (GPS) time timescale value. */
+    public static final String TIMESCALE_GPS = "GPS";
+
+    /** Geocentric Coordinated Time (TCG) timescale value. */
+    public static final String TIMESCALE_TCG = "TCG";
+
+    /** Barycentric Coordinated Time (TCB) timescale value. */
+    public static final String TIMESCALE_TCB = "TCB";
+
+    /** Barycentric Dynamical Time (TDB) timescale value. */
+    public static final String TIMESCALE_TDB = "TDB";
+
+    /** Local time timescale value for free-running clocks. */
+    public static final String TIMESCALE_LOCAL = "LOCAL";
+
+    /** Topocentric time reference position */
+    public static final String TREFPOS_TOPOCENTER = "TOPOCENTER";
+
+    /** Geocentric time reference position */
+    public static final String TREFPOS_GEOCENTER = "GEOCENTER";
+
+    /** Barycentric (Solar-system) time reference position */
+    public static final String TREFPOS_BARYCENTER = "BARYCENTER";
+
+    /** Relocatable time reference position (for simulations only) */
+    public static final String TREFPOS_RELOCATABLE = "RELOCATABLE";
+
+    /** Topocentric time reference position that is not the observatory location */
+    public static final String TREFPOS_CUSTOM = "CUSTOM";
+
+    /** Helioentric time reference position */
+    public static final String TREFPOS_HELIOCENTER = "HELIOCENTER";
+
+    /** Galactocentric time reference position */
+    public static final String TREFPOS_GALACTIC = "GALACTIC";
+
+    /** Earth-Moon barycenter time reference position */
+    public static final String TREFPOS_EMBARYCENTER = "EMBARYCENTER";
+
+    /** Time reference position at the center of Mercury */
+    public static final String TREFPOS_MERCURY = "MERCURY";
+
+    /** Time reference position at the center of Venus */
+    public static final String TREFPOS_VENUS = "VENUS";
+
+    /** Time reference position at the center of Mars */
+    public static final String TREFPOS_MARS = "MARS";
+
+    /** Time reference position at the center of Jupiter */
+    public static final String TREFPOS_JUPITER = "JUPITER";
+
+    /** Time reference position at the center of Saturn */
+    public static final String TREFPOS_SATURN = "SATURN";
+
+    /** Time reference position at the center of Uranus */
+    public static final String TREFPOS_URANUS = "URANUS";
+
+    /** Time reference position at the center of Neptune */
+    public static final String TREFPOS_NEPTUNE = "NEPTUNE";
+
+    /** Solar System ephemeris value for {@link #PLEPHEM} for Standish (1990). */
+    public static final String PLEPHEM_DE200 = "DE200";
+
+    /** Solar System ephemeris value for {@link #PLEPHEM} for Standish (1998). Default */
+    public static final String PLEPHEM_DE405 = "DE405";
+
+    /** Solar System ephemeris value for {@link #PLEPHEM} for Folkner, et al. (2009). */
+    public static final String PLEPHEM_DE421 = "DE421";
+
+    /** Solar System ephemeris value for {@link #PLEPHEM} for Folkner, et al. (2014). */
+    public static final String PLEPHEM_DE430 = "DE430";
+
+    /** Solar System ephemeris value for {@link #PLEPHEM} for Folkner, et al. (2014). */
+    public static final String PLEPHEM_DE431 = "DE431";
+
+    /** Solar System ephemeris value for {@link #PLEPHEM} for Folkner, et al. (2014). */
+    public static final String PLEPHEM_DE432 = "DE432";
+
+    private final IFitsHeader key;
+
+    DateTime(SOURCE status, HDU hdu, VALUE valueType, String comment) {
+        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+    }
+
+    DateTime(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
+        key = new FitsHeaderImpl(headerName == null ? name() : headerName, status, hdu, valueType, comment);
+    }
+
+    @Override
+    public final IFitsHeader impl() {
+        return key;
+    }
+
+}

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -433,7 +433,7 @@ public enum DateTime implements IFitsHeader {
     private final IFitsHeader key;
 
     DateTime(SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+        this(null, status, hdu, valueType, comment);
     }
 
     DateTime(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -401,6 +401,35 @@ public enum DateTime implements IFitsHeader {
     /** Solar System ephemeris value for {@link #PLEPHEM} for Folkner, et al. (2014). */
     public static final String PLEPHEM_DE432 = "DE432";
 
+    /** Time unit value for time measured in seconds */
+    public static final String TIMEUNIT_SECOND = "s";
+
+    /** Time unit value for time measured in days */
+    public static final String TIMEUNIT_DAY = "d";
+
+    /** Time unit value for time measured in Julian years (1 a = 365.25 d) */
+    public static final String TIMEUNIT_JULIAN_YEAR = "a";
+
+    /** Time unit value for time measured in seconds (1 cy = 36525 d) */
+    public static final String TIMEUNIT_JULIAN_CENTURY = "cy";
+
+    /** Time unit value for time measured in minutes */
+    public static final String TIMEUNIT_MINUTE = "min";
+
+    /** Time unit value for time measured in hours */
+    public static final String TIMEUNIT_HOUR = "h";
+
+    /** Time unit value for time measured in Julian years (same as {@link #TIMEUNIT_JULIAN_YEAR}) */
+    public static final String TIMEUNIT_YEAR = "yr";
+
+    /** Time unit value for time measured in tropical years (1 ta ~ 365.2422 d) */
+    public static final String TIMEUNIT_TROPICAL_YEAR = "ta";
+
+    /**
+     * Time unit value for time measured in Besselian years (essentially the sdame as {@link #TIMEUNIT_TROPICAL_YEAR})
+     */
+    public static final String TIMEUNIT_BESSELIAN_YEAR = "Ba";
+
     private final IFitsHeader key;
 
     DateTime(SOURCE status, HDU hdu, VALUE valueType, String comment) {

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -189,28 +189,28 @@ public enum DateTime implements IFitsHeader {
      * 
      * @since 1.19
      */
-    BEPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Besselian epoch of observation"),
+    BEPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[Ba] Besselian epoch of observation"),
 
     /**
      * [yr] Julian epoch of observation
      * 
      * @since 1.19
      */
-    JEPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Julian epoch of observation"),
+    JEPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[yr] Julian epoch of observation"),
 
     /**
-     * [s] Net exposure duration
+     * Net exposure duration
      * 
      * @since 1.19
      */
-    XPOSURE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Net exposure duration"),
+    XPOSURE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Net exposure duration"),
 
     /**
-     * [s] Wall clock exposure duration
+     * Wall clock exposure duration
      * 
      * @since 1.19
      */
-    TELAPSE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Wall-clock exposure duration"),
+    TELAPSE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Wall-clock exposure duration"),
 
     /**
      * Time reference system name
@@ -220,14 +220,14 @@ public enum DateTime implements IFitsHeader {
     TIMESYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time scale"),
 
     /**
-     * Time reference position, e.g. 'TOPOCENT'
+     * Time reference position
      * 
      * @since 1.19
      */
     TREFPOS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time reference position"),
 
     /**
-     * Time reference position for given column index, e.g. 'TOPOCENT'
+     * Time reference position for given column index.
      * 
      * @since 1.19
      */
@@ -262,32 +262,32 @@ public enum DateTime implements IFitsHeader {
     TIMEUNIT(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time unit"),
 
     /**
-     * [s] Precision time offset
+     * Precision time offset
      * 
      * @since 1.19
      */
-    TIMEOFFS(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Time offset"),
+    TIMEOFFS(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Time offset"),
 
     /**
-     * [s] Systematic time error
+     * Systematic time error
      * 
      * @since 1.19
      */
-    TIMESYER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Systematic time error"),
+    TIMESYER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Systematic time error"),
 
     /**
-     * [s] Random time error
+     * Random time error
      * 
      * @since 1.19
      */
-    TIMERDER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Random time error"),
+    TIMERDER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Random time error"),
 
     /**
-     * [s] Time resolution
+     * Time resolution
      * 
      * @since 1.19
      */
-    TIMEDEL(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[s] Time resolution"),
+    TIMEDEL(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Time resolution"),
 
     /**
      * Time location within pixel, between 0.0 and 1.0 (default 0.5).

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -97,6 +97,9 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
 
     @Override
     public String key() {
+        if (key.endsWith("a")) {
+            return key.substring(0, key.length() - 1);
+        }
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -81,6 +81,11 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
     }
 
     @Override
+    public final IFitsHeader impl() {
+        return this;
+    }
+
+    @Override
     public String comment() {
         return comment;
     }
@@ -96,16 +101,6 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
     }
 
     @Override
-    public IFitsHeader n(int... numbers) {
-        StringBuffer headerName = new StringBuffer(key);
-        for (int number : numbers) {
-            int indexOfN = headerName.indexOf("n");
-            headerName.replace(indexOfN, indexOfN + 1, Integer.toString(number));
-        }
-        return new FitsHeaderImpl(headerName.toString(), status, hdu, valueType, comment);
-    }
-
-    @Override
     public SOURCE status() {
         return status;
     }
@@ -116,9 +111,9 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
     }
 
     /**
-     * Checks if a keywords is known to be a comment-style keyword. That is, it checks if the <code>key</code> argument
-     * matches any {@link IFitsHeader} constructed via this implementation with a <code>valueType</code> argument that
-     * was <code>null</code>, or if the key is empty.
+     * (<i>for internal use</i>) Checks if a keywords is known to be a comment-style keyword. That is, it checks if the
+     * <code>key</code> argument matches any {@link IFitsHeader} constructed via this implementation with a
+     * <code>valueType</code> argument that was <code>null</code>, or if the key is empty.
      *
      * @param  key the keyword to check
      *

--- a/src/main/java/nom/tam/fits/header/HierarchicalGrouping.java
+++ b/src/main/java/nom/tam/fits/header/HierarchicalGrouping.java
@@ -57,7 +57,6 @@ public enum HierarchicalGrouping implements IFitsHeader {
      */
     GRPNAME(SOURCE.HEASARC, HDU.TABLE, VALUE.STRING, "the grouping table name");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     HierarchicalGrouping(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
@@ -65,33 +64,7 @@ public enum HierarchicalGrouping implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -180,17 +180,18 @@ public interface IFitsHeader {
      * Constructs a numbered FITS header keyword entry from this stem, attachinh the specified number after the stem.
      * Numbering for FITS header keywords always starts from 1.
      * 
-     * @param  numbers                  the 1-based indices to add to the stem, in the order they appear in the the enum
-     *                                      name.
+     * @param  numbers                   the 1-based indices to add to the stem, in the order they appear in the the
+     *                                       enum name.
      * 
-     * @return                          an indexed instance of this FITS header entry
+     * @return                           an indexed instance of this FITS header entry
      * 
-     * @throws IllegalArgumentException if the index is less than 0 or exceeds 999. (In truth we should throw an
-     *                                      exception for 0 as well, but there may be not quite legal FITS files that
-     *                                      contain these, which we still want to be able to read. Hence we'll relax the
-     *                                      condition).
-     * @throws IllegalStateException    if the resulting indexed keyword exceeds the maximum 8-bytes allowed for
-     *                                      standard FITS keywords.
+     * @throws IllegalArgumentException  if the index is less than 0 or exceeds 999. (In truth we should throw an
+     *                                       exception for 0 as well, but there may be not quite legal FITS files that
+     *                                       contain these, which we still want to be able to read. Hence we'll relax
+     *                                       the condition).
+     * @throws IllegalStateException     if the resulting indexed keyword exceeds the maximum 8-bytes allowed for
+     *                                       standard FITS keywords.
+     * @throws IndexOutOfBoundsException If more indices were supplied than can be filled for this keyword.
      */
     default IFitsHeader n(int... numbers) throws IllegalArgumentException, IllegalStateException {
         StringBuffer headerName = new StringBuffer(key());
@@ -200,6 +201,11 @@ public interface IFitsHeader {
             }
 
             int indexOfN = headerName.indexOf("n");
+
+            if (indexOfN < 0) {
+                throw new IndexOutOfBoundsException("Too many indices (" + numbers.length + ") supplied for " + key());
+            }
+
             headerName.replace(indexOfN, indexOfN + 1, Integer.toString(number));
         }
 

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.header;
 
+import nom.tam.fits.HeaderCard;
+
 /*
  * #%L
  * INDI for Java Utilities for the fits image format
@@ -37,6 +39,9 @@ package nom.tam.fits.header;
  * one to end up with inproperly constructed FITS files. Therefore, their usage is highly encouranged when possible.
  */
 public interface IFitsHeader {
+
+    /** Max numeric index we may use to replace <i>n</i> in the Java name of indexed variables. */
+    int MAX_INDEX = 999;
 
     /** An enumeration of HDU types in which a header keyword may be used. */
     enum HDU {
@@ -128,20 +133,36 @@ public interface IFitsHeader {
     }
 
     /**
+     * (<i>primarily for internal use</i>) Returns the concrete implementation of this header entry, which provides
+     * implementation of access methods.
+     * 
+     * @return the implementation of this keyword, which provides the actual access methods. It may return itself.
+     * 
+     * @since  1.19
+     */
+    default IFitsHeader impl() {
+        return null;
+    }
+
+    /**
      * Returns the comment associated to this FITS header entry. The comment is entirely optional, and it may not be
      * appear in full (or at all) in the FITS header. Comments should thus never contain essential information. Their
      * purpose is only to provide non-essential extra information for human use.
      * 
      * @return the associated standard comment.
      */
-    String comment();
+    default String comment() {
+        return impl().comment();
+    }
 
     /**
      * Returns the type of HDU(s) in which this header entry may be used.
      * 
      * @return the HDU type(s) that this keyword may support.
      */
-    HDU hdu();
+    default HDU hdu() {
+        return impl().hdu();
+    }
 
     /**
      * Returns the FITS header keyword for this header entry. Standard FITS keywords are limited to 8 characters, and
@@ -149,29 +170,59 @@ public interface IFitsHeader {
      * 
      * @return the FITS header keyword for this entry
      */
-    String key();
+    default String key() {
+        return impl().key();
+    }
 
     /**
      * Constructs a numbered FITS header keyword entry from this stem, attachinh the specified number after the stem.
      * Numbering for FITS header keywords always starts from 1.
      * 
-     * @param  number the 1-based index to add to the stem
+     * @param  numbers                  the 1-based indices to add to the stem, in the order they appear in the the enum
+     *                                      name.
      * 
-     * @return        an indexed instance of this FITS header entry
+     * @return                          an indexed instance of this FITS header entry
+     * 
+     * @throws IllegalArgumentException if the index is less than 0 or exceeds 999. (In truth we should throw an
+     *                                      exception for 0 as well, but there may be not quite legal FITS files that
+     *                                      contain these, which we still want to be able to read. Hence we'll relax the
+     *                                      condition).
+     * @throws IllegalStateException    if the resulting indexed keyword exceeds the maximum 8-bytes allowed for
+     *                                      standard FITS keywords.
      */
-    IFitsHeader n(int... number);
+    default IFitsHeader n(int... numbers) throws IllegalArgumentException, IllegalStateException {
+        StringBuffer headerName = new StringBuffer(key());
+        for (int number : numbers) {
+            if (number < 0 || number > MAX_INDEX) {
+                throw new IllegalArgumentException(key() + ": index " + number + " is out of bounds.");
+            }
+
+            int indexOfN = headerName.indexOf("n");
+            headerName.replace(indexOfN, indexOfN + 1, Integer.toString(number));
+        }
+
+        if (headerName.length() > HeaderCard.MAX_KEYWORD_LENGTH) {
+            throw new IllegalStateException("indexed keyword " + headerName.toString() + " is too long.");
+        }
+
+        return new FitsHeaderImpl(headerName.toString(), status(), hdu(), valueType(), comment());
+    }
 
     /**
      * Returns the standard convention, which defines this FITS header entry
      * 
      * @return the standard or convention that specifies this FITS heacer keyword
      */
-    SOURCE status();
+    default SOURCE status() {
+        return impl().status();
+    }
 
     /**
      * The type(s) of value(s) this FITS header entry might take.
      * 
      * @return the value type(s) for this FITS header entry
      */
-    VALUE valueType();
+    default VALUE valueType() {
+        return impl().valueType();
+    }
 }

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -168,9 +168,11 @@ public interface IFitsHeader {
      * Returns the FITS header keyword for this header entry. Standard FITS keywords are limited to 8 characters, and
      * contain only epper-case letters, numbers, hyphen, and underscore characters.
      * 
-     * @return the FITS header keyword for this entry
+     * @return                       the FITS header keyword for this entry
+     * 
+     * @throws IllegalStateException if there are unfilled indices remaining in the keyword template.
      */
-    default String key() {
+    default String key() throws IllegalStateException {
         return impl().key();
     }
 

--- a/src/main/java/nom/tam/fits/header/InstrumentDescription.java
+++ b/src/main/java/nom/tam/fits/header/InstrumentDescription.java
@@ -99,7 +99,6 @@ public enum InstrumentDescription implements IFitsHeader {
      */
     SATURATE(SOURCE.STScI, HDU.ANY, VALUE.INTEGER, "Data value at which saturation occurs");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     InstrumentDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
@@ -107,33 +106,7 @@ public enum InstrumentDescription implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/NonStandard.java
+++ b/src/main/java/nom/tam/fits/header/NonStandard.java
@@ -76,7 +76,6 @@ public enum NonStandard implements IFitsHeader {
      */
     INHERIT(SOURCE.STScI, HDU.EXTENSION, VALUE.LOGICAL, "denotes the INHERIT keyword convention");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     /**
@@ -94,33 +93,7 @@ public enum NonStandard implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/NonStandard.java
+++ b/src/main/java/nom/tam/fits/header/NonStandard.java
@@ -50,6 +50,7 @@ public enum NonStandard implements IFitsHeader {
      */
     @Deprecated
     CONTINUE(SOURCE.HEASARC, HDU.ANY, VALUE.NONE, "denotes the CONTINUE long string keyword convention"),
+
     /**
      * The HIERARCH keyword, when followed by spaces in columns 9 and 10 of the FITS card image, indicates that the ESO
      * HIERARCH keyword convention should be used to interpret the name and value of the keyword. The HIERARCH keyword
@@ -69,6 +70,7 @@ public enum NonStandard implements IFitsHeader {
      * filter position". In this example the logical name of the keyword is 'Filter Wheel' and the value is 12.
      */
     HIERARCH(SOURCE.ESO, HDU.ANY, VALUE.NONE, "denotes the HIERARCH keyword convention"),
+
     /**
      * The presence of this keyword with a value = T in an extension key indicates that the keywords contained in the
      * primary key (except the FITS Mandatory keywords, and any COMMENT, HISTORY or 'blank' keywords) are to be

--- a/src/main/java/nom/tam/fits/header/ObservationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDescription.java
@@ -183,7 +183,6 @@ public enum ObservationDescription implements IFitsHeader {
      */
     SUNANGLE(SOURCE.STScI, HDU.ANY, VALUE.REAL, "angle between the observation and the sun");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     ObservationDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
@@ -191,33 +190,7 @@ public enum ObservationDescription implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
@@ -117,7 +117,7 @@ public enum ObservationDurationDescription implements IFitsHeader {
     private final IFitsHeader key;
 
     ObservationDurationDescription(SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+        this(null, status, hdu, valueType, comment);
     }
 
     ObservationDurationDescription(String key, SOURCE status, HDU hdu, VALUE valueType, String comment) {

--- a/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
@@ -33,8 +33,10 @@ package nom.tam.fits.header;
 
 /**
  * <p>
- * This data dictionary contains FITS keywords that have been widely used within the astronomical community. It is
- * recommended that these keywords only be used as defined here. These are the Keywords that describe the observation.
+ * This data dictionary contains FITS keywords that have been widely used within the astronomical community. Many of
+ * them are not part of the FITS standard. For more standard FITS keywords relating to date-time see {@link DateTime}
+ * instead. It is recommended that these keywords only be used as defined here. These are the Keywords that describe the
+ * observation.
  * </p>
  * <p>
  * See <a href=
@@ -42,6 +44,8 @@ package nom.tam.fits.header;
  * </p>
  *
  * @author Richard van Nieuwenhoven
+ * 
+ * @see    DateTime
  */
 public enum ObservationDurationDescription implements IFitsHeader {
     /**
@@ -49,6 +53,8 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * has the same format, and is used in conjunction with, the standard DATA-OBS keyword that gives the starting date
      * of the observation. These 2 keywords may give either the calendar date using the 'yyyy-mm-dd' format, or may give
      * the full date and time using the 'yyyy-mm-ddThh:mm:ss.sss' format.
+     * 
+     * @see DateTime#DATE_END
      */
     DATE_END("DATE-END", SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "date of the end of observation"),
     /**
@@ -61,6 +67,8 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * seconds. The exact definition of 'exposure time' is mission dependent and may, for example, include corrections
      * for shutter open and close duration, detector dead time, vignetting, or other effects. This keyword is synonymous
      * with the EXPTIME keyword.
+     * 
+     * @see DateTime#XPOSURE
      */
     EXPOSURE(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "exposure time"),
     /**
@@ -85,6 +93,8 @@ public enum ObservationDurationDescription implements IFitsHeader {
     /**
      * The value field shall contain a floating point number giving the difference between the stop and start times of
      * the observation in units of seconds. This keyword is synonymous with the ELAPTIME keyword.
+     * 
+     * @see DateTime#TELAPSE
      */
     TELAPSE(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "elapsed time of the observation"),
     /**
@@ -104,7 +114,6 @@ public enum ObservationDurationDescription implements IFitsHeader {
      */
     TIME_OBS("TIME-OBS", SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "time at the start of the observation");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     ObservationDurationDescription(SOURCE status, HDU hdu, VALUE valueType, String comment) {
@@ -116,34 +125,8 @@ public enum ObservationDurationDescription implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -549,6 +549,46 @@ public enum Standard implements IFitsHeader {
     TZEROn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column scaling zero point"),
 
     /**
+     * The value field of this indexed keyword shall contain a floating point number specifying the maximum valid
+     * physical value represented in column n of the table, exclusive of any special values. This keyword may only be
+     * used in 'TABLE' or 'BINTABLE' extensions and is analogous to the DATAMAX keyword used for FITS images.
+     * 
+     * @since 1.19
+     */
+    TDMAXn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "maximum value in the column"),
+
+    /**
+     * The value field of this indexed keyword shall contain a floating point number specifying the minimum valid
+     * physical value represented in column n of the table, exclusive of any special values. This keyword may only be
+     * used in 'TABLE' or 'BINTABLE' extensions and is analogous to the DATAMIN keyword used for FITS images.
+     * 
+     * @since 1.19
+     */
+    TDMINn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "minimum value in the column"),
+
+    /**
+     * The value field of this indexed keyword shall contain a floating point number specifying the upper bound of the
+     * legal range of physical values that may be represented in column n of the table. The column may contain values
+     * that are greater than this legal maximum value but the interpretation of such values is not defined here. The
+     * value of this keyword is typically used as the maxinum value when constructing a histogram of the values in the
+     * column. This keyword may only be used in 'TABLE' or 'BINTABLE' extensions.
+     * 
+     * @since 1.19
+     */
+    TLMAXn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "maximum legal value in the column"),
+
+    /**
+     * The value field of this indexed keyword shall contain a floating point number specifying the lower bound of the
+     * legal range of physical values that may be represented in column n of the table. The column may contain values
+     * that are less than this legal minimum value but the interpretation of such values is not defined here. The value
+     * of this keyword is typically used as the mininum value when constructing a histogram of the values in the column.
+     * This keyword may only be used in 'TABLE' or 'BINTABLE' extensions.
+     * 
+     * @since 1.19
+     */
+    TLMINn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "minimum legal value in the column"),
+
+    /**
      * The value field shall contain a character string giving the name of the extension type. This keyword is mandatory
      * for an extension key and must not appear in the primary key. For an extension that is not a standard extension,
      * the type name must not be the same as that of a standard extension.

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -187,14 +187,17 @@ public enum Standard implements IFitsHeader {
      * The date on which the HDU was created, in the format specified in the FITS Standard. The old date format was
      * 'yy/mm/dd' and may be used only for dates from 1900 through 1999. the new Y2K compliant date format is
      * 'yyyy-mm-dd' or 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @see DateTime#DATE
      */
-
     DATE(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "date of file creation"),
 
     /**
      * The date of the observation, in the format specified in the FITS Standard. The old date format was 'yy/mm/dd' and
      * may be used only for dates from 1900 through 1999. The new Y2K compliant date format is 'yyyy-mm-dd' or
      * 'yyyy-mm-ddTHH:MM:SS[.sss]'.
+     * 
+     * @see DateTime#DATE_OBS
      */
     DATE_OBS("DATE-OBS", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "date of the observation"),
 
@@ -209,13 +212,16 @@ public enum Standard implements IFitsHeader {
      * EPOCH keyword and thus it shall not be used in FITS files created after the adoption of the standard; rather, the
      * EQUINOX keyword shall be used.
      *
-     * @deprecated use {@link #EQUINOX} in stead
+     * @deprecated use {@link #EQUINOX} instead
      */
-    @Deprecated
     EPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "equinox of celestial coordinate system"),
+
     /**
      * The value field shall contain a floating point number giving the equinox in years for the celestial coordinate
-     * system in which positions are expressed.
+     * system in which positions are expressed. This version of the keyword does not support alternative coordinate
+     * systems
+     * 
+     * @see WCS#EQUINOX
      */
     EQUINOX(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "equinox of celestial coordinate system"),
 
@@ -382,16 +388,18 @@ public enum Standard implements IFitsHeader {
     PZEROn(SOURCE.RESERVED, HDU.GROUPS, VALUE.REAL, "parameter scaling zero point"),
 
     /**
-     * Coordinate reference frame of major/minor axes.If absent the default value is 'FK5'.
+     * Coordinate reference frame of major/minor axes.If absent the default value is 'FK5'. This version of the keyword
+     * does not support alternative coordinate systems.
+     * 
+     * @see WCS#RADESYS
      */
     RADESYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
 
     /**
-     * Coordinate reference frame of major/minor axes. use RADESYS instead.
+     * Coordinate reference frame of major/minor axes (generic).
      *
-     * @deprecated use {@link #RADESYS} instead.
+     * @deprecated Deprecated in the current FITS satndard, use {@link WCS#RADESYS} instead.
      */
-    @Deprecated
     RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
 
     /**
@@ -531,6 +539,8 @@ public enum Standard implements IFitsHeader {
      */
     XTENSION(SOURCE.MANDATORY, HDU.EXTENSION, VALUE.STRING, "marks beginning of new HDU");
 
+    private static final ThreadLocal<Class<?>> COMMENT_CONTEXT = new ThreadLocal<>();
+
     /**
      * A shorthand for {@link #NAXISn}<code>.n(1)</code>, that is the regular dimension along the first, fastest FITS
      * array index (this is the same as the last dimension of Java arrays).
@@ -542,8 +552,6 @@ public enum Standard implements IFitsHeader {
      * array index (this is the same as the one before the last dimension of Java arrays).
      */
     public static final IFitsHeader NAXIS2 = NAXISn.n(2);
-
-    private static final ThreadLocal<Class<?>> COMMENT_CONTEXT = new ThreadLocal<>();
 
     /**
      * The value of the XTENSION keword in case of a binary table.
@@ -562,7 +570,6 @@ public enum Standard implements IFitsHeader {
 
     private final StandardCommentReplacement[] commentReplacements;
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     Standard(SOURCE status, HDU hdu, VALUE valueType, String comment, StandardCommentReplacement... replacements) {
@@ -574,6 +581,11 @@ public enum Standard implements IFitsHeader {
             StandardCommentReplacement... replacements) {
         key = new FitsHeaderImpl(headerName == null ? name() : headerName, status, hdu, valueType, comment);
         commentReplacements = replacements;
+    }
+
+    @Override
+    public final IFitsHeader impl() {
+        return key;
     }
 
     @Override
@@ -590,32 +602,6 @@ public enum Standard implements IFitsHeader {
             }
         }
         return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
     }
 
     /**

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -221,7 +221,7 @@ public enum Standard implements IFitsHeader {
      * system in which positions are expressed. This version of the keyword does not support alternative coordinate
      * systems
      * 
-     * @see WCS#EQUINOX
+     * @see WCS#EQUINOXa
      */
     EQUINOX(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "equinox of celestial coordinate system"),
 
@@ -391,16 +391,32 @@ public enum Standard implements IFitsHeader {
      * Coordinate reference frame of major/minor axes.If absent the default value is 'FK5'. This version of the keyword
      * does not support alternative coordinate systems.
      * 
-     * @see WCS#RADESYS
+     * @see WCS#RADESYSa
      */
     RADESYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
 
     /**
      * Coordinate reference frame of major/minor axes (generic).
      *
-     * @deprecated Deprecated in the current FITS satndard, use {@link WCS#RADESYS} instead.
+     * @deprecated Deprecated in the current FITS satndard, use {@link #RADESYS} instead.
      */
     RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
+
+    /**
+     * [Hz] Rest frequency of observed spectral line.
+     * 
+     * @since 1.19
+     * 
+     * @see   WCS#RESTFRQa
+     */
+    RESTFRQ(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[Hz] Line rest frequency"),
+
+    /**
+     * [Hz] Rest frequeny of observed spectral line (generic).
+     *
+     * @deprecated Deprecated in the current FITS standard, use {@link #RESTFRQ} instead.
+     */
+    RESTFREQ(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[Hz] Observed line rest frequency"),
 
     /**
      * The value field shall contain a character string citing a reference where the data associated with the key are

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -573,8 +573,7 @@ public enum Standard implements IFitsHeader {
     private final IFitsHeader key;
 
     Standard(SOURCE status, HDU hdu, VALUE valueType, String comment, StandardCommentReplacement... replacements) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
-        commentReplacements = replacements;
+        this(null, status, hdu, valueType, comment, replacements);
     }
 
     Standard(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment,

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -100,7 +100,7 @@ public enum Synonyms {
     WCSna(WCS.WCSna, WCS.TWCSna),
 
     /**
-     * Equivalent keywords for array column axis parameter names. The shorter form may be required for column indices
+     * Equivalent keywords for array column axis string parameters. The shorter form may be required for column indices
      * &gt;99 with alternate coordinate systems.
      * 
      * @since 1.19

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -38,23 +38,82 @@ import nom.tam.fits.header.extra.STScIExt;
  */
 
 /**
- * This enum wil try to list synonyms inside or over different dictionaries. So please use always the higest level
+ * This enum wil try to list synonyms inside or over different dictionaries. So please use always the highest level
  * keyword you can find.
  *
  * @author Richard van Nieuwenhoven
  */
+@SuppressWarnings("deprecation")
 public enum Synonyms {
 
     /** EQUINOX is now preferred over the old EPOCH */
-    @SuppressWarnings("deprecation")
+
     EQUINOX(Standard.EQUINOX, Standard.EPOCH),
 
     /** TIMESYS appears in multiple conventions */
     TIMESYS(NOAOExt.TIMESYS, STScIExt.TIMESYS),
 
-    /** RADESYS is no preferred over the old RADECSYS */
-    @SuppressWarnings("deprecation")
+    /** RADESYS is now preferred over the old RADECSYS */
     RADESYS(Standard.RADESYS, Standard.RADECSYS),
+
+    /** RESTFRQ is now preferred over the old RESTFREQ */
+    RESTFRQ(WCS.RESTFRQ, WCS.RESTFREQ),
+
+    /**
+     * Equivalent keywords for column coordinate transformation matrix (PC convention). The shorter form may be required
+     * for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TPn_n(WCS.TPn_n, WCS.TPCn_n),
+
+    /**
+     * Equivalent keywords for column coordinate transformation matrix (CD convention). The shorter form may be required
+     * for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TCn_n(WCS.TCn_n, WCS.TCDn_n),
+
+    /**
+     * Equivalent keywords for column parameter names. The shorter form may be required for column indices &gt;99 with
+     * alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TSn_n(WCS.TVn_n, WCS.TPSn_n),
+
+    /**
+     * Equivalent keywords for column parameter values. The shorter form may be required for column indices &gt;99 with
+     * alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TVn_n(WCS.TVn_n, WCS.TPVn_n),
+
+    /**
+     * Equivalent keywords for column coordinate transformation matrix (PC convention). The shorter form may be required
+     * for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    WCSn(WCS.WCSn, WCS.TWCSn),
+
+    /**
+     * Equivalent keywords for array column axis parameter names. The shorter form may be required for column indices
+     * &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    nSn_n(WCS.nSn_n, WCS.nPSn_n),
+
+    /**
+     * Equivalent keywords for array column axis parameter values. The shorter form may be required for column indices
+     * &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    nVn_n(WCS.nVn_n, WCS.nPVn_n),
 
     /** DARKTIME appears in multiple conventions */
     DARKTIME(NOAOExt.DARKTIME, SBFitsExt.DARKTIME);

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -57,7 +57,7 @@ public enum Synonyms {
     RADESYS(Standard.RADESYS, Standard.RADECSYS),
 
     /** RESTFRQ is now preferred over the old RESTFREQ */
-    RESTFRQ(WCS.RESTFRQ, WCS.RESTFREQ),
+    RESTFRQ(Standard.RESTFRQ, WCS.RESTFREQ),
 
     /**
      * Equivalent keywords for column coordinate transformation matrix (PC convention). The shorter form may be required
@@ -65,7 +65,7 @@ public enum Synonyms {
      * 
      * @since 1.19
      */
-    TPn_n(WCS.TPn_n, WCS.TPCn_n),
+    TPn_na(WCS.TPn_na, WCS.TPCn_na),
 
     /**
      * Equivalent keywords for column coordinate transformation matrix (CD convention). The shorter form may be required
@@ -73,7 +73,7 @@ public enum Synonyms {
      * 
      * @since 1.19
      */
-    TCn_n(WCS.TCn_n, WCS.TCDn_n),
+    TCn_na(WCS.TCn_na, WCS.TCDn_na),
 
     /**
      * Equivalent keywords for column parameter names. The shorter form may be required for column indices &gt;99 with
@@ -81,7 +81,7 @@ public enum Synonyms {
      * 
      * @since 1.19
      */
-    TSn_n(WCS.TVn_n, WCS.TPSn_n),
+    TSn_na(WCS.TVn_na, WCS.TPSn_na),
 
     /**
      * Equivalent keywords for column parameter values. The shorter form may be required for column indices &gt;99 with
@@ -89,7 +89,7 @@ public enum Synonyms {
      * 
      * @since 1.19
      */
-    TVn_n(WCS.TVn_n, WCS.TPVn_n),
+    TVn_na(WCS.TVn_na, WCS.TPVn_na),
 
     /**
      * Equivalent keywords for column coordinate transformation matrix (PC convention). The shorter form may be required
@@ -97,7 +97,7 @@ public enum Synonyms {
      * 
      * @since 1.19
      */
-    WCSn(WCS.WCSn, WCS.TWCSn),
+    WCSna(WCS.WCSna, WCS.TWCSna),
 
     /**
      * Equivalent keywords for array column axis parameter names. The shorter form may be required for column indices
@@ -105,7 +105,7 @@ public enum Synonyms {
      * 
      * @since 1.19
      */
-    nSn_n(WCS.nSn_n, WCS.nPSn_n),
+    nSn_na(WCS.nSn_na, WCS.nPSn_na),
 
     /**
      * Equivalent keywords for array column axis parameter values. The shorter form may be required for column indices
@@ -113,7 +113,7 @@ public enum Synonyms {
      * 
      * @since 1.19
      */
-    nVn_n(WCS.nVn_n, WCS.nPVn_n),
+    nVn_na(WCS.nVn_na, WCS.nPVn_na),
 
     /** DARKTIME appears in multiple conventions */
     DARKTIME(NOAOExt.DARKTIME, SBFitsExt.DARKTIME);

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -952,26 +952,6 @@ public enum WCS implements IFitsHeader {
         supportsAlt = allowsAlt;
     }
 
-    @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
     /**
      * Use for specifying an alternative coordinate system.
      * 
@@ -1021,17 +1001,6 @@ public enum WCS implements IFitsHeader {
      */
     public boolean supportsAlt() {
         return supportsAlt;
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -958,7 +958,8 @@ public enum WCS implements IFitsHeader {
     }
 
     /**
-     * Use for specifying an alternative coordinate system.
+     * Use for specifying an alternative coordinate system. You will want to call this before chaining other calls to
+     * {@link IFitsHeader}.
      * 
      * @param  c                             The alternativce coordinate system marker 'A' through 'Z' (case
      *                                           insensitive).

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -1,5 +1,36 @@
 package nom.tam.fits.header;
 
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
 /**
  * Standard FITS keywords for defining world coordinate systems (WCS). Many (but not all) keywords listed here support
  * alternative coordinate systems, which can be set via the {@link #alt(char)} method.
@@ -910,8 +941,7 @@ public enum WCS implements IFitsHeader {
     private boolean supportsAlt;
 
     WCS(SOURCE status, HDU hdu, VALUE valueType, boolean allowsAlt, String comment) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
-        supportsAlt = allowsAlt;
+        this(null, status, hdu, valueType, allowsAlt, comment);
     }
 
     WCS(String headerName, SOURCE status, HDU hdu, VALUE valueType, boolean allowsAlt, String comment) {

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -954,12 +954,13 @@ public enum WCS implements IFitsHeader {
     }
 
     /**
-     * Use for specifying an alternative coordinate system. This call is available only for the enums, which have a
-     * lower-case 'a' at the end of their Java names. Attempting to call this on keywords that do not end with
-     * lower-case 'a' will throw and {@link UnsupportedOperationException}. You will want to call this before chaining
-     * other calls to {@link IFitsHeader}.
+     * Use for specifying an alternative coordinate system. Alterntive systems are labelled 'A' through 'Z'. This call
+     * is available only for the enums, which have a lower-case 'a' at the end of their Java names (such as
+     * {@link #WCSNAMEa}). Attempting to call this on WCS keywords that do not end with lower-case 'a' in their Java
+     * names (such as {@link #OBSGEO_X} will throw and {@link UnsupportedOperationException}. You will want to call this
+     * before chaining other calls to {@link IFitsHeader}.
      * 
-     * @param  c                             The alternativce coordinate system marker 'A' through 'Z' (case
+     * @param  c                             The alternative coordinate system marker 'A' through 'Z' (case
      *                                           insensitive).
      * 
      * @return                               The standard FITS keyword with the alternate coordinate system marker
@@ -970,7 +971,7 @@ public enum WCS implements IFitsHeader {
      * @throws UnsupportedOperationException if the keyword does not support alternative coordinate systems
      */
     public IFitsHeader alt(char c) throws IllegalArgumentException, UnsupportedOperationException {
-        if (!key().contains("a")) {
+        if (!name().endsWith("a")) {
             throw new UnsupportedOperationException("WCS keyword " + key.key() + " does not support alternatives.");
         }
 
@@ -979,9 +980,7 @@ public enum WCS implements IFitsHeader {
             throw new IllegalArgumentException("Expected 'A' through 'Z': Got '%c'");
         }
 
-        String headerName = key().replace('a', Character.toUpperCase(c));
-
-        return new FitsHeaderImpl(headerName.toString(), status(), hdu(), valueType(), comment());
+        return new FitsHeaderImpl(key() + Character.toUpperCase(c), status(), hdu(), valueType(), comment());
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -1,0 +1,1037 @@
+package nom.tam.fits.header;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import nom.tam.fits.HeaderCard;
+
+/**
+ * Standard FITS keywords for defining world coordinate systems (WCS). Many (but not all) keywords listed here support
+ * alternative coordinate systems, which can be set via the {@link #alt(char)} method.
+ * 
+ * @author Attila Kovacs
+ * 
+ * @see    DateTime
+ * 
+ * @since  1.19
+ */
+public enum WCS implements IFitsHeader {
+
+    /**
+     * World coordinate system name
+     * 
+     * @since 1.19
+     */
+    WCSNAME(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Coordinate system name"),
+
+    /**
+     * Dimensionality of image coordinate system
+     * 
+     * @since 1.19
+     */
+    WCSAXES(SOURCE.RESERVED, HDU.IMAGE, VALUE.INTEGER, true, "Coordinate system dimensions"),
+
+    /**
+     * Coordinate reference frame of major/minor axes.If absent the default value is 'FK5'.
+     */
+    RADESYS(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Coordinate reference frame of major/minor axes."),
+
+    /**
+     * Coordinate reference frame of major/minor axes (generic).
+     *
+     * @deprecated Deprecated in the current FITS standard, use {@link #RADESYS} instead.
+     */
+    RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "Coordinate reference frame of major/minor axes."),
+
+    /**
+     * [deg] The longitude of the celestial pole (for spherical coordinates).
+     * 
+     * @since 1.19
+     */
+    LONPOLE(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "[deg] Celestial pole longitude"),
+
+    /**
+     * [deg] The latitude of the celestial pole (for spherical coordinates).
+     * 
+     * @since 1.19
+     */
+    LATPOLE(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "[deg] Celestial pole latitude"),
+
+    /**
+     * The value field shall contain a floating point number giving the equinox in years for the celestial coordinate
+     * system in which positions are expressed. Starting with Version 1, the Standard has deprecated the use of the
+     * EPOCH keyword and thus it shall not be used in FITS files created after the adoption of the standard; rather, the
+     * EQUINOX keyword shall be used.
+     *
+     * @deprecated Deprecated in the current FITS standard, use {@link #EQUINOX} instead.
+     */
+    @Deprecated
+    EPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, false, "equinox of celestial coordinate system"),
+
+    /**
+     * The value field shall contain a floating point number giving the equinox in years for the celestial coordinate
+     * system in which positions are expressed.
+     * 
+     * @since 1.19
+     */
+    EQUINOX(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "equinox of celestial coordinate system"),
+
+    /**
+     * Coordinate axis name.
+     * 
+     * @since 1.19
+     */
+    CNAMEn(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "coordinate system display name"),
+
+    /**
+     * The value field shall contain a floating point number, identifying the location of a reference point along axis
+     * n, in units of the axis index. This value is based upon a counter that runs from 1 to NAXISn with an increment of
+     * 1 per pixel. The reference point value need not be that for the center of a pixel nor lie within the actual data
+     * array. Use comments to indicate the location of the index point relative to the pixel.
+     * 
+     * @since 1.19
+     */
+    CRPIXn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "coordinate system reference pixel"),
+
+    /**
+     * The value field shall contain a floating point number, giving the value of the coordinate specified by the CTYPEn
+     * keyword at the reference point CRPIXn. Units must follow the prescriptions of section 5.3 of the FITS Standard.
+     * 
+     * @since 1.19
+     */
+    CRVALn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "coordinate system value at reference pixel"),
+
+    /**
+     * The value field shall contain a character string, giving the name of the coordinate represented by axis n.
+     * 
+     * @since 1.19
+     */
+    CTYPEn(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "name of the coordinate axis"),
+
+    /**
+     * The value field shall contain a floating point number giving the partial derivative of the coordinate specified
+     * by the CTYPEn keywords with respect to the pixel index, evaluated at the reference point CRPIXn, in units of the
+     * coordinate specified by the CTYPEn keyword. These units must follow the prescriptions of section 5.3 of the FITS
+     * Standard.
+     * 
+     * @since 1.19
+     */
+    CDELTn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "coordinate increment along axis"),
+
+    /**
+     * Random coordinate error on axis <i>n</i> in the physical coordinate unit (if defined).
+     * 
+     * @since 1.19
+     */
+    CRDERn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "random error in coordinate"),
+
+    /**
+     * Systematic coordinate error on axis <i>n</i> in the physical coordinate unit (if defined).
+     * 
+     * @since 1.19
+     */
+    CSYERn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "systematic error in coordinate"),
+
+    /**
+     * Phase axis zero point
+     * 
+     * @since 1.19
+     */
+    CZPHSn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "phase axis zero point"),
+
+    /**
+     * Phase axis period
+     */
+    CPERIn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "phase axis period"),
+
+    /**
+     * [Hz] Rest frequency of observed spectral line.
+     * 
+     * @since 1.19
+     */
+    RESTFRQ(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "[Hz] Line rest frequency"),
+
+    /**
+     * [Hz] Rest frequeny of observed spectral line (generic).
+     *
+     * @deprecated Deprecated in the current FITS standard, use {@link #RESTFRQ} instead.
+     */
+    RESTFREQ(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "[Hz] Observed line rest frequency"),
+
+    /**
+     * [m] Rest wavelength of observed spectral line in image.
+     * 
+     * @since 1.19
+     */
+    RESTWAV(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "[m] Line rest wavelength"),
+
+    /**
+     * Image spectral reference system name.
+     * 
+     * @since 1.19
+     */
+    SPECSYS(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Spectral reference frame"),
+
+    /**
+     * Image spectral reference system name of observer.
+     * 
+     * @since 1.19
+     */
+    SSYSOBS(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Spectral reference frame of observer"),
+
+    /**
+     * Spectral reference system name of source.
+     * 
+     * @since 1.19
+     */
+    SSYSSRC(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Spectral reference frame of source"),
+
+    /**
+     * [m/s] Radial velocity of source in the spectral reference frame.
+     * 
+     * @since 1.19
+     */
+    VELOSYS(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "[m/s] source radial velocity"),
+
+    /**
+     * Redshift value of source in the spectral reference frame.
+     * 
+     * @since 1.19
+     */
+    ZSOURCE(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "source redshift value"),
+
+    /**
+     * [deg] True velocity angle of source
+     * 
+     * @since 1.19
+     */
+    VELANGL(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "[deg] True velocity angle"),
+
+    /**
+     * [m] Geodetic location of observer (<i>x</i> coordinate).
+     * 
+     * @since 1.19
+     */
+    OBSGEO_X("OBSGEO-X", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "[m] Geodetic location x of observer"),
+
+    /**
+     * [m] Geodetic location of observer (<i>y</i> coordinate).
+     * 
+     * @since 1.19
+     */
+    OBSGEO_Y("OBSGEO-Y", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "[m] Geodetic location y of observer"),
+
+    /**
+     * [m] Geodetic location of observer (<i>z</i> coordinate).
+     * 
+     * @since 1.19
+     */
+    OBSGEO_Z("OBSGEO-Z", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "[m] Geodetic location z of observer"),
+
+    /**
+     * WCS name for the array entries in the given column index.
+     * 
+     * @since 1.19
+     */
+    WCSNn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column WCS name"),
+
+    /**
+     * [deg] The longitude of the celestial pole for the entries in the given column index (for spherical coordinates).
+     * 
+     * @since 1.19
+     */
+    LONPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[deg] column celestial pole longitude"),
+
+    /**
+     * [deg] The latitude of the celestial pole for the entries in the given column index (for spherical coordinates).
+     * 
+     * @since 1.19
+     */
+    LATPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[deg] column celestial pole latitude"),
+
+    /**
+     * [yr] Coordinate epoch for which the celestial coorinate system is defined for the given column index.
+     * 
+     * @since 1.19
+     */
+    EQUIn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[yr] column coordinate epoch"),
+
+    /**
+     * The equatorial coordinate frame used for the given column index, e.g. 'FK4', 'FK5', or 'ICRS'.
+     * 
+     * @since 1.19
+     */
+    RADEn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column equatorial coordinate frame"),
+
+    /**
+     * [Hz] The rest frequency of the line in the given column index.
+     * 
+     * @since 1.19
+     */
+    RFRQn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[Hz] line rest frequency in column"),
+
+    /**
+     * [Hz] The rest wavelength of the line in the given column index.
+     * 
+     * @since 1.19
+     */
+    RWAVn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[m] line rest wavelength in column"),
+
+    /**
+     * Spectral reference frame for the given column index.
+     * 
+     * @since 1.19
+     */
+    SPECn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column spectral reference frame"),
+
+    /**
+     * Spectral reference system of observer for the given column index.
+     * 
+     * @since 1.19
+     */
+    SOBSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column observer spectral frame"),
+
+    /**
+     * Spectral reference system of source for the given column index.
+     * 
+     * @since 1.19
+     */
+    SSRCn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column source spectral frame"),
+
+    /**
+     * [m/s] Source radial velocity for the given column index.
+     * 
+     * @since 1.19
+     */
+    VSYSn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[m/s] column radial velocity"),
+
+    /**
+     * [deg] Angle of true velocity for the given column index.
+     * 
+     * @since 1.19
+     */
+    VANGn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[deg] angle of velocity in column"),
+
+    /**
+     * Source redshift value for the given column index.
+     * 
+     * @since 1.19
+     */
+    ZSOUn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column redshift value"),
+
+    /**
+     * [m] Geodetic location (<i>x</i> coordinate) of observer for he given column index.
+     * 
+     * @since 1.19
+     */
+    OBSGXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[m] column geodetic location x"),
+
+    /**
+     * [m] Geodetic location (<i>y</i> coordinate) of observer for he given column index.
+     * 
+     * @since 1.19
+     */
+    OBSGYn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[m] column geodetic location y"),
+
+    /**
+     * [m] Geodetic location (<i>z</i> coordinate) of observer for he given column index.
+     * 
+     * @since 1.19
+     */
+    OBSGZn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[m] column geodetic location z"),
+
+    /**
+     * The coordinate axis type for array entries in this column (trailing index). The number of coordinate axes
+     * (leading index) defined this way should match the dimensionality of the array elements in the column. This
+     * version does not support alternative coordinates systems.
+     * 
+     * @see   #nCTYn
+     * 
+     * @since 1.19
+     */
+    nCTYPn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, false, "column coordinate axis type"),
+
+    /**
+     * The coordinate axis type for array entries in this column (trailing index). The number of coordinate axes
+     * (leading index) defined this way should match the dimensionality of the array elements in the column. This
+     * version supports alternative coordinates systems.
+     * 
+     * @see   #nCTYPn
+     * 
+     * @since 1.19
+     */
+    nCTYn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column coordinate axis type"),
+
+    /**
+     * The coordinate axis name for array entries in this column (trailing index). The number of coordinate axes
+     * (leading index) defined this way should match the dimensionality of the array elements in the column.
+     * 
+     * @since 1.19
+     */
+    nCNAn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column coordinate axis type"),
+
+    /**
+     * The physical coordinate unit for array entries in this column (trailing index). The number of coordinate axes
+     * (leading index) defined this way should match the dimensionality of the array elements in the column. This
+     * version does not support alternative coordinates systems.
+     * 
+     * @see   #nCUNn
+     * 
+     * @since 1.19
+     */
+    nCUNIn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, false, "column coordinate axis unit"),
+
+    /**
+     * The physical coordinate unit for array entries in this column (trailing index). The number of coordinate axes
+     * (leading index) defined this way should match the dimensionality of the array elements in the column. This
+     * version supports alternative coordinates systems.
+     * 
+     * @see   #nCUNIn
+     * 
+     * @since 1.19
+     */
+    nCUNn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column coordinate axis unit"),
+
+    /**
+     * The coordinate reference value in the physical unit of the axis (if defined) for array entries in this column
+     * (trailing index). The number of coordinate axes (leading index) defined this way should match the dimensionality
+     * of the array elements in the column. This version does not support alternative coordinates systems.
+     * 
+     * @see   #nCRVn
+     * 
+     * @since 1.19
+     */
+    nCRVLn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column coordinate axis reference value"),
+
+    /**
+     * The coordinate reference value in the physical unit of the axis (if defined) for array entries in this column
+     * (trailing index). The number of coordinate axes (leading index) defined this way should match the dimensionality
+     * of the array elements in the column. This version supports alternative coordinates systems.
+     * 
+     * @see   #nCRVLn
+     * 
+     * @since 1.19
+     */
+    nCRVn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis reference value"),
+
+    /**
+     * The coordinate axis random error in the physical unit of the axis (if defined) for array entries in this column
+     * (trailing index). The number of coordinate axes (leading index) defined this way should match the dimensionality
+     * of the array elements in the column.
+     * 
+     * @since 1.19
+     */
+    nCRDn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis random error"),
+
+    /**
+     * The coordinate axis systematic error in the physical unit of the axis (if defined) for array entries in this
+     * column (trailing index). The number of coordinate axes (leading index) defined this way should match the
+     * dimensionality of the array elements in the column.
+     * 
+     * @since 1.19
+     */
+    nCSYn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis systematic error"),
+
+    /**
+     * Phase axis zero point on axis (leading index) for array entries in this column (trailing index)
+     * 
+     * @since 1.19
+     */
+    nCZPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "phase axis zero point"),
+
+    /**
+     * Phase axis period on axis (leading index) for array entries in this column (trailing index)
+     * 
+     * @since 1.19
+     */
+    nCPRn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "phase axis period"),
+
+    /**
+     * The coordinate axis spacing in the physical unit of the axis (if defined) for array entries in this column
+     * (trailing index). The number of coordinate axes (leading index) defined this way should match the dimensionality
+     * of the array elements in the column. This version does not support alternative coordinates systems.
+     * 
+     * @see   #nCDEn
+     * 
+     * @since 1.19
+     */
+    nCDLTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column coordinate axis spacing"),
+
+    /**
+     * The coordinate axis spacing in the physical unit of the axis (if defined) for array entries in this column
+     * (trailing index). The number of coordinate axes (leading index) defined this way should match the dimensionality
+     * of the array elements in the column. This version supports alternative coordinates systems.
+     * 
+     * @see   #nCDLTn
+     * 
+     * @since 1.19
+     */
+    nCDEn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis spacing"),
+
+    /**
+     * The 1-based coordinate reference pixel index in the physical unit of the axis (if defined) for array entries in
+     * this column (trailing index). The number of coordinate axes (leading index) defined this way should match the
+     * dimensionality of the array elements in the column. This version does not support alternative coordinates
+     * systems.
+     * 
+     * @see   #nCRPn
+     * 
+     * @since 1.19
+     */
+    nCRPXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column coordinate axis reference pixel"),
+
+    /**
+     * The 1-based coordinate reference pixel index in the physical unit of the axis (if defined) for array entries in
+     * this column (trailing index). The number of coordinate axes (leading index) defined this way should match the
+     * dimensionality of the array elements in the column. This version supports alternative coordinates systems.
+     * 
+     * @see   #nCRPXn
+     * 
+     * @since 1.19
+     */
+    nCRPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis reference pixel"),
+
+    /**
+     * @deprecated The FITS standard deprecated this keyword. Use {@link WCS#nnPCn} and {@link WCS#nnCDn}instead. [deg]
+     *                 The coordinate axis rotation in the physical unit of the axis (if defined) for array entries in
+     *                 this column (trailing index). The number of coordinate axes (leading index) defined this way
+     *                 should match the dimensionality of the array elements in the column.
+     * 
+     * @since      1.19
+     */
+    nCROTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[deg] column coordinate axis rotation"),
+
+    /**
+     * Coordinate transformation matrix in the PC convention. from rectilinear coordinate index <i>i</i> (leading index)
+     * to coordinate index <i>j</i> (second index) for the for array entries in this column (trailing index). The number
+     * of coordinate axes (leading index) defined this way should match the dimensionality of the array elements in the
+     * column.
+     * 
+     * @since 1.19
+     */
+    nnPCn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coord. trans. matrix element"),
+
+    /**
+     * Coordinate transformation matrix in the CD convention. from rectilinear coordinate index <i>i</i> (leading index)
+     * to coordinate index <i>j</i> (second index) for the for array entries in this column (trailing index). The number
+     * of coordinate axes (leading index) defined this way should match the dimensionality of the array elements in the
+     * column.
+     * 
+     * @since 1.19
+     */
+    nnCDn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coord. trans. matrix element"),
+
+    /**
+     * The coordinate parameter name <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
+     * this column (middle index). The number of coordinate axes (leading index) defined this way should match the
+     * dimensionality of the array elements in the column. The shorter {@link #nSn_n} form may be required for column
+     * indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    nPSn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column axis parameter name"),
+
+    /**
+     * The coordinate parameter name <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
+     * this column (middle index). The number of coordinate axes (leading index) defined this way should match the
+     * dimensionality of the array elements in the column. Same as {@value #nPSn_n}. This shorter form may be required
+     * for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    nSn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column axis parameter name"),
+
+    /**
+     * The coordinate parameter value <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
+     * this column (middle index). The number of coordinateaxes defined this way should match the dimensionality of the
+     * array elements in the column. The shorter {@link #nVn_n} form may be required for column indices &gt;99 with
+     * alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    nPVn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column axis parameter value"),
+
+    /**
+     * The coordinate parameter value <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
+     * this column (middle index). The number of coordinateaxes defined this way should match the dimensionality of the
+     * array elements in the column. Same as {@link #nPVn_n}. This shorter form may be required for column indices
+     * &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    nVn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column axis parameter value"),
+
+    /**
+     * The coordinate parameter value for axis <i>i</i> (leading index) for array entries in this column (middle index).
+     * The number of coordinate axes defined this way should match the dimensionality of the array elements in the
+     * column.
+     * 
+     * @since 1.19
+     */
+    nVn_X(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column axis parameter value"),
+
+    /**
+     * WCS name for the pixe list entries in the given column index. Same as {@link #TWCSn}. This shorter form may be
+     * required for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    WCSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column WCS name"),
+
+    /**
+     * WCS name for the pixe list entries in the given column index. The shorter form {@link #WCSn} may be required for
+     * column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TWCSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column WCS name"),
+
+    /**
+     * WCS dimensions for given column index.
+     * 
+     * @since 1.19
+     */
+    WCAXn(SOURCE.RESERVED, HDU.TABLE, VALUE.INTEGER, true, "Coordinate dimensions"),
+
+    /**
+     * The coordinate axis type for (1D) pixel lists in this column (trailing index). This version does not support
+     * alternative coordinates systems.
+     * 
+     * @see   #TCTYn
+     * 
+     * @since 1.19
+     */
+    TCTYPn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, false, "column pixel axis type"),
+
+    /**
+     * The coordinate axis type for (1D) pixel lists in this column (trailing index). This version supports alternative
+     * coordinates systems.
+     * 
+     * @see   #TCTYPn
+     * 
+     * @since 1.19
+     */
+    TCTYn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column pixel axis type"),
+
+    /**
+     * The coordinate axis name for (1D) pixel lists in this column (trailing index).
+     * 
+     * @since 1.19
+     */
+    TCNAn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column pixel axis name"),
+
+    /**
+     * The physical coordinate unit for (1D) pixel lists in this column (trailing index). This version does not support
+     * alternative coordinates systems.
+     * 
+     * @see   #TCUNn
+     * 
+     * @since 1.19
+     */
+    TCUNIn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, false, "column pixel axis unit"),
+
+    /**
+     * The physical coordinate unit for (1D) pixel lists in this column (trailing index). This version supports
+     * alternative coordinates systems.
+     * 
+     * @see   #TCUNIn
+     * 
+     * @since 1.19
+     */
+    TCUNn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column pixel axis unit"),
+
+    /**
+     * The coordinate reference value in the physical unit of the axis (if defined) for the (1D) pixel lists in this
+     * column (trailing index). This version does not support alternative coordinates systems.
+     * 
+     * @see   #TCRVn
+     * 
+     * @since 1.19
+     */
+    TCRVLn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column pixel axis reference value"),
+
+    /**
+     * The coordinate reference value in the physical unit of the axis (if defined) for the (1D) pixel lists in this
+     * column (trailing index). This version supports alternative coordinates systems.
+     * 
+     * @see   #TCRVn
+     * 
+     * @since 1.19
+     */
+    TCRVn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis reference value"),
+
+    /**
+     * The coordinate axis spacing in the physical unit of the axis (if defined) for the (1D_) pixel lists in this
+     * column (trailing index). This version does not support alternative coordinates systems.
+     * 
+     * @see   #TCDEn
+     * 
+     * @since 1.19
+     */
+    TCDLTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column pixel axis spacing"),
+
+    /**
+     * The coordinate axis spacing in the physical unit of the axis (if defined) for the (1D_) pixel lists in this
+     * column (trailing index). This version supports alternative coordinates systems.
+     * 
+     * @see   #TCDLTn
+     * 
+     * @since 1.19
+     */
+    TCDEn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis spacing"),
+
+    /**
+     * The coordinate axis random error in the physical unit of the axis (if defined) for the (1D_) pixel lists in this
+     * column (trailing index).
+     * 
+     * @since 1.19
+     */
+    TCRDn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis random error"),
+
+    /**
+     * The coordinate axis systematics error in the physical unit of the axis (if defined) for the (1D_) pixel lists in
+     * this column (trailing index).
+     * 
+     * @since 1.19
+     */
+    TCSYn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis random error"),
+
+    /**
+     * Phase axis zero point on axis (leading index) for array entries in this column (trailing index)
+     * 
+     * @since 1.19
+     */
+    TCZPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "phase axis zero point"),
+
+    /**
+     * Phase axis period on axis (leading index) for array entries in this column (trailing index)
+     * 
+     * @since 1.19
+     */
+    TCPRn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "phase axis period"),
+
+    /**
+     * The 1-based coordinate reference pixel index in the physical unit of the axis (if defined) for the (1D) pixel
+     * lists in this column (trailing index). This version does not support alternative coordinates systems.
+     * 
+     * @see   #TCRPn
+     * 
+     * @since 1.19
+     */
+    TCRPXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column pixel axis reference pixel"),
+
+    /**
+     * The 1-based coordinate reference pixel index in the physical unit of the axis (if defined) for the (1D) pixel
+     * lists in this column (trailing index). This version supports alternative coordinates systems.
+     * 
+     * @see   #TCRPXn
+     * 
+     * @since 1.19
+     */
+    TCRPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis reference pixel"),
+
+    /**
+     * Coordinate transformation matrix in the PC convention. from column index <i>n</i> (leading index) to column index
+     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. The shorter form {@link #TPn_n} may be
+     * required for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @see   #TPn_n
+     * 
+     * @since 1.19
+     */
+    TPCn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pix trans. matrix element"),
+
+    /**
+     * Coordinate transformation matrix in the PC convention. from column index <i>n</i> (leading index) to column index
+     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. Same as {@link #TPCn_n}. This shorter
+     * form may be required for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @see   #TPCn_n
+     * 
+     * @since 1.19
+     */
+    TPn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pix trans. matrix element"),
+
+    /**
+     * @deprecated The FITS standard deprecated this keyword. Use {@link WCS#TPCn_n} and {@link WCS#TCDn_n}instead.
+     *                 [deg] The coordinate axis rotation in the physical unit of the axis (if defined) for the (1D)
+     *                 pixel lists in this column (trailing index).
+     * 
+     * @since      1.19
+     */
+    TCROTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[deg] column pixel axis rotation"),
+
+    /**
+     * Coordinate transformation matrix in the CD convention. from column index <i>n</i> (leading index) to column index
+     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. The shorter form {@link #TCn_n} may be
+     * required for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TCDn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pix trans. matrix element"),
+
+    /**
+     * Coordinate transformation matrix in the CD convention. from column index <i>n</i> (leading index) to column index
+     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. Same as {@link #TCDn_n}. This shorter
+     * form may be required for column indices &gt;99 with alternate coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TCn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pix trans. matrix element"),
+
+    /**
+     * The coordinate parameter name <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
+     * index). This shorter form {@link #TSn_n} may be required for column indices &gt;99 with alternate coordinate
+     * systems.
+     * 
+     * @since 1.19
+     */
+    TPSn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column axis parameter name"),
+
+    /**
+     * The coordinate parameter name <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
+     * index). Same as {@link #TPSn_n}. This shorter form may be required for column indices &gt;99 with alternate
+     * coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TSn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column axis parameter name"),
+
+    /**
+     * The coordinate parameter value <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
+     * index). The shorter form {@link #TVn_n} may be required for column indices &gt;99 with alternate coordinate
+     * systems.
+     * 
+     * @since 1.19
+     */
+    TPVn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis parameter value"),
+
+    /**
+     * The coordinate parameter value <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
+     * index). Same as {@value #TPVn_n}. This shorter form may be required for column indices &gt;99 with alternate
+     * coordinate systems.
+     * 
+     * @since 1.19
+     */
+    TVn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis parameter value");
+
+    /** ICRS coordinate reference frame */
+    public static final String RADESYS_ICRS = "ICRS";
+
+    /** IAU 1984 FK5 coordinate reference frame */
+    public static final String RADESYS_FK5 = "FK5";
+
+    /** Bessel-Newcomb FK4 coordinate reference frame */
+    public static final String RADESYS_FK4 = "FK4";
+
+    /** Bessel-Newcomb FK4 coordinate reference frame, without eccentricity terms */
+    public static final String RADESYS_FK4_NO_E = "FK4-NO-E";
+
+    /** Geocentric apparent place (IAU 1984) */
+    public static final String RADESYS_GAPPT = "GAPPT";
+
+    /** Logarithmically sampled algorithm code for {@link #CTYPEn} keywords */
+    public static final String ALGO_LOG = "LOG";
+
+    /** Detector sampling algorithm code for {@link #CTYPEn} keywords */
+    public static final String ALGO_GRI = "GRI";
+
+    /** Detector sampling algorithm code for {@link #CTYPEn} keywords */
+    public static final String ALGO_GRA = "GRA";
+
+    /** Irregular sampling algorithm code for {@link #CTYPEn} keywords */
+    public static final String ALGO_TAB = "TAB";
+
+    /** Spectral frequency coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_FREQ = "FREQ";
+
+    /** Spectral energy coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_ENER = "ENER";
+
+    /** Spectral wavenumber coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_WAVN = "WAVN";
+
+    /** Spectral radial velocity coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_VRAD = "VRAD";
+
+    /** Spectral vacuum wavenlength coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_WAVE = "WAVE";
+
+    /** Spectral optical velocity coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_VOPT = "VOPT";
+
+    /** Spectral redshift coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_ZOPT = "ZOPT";
+
+    /** Spectral wavelength in air coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_AWAV = "AWAV";
+
+    /** Spectral apparent radial velocity coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_VELO = "VELO";
+
+    /** Spectral beta factor (<i>v/c</i>) coordinate value for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_TYPE_BETA = "BETA";
+
+    /** Spectral frequency expressed as wavelength transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_F2W = "F2W";
+
+    /** Spectral frequency expressed as apparent radial velocity transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_F2V = "F2V";
+
+    /** Spectral frequency expressed as air wavelength transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_F2A = "F2A";
+
+    /** Spectral wavelength expressed as frequency transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_W2F = "W2F";
+
+    /** Spectral wavelength expressed as apparent radial velocity transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_W2V = "W2V";
+
+    /** Spectral wavelength expressed as air wavelength transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_W2A = "W2A";
+
+    /** Spectral radial velocity expressed as frequency transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_V2F = "V2F";
+
+    /** Spectral radial velocity expressed as wavelength transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_V2W = "V2W";
+
+    /** Spectral radial velocity expressed as air wavelength transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_V2A = "V2A";
+
+    /** Spectral air wavelength expressed as frequency transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_A2F = "A2F";
+
+    /** Spectral air wavelength expressed as vacuum wavelength transformation code for {@link #CTYPEn} keywords */
+    public static final String SPECTRAL_ALGO_A2W = "A2W";
+
+    /**
+     * Spectral air wavelength expressed as apparent radial velocity transformation code for {@link #CTYPEn} keywords
+     */
+    public static final String SPECTRAL_ALGO_A2V = "A2V";
+
+    private final IFitsHeader key;
+
+    private boolean supportsAlt;
+
+    WCS(SOURCE status, HDU hdu, VALUE valueType, boolean allowsAlt, String comment) {
+        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+        supportsAlt = allowsAlt;
+    }
+
+    WCS(String headerName, SOURCE status, HDU hdu, VALUE valueType, boolean allowsAlt, String comment) {
+        key = new FitsHeaderImpl(headerName == null ? name() : headerName, status, hdu, valueType, comment);
+        supportsAlt = allowsAlt;
+    }
+
+    @Override
+    public String comment() {
+        return key.comment();
+    }
+
+    @Override
+    public HDU hdu() {
+        return key.hdu();
+    }
+
+    @Override
+    public String key() {
+        return key.key();
+    }
+
+    @Override
+    public IFitsHeader n(int... number) {
+        return key.n(number);
+    }
+
+    /**
+     * Use for specifying an alternative coordinate system.
+     * 
+     * @param  c                             The alternativce coordinate system marker 'A' through 'Z' (case
+     *                                           insensitive).
+     * 
+     * @return                               The standard FITS keyword with the alternate coordinate system marker
+     *                                           attached.
+     * 
+     * @throws IllegalArgumentException      if the marker is outside of the legal range of 'A' through 'Z' (case
+     *                                           insensitive).
+     * @throws IllegalStateException         if the keyword with the alternate coordinate marker exceeeds the maximum
+     *                                           8-byre length of standard FITS keywords. You might want to use an
+     *                                           equivalent shorter alternative keyword.
+     * @throws UnsupportedOperationException if the keyword does not support alternative coordinate systems
+     * 
+     * @see                                  #supportsAlt()
+     */
+    public IFitsHeader alt(char c) throws IllegalArgumentException, IllegalStateException, UnsupportedOperationException {
+        if (!supportsAlt) {
+            throw new UnsupportedOperationException("WCS keyword " + key.key() + " does not support alternatives.");
+        }
+
+        c = Character.toUpperCase(c);
+        if (c < 'A' || c > 'Z') {
+            throw new IllegalArgumentException("Expected 'A' through 'Z': Got '%c'");
+        }
+
+        StringBuffer headerName = new StringBuffer(key.key());
+        headerName.append(Character.toUpperCase(c));
+
+        if (headerName.length() > HeaderCard.MAX_KEYWORD_LENGTH) {
+            throw new IllegalStateException(
+                    "Alternate keyword " + headerName.toString() + " is too long. Use shorter equivalent instead.");
+        }
+
+        return new FitsHeaderImpl(headerName.toString(), status(), hdu(), valueType(), comment());
+    }
+
+    /**
+     * Checks if this keyword can be used with alternative coordinate systems.
+     * 
+     * @return <code>true</code> if the keyword is capable of supporting alternative coordinate systems, or else
+     *             <code>false</code>
+     * 
+     * @see    #alt(char)
+     */
+    public boolean supportsAlt() {
+        return supportsAlt;
+    }
+
+    @Override
+    public SOURCE status() {
+        return key.status();
+    }
+
+    @Override
+    @SuppressWarnings("CPD-END")
+    public VALUE valueType() {
+        return key.valueType();
+    }
+
+}

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -952,6 +952,11 @@ public enum WCS implements IFitsHeader {
         supportsAlt = allowsAlt;
     }
 
+    @Override
+    public final IFitsHeader impl() {
+        return key;
+    }
+
     /**
      * Use for specifying an alternative coordinate system.
      * 

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -33,7 +33,8 @@ package nom.tam.fits.header;
 
 /**
  * Standard FITS keywords for defining world coordinate systems (WCS). Many (but not all) keywords listed here support
- * alternative coordinate systems, which can be set via the {@link #alt(char)} method.
+ * alternative coordinate systems. These have a lower case 'a' at the end of their enum names, e.g.
+ * <code>WCSNAMEa</code>. The alternative coordinate system for these can be set via the {@link #alt(char)} method.
  * 
  * @author Attila Kovacs
  * 
@@ -48,40 +49,42 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    WCSNAME(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Coordinate system name"),
+    WCSNAMEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Coordinate system name"),
 
     /**
      * Dimensionality of image coordinate system
      * 
      * @since 1.19
      */
-    WCSAXES(SOURCE.RESERVED, HDU.IMAGE, VALUE.INTEGER, true, "Coordinate system dimensions"),
+    WCSAXESa(SOURCE.RESERVED, HDU.IMAGE, VALUE.INTEGER, "Coordinate system dimensions"),
 
     /**
      * Coordinate reference frame of major/minor axes.If absent the default value is 'FK5'.
+     * 
+     * @since 1.19
      */
-    RADESYS(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Coordinate reference frame of major/minor axes."),
+    RADESYSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
 
     /**
      * Coordinate reference frame of major/minor axes (generic).
      *
-     * @deprecated Deprecated in the current FITS standard, use {@link #RADESYS} instead.
+     * @deprecated Deprecated in the current FITS standard, use {@link #RADESYSa} instead.
      */
-    RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "Coordinate reference frame of major/minor axes."),
+    RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
 
     /**
      * [deg] The longitude of the celestial pole (for spherical coordinates).
      * 
      * @since 1.19
      */
-    LONPOLE(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "[deg] Celestial pole longitude"),
+    LONPOLEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] Celestial pole longitude"),
 
     /**
      * [deg] The latitude of the celestial pole (for spherical coordinates).
      * 
      * @since 1.19
      */
-    LATPOLE(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "[deg] Celestial pole latitude"),
+    LATPOLEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] Celestial pole latitude"),
 
     /**
      * The value field shall contain a floating point number giving the equinox in years for the celestial coordinate
@@ -89,10 +92,10 @@ public enum WCS implements IFitsHeader {
      * EPOCH keyword and thus it shall not be used in FITS files created after the adoption of the standard; rather, the
      * EQUINOX keyword shall be used.
      *
-     * @deprecated Deprecated in the current FITS standard, use {@link #EQUINOX} instead.
+     * @deprecated Deprecated in the current FITS standard, use {@link #EQUINOXa} instead.
      */
     @Deprecated
-    EPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, false, "equinox of celestial coordinate system"),
+    EPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[yr] equinox of celestial coordinate system"),
 
     /**
      * The value field shall contain a floating point number giving the equinox in years for the celestial coordinate
@@ -100,14 +103,14 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    EQUINOX(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "equinox of celestial coordinate system"),
+    EQUINOXa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[yr] equinox of celestial coordinate system"),
 
     /**
      * Coordinate axis name.
      * 
      * @since 1.19
      */
-    CNAMEn(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "coordinate system display name"),
+    CNAMEna(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "coordinate system display name"),
 
     /**
      * The value field shall contain a floating point number, identifying the location of a reference point along axis
@@ -117,7 +120,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    CRPIXn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "coordinate system reference pixel"),
+    CRPIXna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate system reference pixel"),
 
     /**
      * The value field shall contain a floating point number, giving the value of the coordinate specified by the CTYPEn
@@ -125,14 +128,14 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    CRVALn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "coordinate system value at reference pixel"),
+    CRVALna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate system value at reference pixel"),
 
     /**
      * The value field shall contain a character string, giving the name of the coordinate represented by axis n.
      * 
      * @since 1.19
      */
-    CTYPEn(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "name of the coordinate axis"),
+    CTYPEna(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "name of the coordinate axis"),
 
     /**
      * The value field shall contain a floating point number giving the partial derivative of the coordinate specified
@@ -142,240 +145,240 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    CDELTn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "coordinate increment along axis"),
+    CDELTna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate increment along axis"),
 
     /**
      * Random coordinate error on axis <i>n</i> in the physical coordinate unit (if defined).
      * 
      * @since 1.19
      */
-    CRDERn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "random error in coordinate"),
+    CRDERna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "random error in coordinate"),
 
     /**
      * Systematic coordinate error on axis <i>n</i> in the physical coordinate unit (if defined).
      * 
      * @since 1.19
      */
-    CSYERn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "systematic error in coordinate"),
+    CSYERna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "systematic error in coordinate"),
 
     /**
      * Phase axis zero point
      * 
      * @since 1.19
      */
-    CZPHSn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "phase axis zero point"),
+    CZPHSna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "phase axis zero point"),
 
     /**
      * Phase axis period
      */
-    CPERIn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "phase axis period"),
+    CPERIna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "phase axis period"),
 
     /**
      * [Hz] Rest frequency of observed spectral line.
      * 
      * @since 1.19
      */
-    RESTFRQ(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "[Hz] Line rest frequency"),
+    RESTFRQa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[Hz] Line rest frequency"),
 
     /**
      * [Hz] Rest frequeny of observed spectral line (generic).
      *
-     * @deprecated Deprecated in the current FITS standard, use {@link #RESTFRQ} instead.
+     * @deprecated Deprecated in the current FITS standard, use {@link #RESTFRQa} instead.
      */
-    RESTFREQ(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "[Hz] Observed line rest frequency"),
+    RESTFREQ(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[Hz] Observed line rest frequency"),
 
     /**
      * [m] Rest wavelength of observed spectral line in image.
      * 
      * @since 1.19
      */
-    RESTWAV(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, true, "[m] Line rest wavelength"),
+    RESTWAVa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[m] Line rest wavelength"),
 
     /**
      * Image spectral reference system name.
      * 
      * @since 1.19
      */
-    SPECSYS(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Spectral reference frame"),
+    SPECSYSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Spectral reference frame"),
 
     /**
      * Image spectral reference system name of observer.
      * 
      * @since 1.19
      */
-    SSYSOBS(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Spectral reference frame of observer"),
+    SSYSOBSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Spectral reference frame of observer"),
 
     /**
      * Spectral reference system name of source.
      * 
      * @since 1.19
      */
-    SSYSSRC(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "Spectral reference frame of source"),
+    SSYSSRCa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Spectral reference frame of source"),
 
     /**
      * [m/s] Radial velocity of source in the spectral reference frame.
      * 
      * @since 1.19
      */
-    VELOSYS(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "[m/s] source radial velocity"),
+    VELOSYSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[m/s] source radial velocity"),
 
     /**
      * Redshift value of source in the spectral reference frame.
      * 
      * @since 1.19
      */
-    ZSOURCE(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "source redshift value"),
+    ZSOURCEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "source redshift value"),
 
     /**
      * [deg] True velocity angle of source
      * 
      * @since 1.19
      */
-    VELANGL(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, true, "[deg] True velocity angle"),
+    VELANGLa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] True velocity angle"),
 
     /**
      * [m] Geodetic location of observer (<i>x</i> coordinate).
      * 
      * @since 1.19
      */
-    OBSGEO_X("OBSGEO-X", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "[m] Geodetic location x of observer"),
+    OBSGEO_X("OBSGEO-X", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] Geodetic location x of observer"),
 
     /**
      * [m] Geodetic location of observer (<i>y</i> coordinate).
      * 
      * @since 1.19
      */
-    OBSGEO_Y("OBSGEO-Y", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "[m] Geodetic location y of observer"),
+    OBSGEO_Y("OBSGEO-Y", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] Geodetic location y of observer"),
 
     /**
      * [m] Geodetic location of observer (<i>z</i> coordinate).
      * 
      * @since 1.19
      */
-    OBSGEO_Z("OBSGEO-Z", SOURCE.RESERVED, HDU.ANY, VALUE.STRING, false, "[m] Geodetic location z of observer"),
+    OBSGEO_Z("OBSGEO-Z", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] Geodetic location z of observer"),
 
     /**
      * WCS name for the array entries in the given column index.
      * 
      * @since 1.19
      */
-    WCSNn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column WCS name"),
+    WCSNna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column WCS name"),
 
     /**
      * [deg] The longitude of the celestial pole for the entries in the given column index (for spherical coordinates).
      * 
      * @since 1.19
      */
-    LONPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[deg] column celestial pole longitude"),
+    LONPna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[deg] column celestial pole longitude"),
 
     /**
      * [deg] The latitude of the celestial pole for the entries in the given column index (for spherical coordinates).
      * 
      * @since 1.19
      */
-    LATPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[deg] column celestial pole latitude"),
+    LATPna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[deg] column celestial pole latitude"),
 
     /**
      * [yr] Coordinate epoch for which the celestial coorinate system is defined for the given column index.
      * 
      * @since 1.19
      */
-    EQUIn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[yr] column coordinate epoch"),
+    EQUIna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[yr] column coordinate epoch"),
 
     /**
      * The equatorial coordinate frame used for the given column index, e.g. 'FK4', 'FK5', or 'ICRS'.
      * 
      * @since 1.19
      */
-    RADEn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column equatorial coordinate frame"),
+    RADEna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column equatorial coordinate frame"),
 
     /**
      * [Hz] The rest frequency of the line in the given column index.
      * 
      * @since 1.19
      */
-    RFRQn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[Hz] line rest frequency in column"),
+    RFRQna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[Hz] line rest frequency in column"),
 
     /**
      * [Hz] The rest wavelength of the line in the given column index.
      * 
      * @since 1.19
      */
-    RWAVn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[m] line rest wavelength in column"),
+    RWAVna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[m] line rest wavelength in column"),
 
     /**
      * Spectral reference frame for the given column index.
      * 
      * @since 1.19
      */
-    SPECn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column spectral reference frame"),
+    SPECna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column spectral reference frame"),
 
     /**
      * Spectral reference system of observer for the given column index.
      * 
      * @since 1.19
      */
-    SOBSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column observer spectral frame"),
+    SOBSna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column observer spectral frame"),
 
     /**
      * Spectral reference system of source for the given column index.
      * 
      * @since 1.19
      */
-    SSRCn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column source spectral frame"),
+    SSRCna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column source spectral frame"),
 
     /**
      * [m/s] Source radial velocity for the given column index.
      * 
      * @since 1.19
      */
-    VSYSn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[m/s] column radial velocity"),
+    VSYSna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[m/s] column radial velocity"),
 
     /**
      * [deg] Angle of true velocity for the given column index.
      * 
      * @since 1.19
      */
-    VANGn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "[deg] angle of velocity in column"),
+    VANGna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[deg] angle of velocity in column"),
 
     /**
      * Source redshift value for the given column index.
      * 
      * @since 1.19
      */
-    ZSOUn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column redshift value"),
+    ZSOUna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column redshift value"),
 
     /**
      * [m] Geodetic location (<i>x</i> coordinate) of observer for he given column index.
      * 
      * @since 1.19
      */
-    OBSGXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[m] column geodetic location x"),
+    OBSGXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[m] column geodetic location x"),
 
     /**
      * [m] Geodetic location (<i>y</i> coordinate) of observer for he given column index.
      * 
      * @since 1.19
      */
-    OBSGYn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[m] column geodetic location y"),
+    OBSGYn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[m] column geodetic location y"),
 
     /**
      * [m] Geodetic location (<i>z</i> coordinate) of observer for he given column index.
      * 
      * @since 1.19
      */
-    OBSGZn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[m] column geodetic location z"),
+    OBSGZn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[m] column geodetic location z"),
 
     /**
      * The coordinate axis type for array entries in this column (trailing index). The number of coordinate axes
      * (leading index) defined this way should match the dimensionality of the array elements in the column. This
      * version does not support alternative coordinates systems.
      * 
-     * @see   #nCTYn
+     * @see   #nCTYna
      * 
      * @since 1.19
      */
-    nCTYPn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, false, "column coordinate axis type"),
+    nCTYPn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column coordinate axis type"),
 
     /**
      * The coordinate axis type for array entries in this column (trailing index). The number of coordinate axes
@@ -386,7 +389,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nCTYn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column coordinate axis type"),
+    nCTYna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column coordinate axis type"),
 
     /**
      * The coordinate axis name for array entries in this column (trailing index). The number of coordinate axes
@@ -394,18 +397,18 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nCNAn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column coordinate axis type"),
+    nCNAna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column coordinate axis type"),
 
     /**
      * The physical coordinate unit for array entries in this column (trailing index). The number of coordinate axes
      * (leading index) defined this way should match the dimensionality of the array elements in the column. This
      * version does not support alternative coordinates systems.
      * 
-     * @see   #nCUNn
+     * @see   #nCUNna
      * 
      * @since 1.19
      */
-    nCUNIn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, false, "column coordinate axis unit"),
+    nCUNIn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column coordinate axis unit"),
 
     /**
      * The physical coordinate unit for array entries in this column (trailing index). The number of coordinate axes
@@ -416,18 +419,18 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nCUNn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column coordinate axis unit"),
+    nCUNna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column coordinate axis unit"),
 
     /**
      * The coordinate reference value in the physical unit of the axis (if defined) for array entries in this column
      * (trailing index). The number of coordinate axes (leading index) defined this way should match the dimensionality
      * of the array elements in the column. This version does not support alternative coordinates systems.
      * 
-     * @see   #nCRVn
+     * @see   #nCRVna
      * 
      * @since 1.19
      */
-    nCRVLn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column coordinate axis reference value"),
+    nCRVLn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coordinate axis reference value"),
 
     /**
      * The coordinate reference value in the physical unit of the axis (if defined) for array entries in this column
@@ -438,7 +441,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nCRVn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis reference value"),
+    nCRVna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coordinate axis reference value"),
 
     /**
      * The coordinate axis random error in the physical unit of the axis (if defined) for array entries in this column
@@ -447,7 +450,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nCRDn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis random error"),
+    nCRDna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coordinate axis random error"),
 
     /**
      * The coordinate axis systematic error in the physical unit of the axis (if defined) for array entries in this
@@ -456,32 +459,32 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nCSYn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis systematic error"),
+    nCSYna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coordinate axis systematic error"),
 
     /**
      * Phase axis zero point on axis (leading index) for array entries in this column (trailing index)
      * 
      * @since 1.19
      */
-    nCZPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "phase axis zero point"),
+    nCZPna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "phase axis zero point"),
 
     /**
      * Phase axis period on axis (leading index) for array entries in this column (trailing index)
      * 
      * @since 1.19
      */
-    nCPRn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "phase axis period"),
+    nCPRna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "phase axis period"),
 
     /**
      * The coordinate axis spacing in the physical unit of the axis (if defined) for array entries in this column
      * (trailing index). The number of coordinate axes (leading index) defined this way should match the dimensionality
      * of the array elements in the column. This version does not support alternative coordinates systems.
      * 
-     * @see   #nCDEn
+     * @see   #nCDEna
      * 
      * @since 1.19
      */
-    nCDLTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column coordinate axis spacing"),
+    nCDLTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coordinate axis spacing"),
 
     /**
      * The coordinate axis spacing in the physical unit of the axis (if defined) for array entries in this column
@@ -492,7 +495,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nCDEn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis spacing"),
+    nCDEna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coordinate axis spacing"),
 
     /**
      * The 1-based coordinate reference pixel index in the physical unit of the axis (if defined) for array entries in
@@ -500,11 +503,11 @@ public enum WCS implements IFitsHeader {
      * dimensionality of the array elements in the column. This version does not support alternative coordinates
      * systems.
      * 
-     * @see   #nCRPn
+     * @see   #nCRPna
      * 
      * @since 1.19
      */
-    nCRPXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column coordinate axis reference pixel"),
+    nCRPXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coordinate axis reference pixel"),
 
     /**
      * The 1-based coordinate reference pixel index in the physical unit of the axis (if defined) for array entries in
@@ -515,17 +518,17 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nCRPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coordinate axis reference pixel"),
+    nCRPna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coordinate axis reference pixel"),
 
     /**
-     * @deprecated The FITS standard deprecated this keyword. Use {@link WCS#nnPCn} and {@link WCS#nnCDn}instead. [deg]
-     *                 The coordinate axis rotation in the physical unit of the axis (if defined) for array entries in
-     *                 this column (trailing index). The number of coordinate axes (leading index) defined this way
-     *                 should match the dimensionality of the array elements in the column.
+     * @deprecated The FITS standard deprecated this keyword. Use {@link WCS#nnPCna} and {@link WCS#nnCDna}instead.
+     *                 [deg] The coordinate axis rotation in the physical unit of the axis (if defined) for array
+     *                 entries in this column (trailing index). The number of coordinate axes (leading index) defined
+     *                 this way should match the dimensionality of the array elements in the column.
      * 
      * @since      1.19
      */
-    nCROTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[deg] column coordinate axis rotation"),
+    nCROTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[deg] column coordinate axis rotation"),
 
     /**
      * Coordinate transformation matrix in the PC convention. from rectilinear coordinate index <i>i</i> (leading index)
@@ -535,7 +538,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nnPCn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coord. trans. matrix element"),
+    nnPCna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coord. trans. matrix element"),
 
     /**
      * Coordinate transformation matrix in the CD convention. from rectilinear coordinate index <i>i</i> (leading index)
@@ -545,89 +548,88 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    nnCDn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column coord. trans. matrix element"),
+    nnCDna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column coord. trans. matrix element"),
 
     /**
-     * The coordinate parameter name <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
+     * The coordinate string parameter <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
      * this column (middle index). The number of coordinate axes (leading index) defined this way should match the
-     * dimensionality of the array elements in the column. The shorter {@link #nSn_n} form may be required for column
+     * dimensionality of the array elements in the column. The shorter {@link #nSn_na} form may be required for column
      * indices &gt;99 with alternate coordinate systems.
      * 
      * @since 1.19
      */
-    nPSn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column axis parameter name"),
+    nPSn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column axis parameter name"),
 
     /**
-     * The coordinate parameter name <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
+     * The coordinate string parameter <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
      * this column (middle index). The number of coordinate axes (leading index) defined this way should match the
-     * dimensionality of the array elements in the column. Same as {@value #nPSn_n}. This shorter form may be required
+     * dimensionality of the array elements in the column. Same as {@value #nPSn_na}. This shorter form may be required
      * for column indices &gt;99 with alternate coordinate systems.
      * 
      * @since 1.19
      */
-    nSn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column axis parameter name"),
+    nSn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column axis parameter name"),
 
     /**
      * The coordinate parameter value <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
      * this column (middle index). The number of coordinateaxes defined this way should match the dimensionality of the
-     * array elements in the column. The shorter {@link #nVn_n} form may be required for column indices &gt;99 with
+     * array elements in the column. The shorter {@link #nVn_na} form may be required for column indices &gt;99 with
      * alternate coordinate systems.
      * 
      * @since 1.19
      */
-    nPVn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column axis parameter value"),
+    nPVn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column axis parameter value"),
 
     /**
      * The coordinate parameter value <i>m</i> (trailing index) for axis <i>i</i> (leading index) for array entries in
      * this column (middle index). The number of coordinateaxes defined this way should match the dimensionality of the
-     * array elements in the column. Same as {@link #nPVn_n}. This shorter form may be required for column indices
+     * array elements in the column. Same as {@link #nPVn_na}. This shorter form may be required for column indices
      * &gt;99 with alternate coordinate systems.
      * 
      * @since 1.19
      */
-    nVn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column axis parameter value"),
+    nVn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column axis parameter value"),
 
     /**
-     * The coordinate parameter value for axis <i>i</i> (leading index) for array entries in this column (middle index).
-     * The number of coordinate axes defined this way should match the dimensionality of the array elements in the
-     * column.
+     * The coordinate parameter array for axis <i>i</i> (leading index) in this column (middle index). The number of
+     * coordinate axes defined this way should match the dimensionality of the array elements in the column.
      * 
      * @since 1.19
      */
-    nVn_X(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column axis parameter value"),
+    nVn_Xa(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column parameter array"),
 
     /**
-     * WCS name for the pixe list entries in the given column index. Same as {@link #TWCSn}. This shorter form may be
+     * WCS name for the pixe list entries in the given column index. Same as {@link #TWCSna}. This shorter form may be
      * required for column indices &gt;99 with alternate coordinate systems.
      * 
      * @since 1.19
      */
-    WCSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column WCS name"),
+    WCSna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column WCS name"),
 
     /**
-     * WCS name for the pixe list entries in the given column index. The shorter form {@link #WCSn} may be required for
+     * WCS name for the pixe list entries in the given column index. The shorter form {@link #WCSna} may be required for
      * column indices &gt;99 with alternate coordinate systems.
      * 
      * @since 1.19
      */
-    TWCSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column WCS name"),
+    TWCSna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column WCS name"),
 
     /**
      * WCS dimensions for given column index.
      * 
      * @since 1.19
      */
-    WCAXn(SOURCE.RESERVED, HDU.TABLE, VALUE.INTEGER, true, "Coordinate dimensions"),
+    WCAXna(SOURCE.RESERVED, HDU.TABLE, VALUE.INTEGER, "Coordinate dimensions"),
 
     /**
      * The coordinate axis type for (1D) pixel lists in this column (trailing index). This version does not support
      * alternative coordinates systems.
      * 
-     * @see   #TCTYn
+     * @see   #TCTYna
      * 
      * @since 1.19
      */
-    TCTYPn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, false, "column pixel axis type"),
+    TCTYPn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column pixel axis type"),
 
     /**
      * The coordinate axis type for (1D) pixel lists in this column (trailing index). This version supports alternative
@@ -637,24 +639,24 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TCTYn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column pixel axis type"),
+    TCTYna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column pixel axis type"),
 
     /**
      * The coordinate axis name for (1D) pixel lists in this column (trailing index).
      * 
      * @since 1.19
      */
-    TCNAn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column pixel axis name"),
+    TCNAna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column pixel axis name"),
 
     /**
      * The physical coordinate unit for (1D) pixel lists in this column (trailing index). This version does not support
      * alternative coordinates systems.
      * 
-     * @see   #TCUNn
+     * @see   #TCUNna
      * 
      * @since 1.19
      */
-    TCUNIn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, false, "column pixel axis unit"),
+    TCUNIn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column pixel axis unit"),
 
     /**
      * The physical coordinate unit for (1D) pixel lists in this column (trailing index). This version supports
@@ -664,37 +666,37 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TCUNn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column pixel axis unit"),
+    TCUNna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column pixel axis unit"),
 
     /**
      * The coordinate reference value in the physical unit of the axis (if defined) for the (1D) pixel lists in this
      * column (trailing index). This version does not support alternative coordinates systems.
      * 
-     * @see   #TCRVn
+     * @see   #TCRVna
      * 
      * @since 1.19
      */
-    TCRVLn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column pixel axis reference value"),
+    TCRVLn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis reference value"),
 
     /**
      * The coordinate reference value in the physical unit of the axis (if defined) for the (1D) pixel lists in this
      * column (trailing index). This version supports alternative coordinates systems.
      * 
-     * @see   #TCRVn
+     * @see   #TCRVLn
      * 
      * @since 1.19
      */
-    TCRVn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis reference value"),
+    TCRVna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis reference value"),
 
     /**
      * The coordinate axis spacing in the physical unit of the axis (if defined) for the (1D_) pixel lists in this
      * column (trailing index). This version does not support alternative coordinates systems.
      * 
-     * @see   #TCDEn
+     * @see   #TCDEna
      * 
      * @since 1.19
      */
-    TCDLTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column pixel axis spacing"),
+    TCDLTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis spacing"),
 
     /**
      * The coordinate axis spacing in the physical unit of the axis (if defined) for the (1D_) pixel lists in this
@@ -704,7 +706,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TCDEn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis spacing"),
+    TCDEna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis spacing"),
 
     /**
      * The coordinate axis random error in the physical unit of the axis (if defined) for the (1D_) pixel lists in this
@@ -712,7 +714,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TCRDn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis random error"),
+    TCRDna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis random error"),
 
     /**
      * The coordinate axis systematics error in the physical unit of the axis (if defined) for the (1D_) pixel lists in
@@ -720,31 +722,31 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TCSYn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis random error"),
+    TCSYna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis random error"),
 
     /**
      * Phase axis zero point on axis (leading index) for array entries in this column (trailing index)
      * 
      * @since 1.19
      */
-    TCZPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "phase axis zero point"),
+    TCZPna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "phase axis zero point"),
 
     /**
      * Phase axis period on axis (leading index) for array entries in this column (trailing index)
      * 
      * @since 1.19
      */
-    TCPRn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "phase axis period"),
+    TCPRna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "phase axis period"),
 
     /**
      * The 1-based coordinate reference pixel index in the physical unit of the axis (if defined) for the (1D) pixel
      * lists in this column (trailing index). This version does not support alternative coordinates systems.
      * 
-     * @see   #TCRPn
+     * @see   #TCRPna
      * 
      * @since 1.19
      */
-    TCRPXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "column pixel axis reference pixel"),
+    TCRPXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis reference pixel"),
 
     /**
      * The 1-based coordinate reference pixel index in the physical unit of the axis (if defined) for the (1D) pixel
@@ -754,92 +756,92 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TCRPn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis reference pixel"),
+    TCRPna(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis reference pixel"),
 
     /**
      * Coordinate transformation matrix in the PC convention. from column index <i>n</i> (leading index) to column index
-     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. The shorter form {@link #TPn_n} may be
+     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. The shorter form {@link #TPn_na} may be
      * required for column indices &gt;99 with alternate coordinate systems.
      * 
-     * @see   #TPn_n
+     * @see   #TPn_na
      * 
      * @since 1.19
      */
-    TPCn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pix trans. matrix element"),
+    TPCn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pix trans. matrix element"),
 
     /**
      * Coordinate transformation matrix in the PC convention. from column index <i>n</i> (leading index) to column index
-     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. Same as {@link #TPCn_n}. This shorter
+     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. Same as {@link #TPCn_na}. This shorter
      * form may be required for column indices &gt;99 with alternate coordinate systems.
      * 
-     * @see   #TPCn_n
+     * @see   #TPCn_na
      * 
      * @since 1.19
      */
-    TPn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pix trans. matrix element"),
+    TPn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pix trans. matrix element"),
 
     /**
-     * @deprecated The FITS standard deprecated this keyword. Use {@link WCS#TPCn_n} and {@link WCS#TCDn_n}instead.
+     * @deprecated The FITS standard deprecated this keyword. Use {@link WCS#TPCn_na} and {@link WCS#TCDn_na}instead.
      *                 [deg] The coordinate axis rotation in the physical unit of the axis (if defined) for the (1D)
      *                 pixel lists in this column (trailing index).
      * 
      * @since      1.19
      */
-    TCROTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, false, "[deg] column pixel axis rotation"),
+    TCROTn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "[deg] column pixel axis rotation"),
 
     /**
      * Coordinate transformation matrix in the CD convention. from column index <i>n</i> (leading index) to column index
-     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. The shorter form {@link #TCn_n} may be
+     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. The shorter form {@link #TCn_na} may be
      * required for column indices &gt;99 with alternate coordinate systems.
      * 
      * @since 1.19
      */
-    TCDn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pix trans. matrix element"),
+    TCDn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pix trans. matrix element"),
 
     /**
      * Coordinate transformation matrix in the CD convention. from column index <i>n</i> (leading index) to column index
-     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. Same as {@link #TCDn_n}. This shorter
+     * <i>k</i> (second index) for the for the (1D) pixel lists in this column. Same as {@link #TCDn_na}. This shorter
      * form may be required for column indices &gt;99 with alternate coordinate systems.
      * 
      * @since 1.19
      */
-    TCn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pix trans. matrix element"),
+    TCn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pix trans. matrix element"),
 
     /**
-     * The coordinate parameter name <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
-     * index). This shorter form {@link #TSn_n} may be required for column indices &gt;99 with alternate coordinate
+     * The coordinate string parameter <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
+     * index). This shorter form {@link #TSn_na} may be required for column indices &gt;99 with alternate coordinate
      * systems.
      * 
      * @since 1.19
      */
-    TPSn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column axis parameter name"),
+    TPSn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column axis parameter name"),
 
     /**
-     * The coordinate parameter name <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
-     * index). Same as {@link #TPSn_n}. This shorter form may be required for column indices &gt;99 with alternate
+     * The coordinate string parameter <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
+     * index). Same as {@link #TPSn_na}. This shorter form may be required for column indices &gt;99 with alternate
      * coordinate systems.
      * 
      * @since 1.19
      */
-    TSn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, true, "column axis parameter name"),
+    TSn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column axis parameter name"),
 
     /**
      * The coordinate parameter value <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
-     * index). The shorter form {@link #TVn_n} may be required for column indices &gt;99 with alternate coordinate
+     * index). The shorter form {@link #TVn_na} may be required for column indices &gt;99 with alternate coordinate
      * systems.
      * 
      * @since 1.19
      */
-    TPVn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis parameter value"),
+    TPVn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis parameter value"),
 
     /**
      * The coordinate parameter value <i>m</i> (trailing index) for the (1D) pixel list entries in this column (leading
-     * index). Same as {@value #TPVn_n}. This shorter form may be required for column indices &gt;99 with alternate
+     * index). Same as {@value #TPVn_na}. This shorter form may be required for column indices &gt;99 with alternate
      * coordinate systems.
      * 
      * @since 1.19
      */
-    TVn_n(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, true, "column pixel axis parameter value");
+    TVn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis parameter value");
 
     /** ICRS coordinate reference frame */
     public static final String RADESYS_ICRS = "ICRS";
@@ -856,97 +858,94 @@ public enum WCS implements IFitsHeader {
     /** Geocentric apparent place (IAU 1984) */
     public static final String RADESYS_GAPPT = "GAPPT";
 
-    /** Logarithmically sampled algorithm code for {@link #CTYPEn} keywords */
+    /** Logarithmically sampled algorithm code for {@link #CTYPEna} keywords */
     public static final String ALGO_LOG = "LOG";
 
-    /** Detector sampling algorithm code for {@link #CTYPEn} keywords */
+    /** Detector sampling algorithm code for {@link #CTYPEna} keywords */
     public static final String ALGO_GRI = "GRI";
 
-    /** Detector sampling algorithm code for {@link #CTYPEn} keywords */
+    /** Detector sampling algorithm code for {@link #CTYPEna} keywords */
     public static final String ALGO_GRA = "GRA";
 
-    /** Irregular sampling algorithm code for {@link #CTYPEn} keywords */
+    /** Irregular sampling algorithm code for {@link #CTYPEna} keywords */
     public static final String ALGO_TAB = "TAB";
 
-    /** Spectral frequency coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral frequency coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_FREQ = "FREQ";
 
-    /** Spectral energy coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral energy coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_ENER = "ENER";
 
-    /** Spectral wavenumber coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral wavenumber coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_WAVN = "WAVN";
 
-    /** Spectral radial velocity coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral radial velocity coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_VRAD = "VRAD";
 
-    /** Spectral vacuum wavenlength coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral vacuum wavenlength coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_WAVE = "WAVE";
 
-    /** Spectral optical velocity coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral optical velocity coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_VOPT = "VOPT";
 
-    /** Spectral redshift coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral redshift coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_ZOPT = "ZOPT";
 
-    /** Spectral wavelength in air coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral wavelength in air coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_AWAV = "AWAV";
 
-    /** Spectral apparent radial velocity coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral apparent radial velocity coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_VELO = "VELO";
 
-    /** Spectral beta factor (<i>v/c</i>) coordinate value for {@link #CTYPEn} keywords */
+    /** Spectral beta factor (<i>v/c</i>) coordinate value for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_TYPE_BETA = "BETA";
 
-    /** Spectral frequency expressed as wavelength transformation code for {@link #CTYPEn} keywords */
+    /** Spectral frequency expressed as wavelength transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_F2W = "F2W";
 
-    /** Spectral frequency expressed as apparent radial velocity transformation code for {@link #CTYPEn} keywords */
+    /** Spectral frequency expressed as apparent radial velocity transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_F2V = "F2V";
 
-    /** Spectral frequency expressed as air wavelength transformation code for {@link #CTYPEn} keywords */
+    /** Spectral frequency expressed as air wavelength transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_F2A = "F2A";
 
-    /** Spectral wavelength expressed as frequency transformation code for {@link #CTYPEn} keywords */
+    /** Spectral wavelength expressed as frequency transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_W2F = "W2F";
 
-    /** Spectral wavelength expressed as apparent radial velocity transformation code for {@link #CTYPEn} keywords */
+    /** Spectral wavelength expressed as apparent radial velocity transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_W2V = "W2V";
 
-    /** Spectral wavelength expressed as air wavelength transformation code for {@link #CTYPEn} keywords */
+    /** Spectral wavelength expressed as air wavelength transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_W2A = "W2A";
 
-    /** Spectral radial velocity expressed as frequency transformation code for {@link #CTYPEn} keywords */
+    /** Spectral radial velocity expressed as frequency transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_V2F = "V2F";
 
-    /** Spectral radial velocity expressed as wavelength transformation code for {@link #CTYPEn} keywords */
+    /** Spectral radial velocity expressed as wavelength transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_V2W = "V2W";
 
-    /** Spectral radial velocity expressed as air wavelength transformation code for {@link #CTYPEn} keywords */
+    /** Spectral radial velocity expressed as air wavelength transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_V2A = "V2A";
 
-    /** Spectral air wavelength expressed as frequency transformation code for {@link #CTYPEn} keywords */
+    /** Spectral air wavelength expressed as frequency transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_A2F = "A2F";
 
-    /** Spectral air wavelength expressed as vacuum wavelength transformation code for {@link #CTYPEn} keywords */
+    /** Spectral air wavelength expressed as vacuum wavelength transformation code for {@link #CTYPEna} keywords */
     public static final String SPECTRAL_ALGO_A2W = "A2W";
 
     /**
-     * Spectral air wavelength expressed as apparent radial velocity transformation code for {@link #CTYPEn} keywords
+     * Spectral air wavelength expressed as apparent radial velocity transformation code for {@link #CTYPEna} keywords
      */
     public static final String SPECTRAL_ALGO_A2V = "A2V";
 
     private final IFitsHeader key;
 
-    private boolean supportsAlt;
-
-    WCS(SOURCE status, HDU hdu, VALUE valueType, boolean allowsAlt, String comment) {
-        this(null, status, hdu, valueType, allowsAlt, comment);
+    WCS(SOURCE status, HDU hdu, VALUE valueType, String comment) {
+        this(null, status, hdu, valueType, comment);
     }
 
-    WCS(String headerName, SOURCE status, HDU hdu, VALUE valueType, boolean allowsAlt, String comment) {
+    WCS(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsHeaderImpl(headerName == null ? name() : headerName, status, hdu, valueType, comment);
-        supportsAlt = allowsAlt;
     }
 
     @Override
@@ -955,8 +954,10 @@ public enum WCS implements IFitsHeader {
     }
 
     /**
-     * Use for specifying an alternative coordinate system. You will want to call this before chaining other calls to
-     * {@link IFitsHeader}.
+     * Use for specifying an alternative coordinate system. This call is available only for the enums, which have a
+     * lower-case 'a' at the end of their Java names. Attempting to call this on keywords that do not end with
+     * lower-case 'a' will throw and {@link UnsupportedOperationException}. You will want to call this before chaining
+     * other calls to {@link IFitsHeader}.
      * 
      * @param  c                             The alternativce coordinate system marker 'A' through 'Z' (case
      *                                           insensitive).
@@ -967,11 +968,9 @@ public enum WCS implements IFitsHeader {
      * @throws IllegalArgumentException      if the marker is outside of the legal range of 'A' through 'Z' (case
      *                                           insensitive).
      * @throws UnsupportedOperationException if the keyword does not support alternative coordinate systems
-     * 
-     * @see                                  #supportsAlt()
      */
     public IFitsHeader alt(char c) throws IllegalArgumentException, UnsupportedOperationException {
-        if (!supportsAlt) {
+        if (!key().contains("a")) {
             throw new UnsupportedOperationException("WCS keyword " + key.key() + " does not support alternatives.");
         }
 
@@ -980,22 +979,9 @@ public enum WCS implements IFitsHeader {
             throw new IllegalArgumentException("Expected 'A' through 'Z': Got '%c'");
         }
 
-        StringBuffer headerName = new StringBuffer(key.key());
-        headerName.append(Character.toUpperCase(c));
+        String headerName = key().replace('a', Character.toUpperCase(c));
 
         return new FitsHeaderImpl(headerName.toString(), status(), hdu(), valueType(), comment());
-    }
-
-    /**
-     * Checks if this keyword can be used with alternative coordinate systems.
-     * 
-     * @return <code>true</code> if the keyword is capable of supporting alternative coordinate systems, or else
-     *             <code>false</code>
-     * 
-     * @see    #alt(char)
-     */
-    public boolean supportsAlt() {
-        return supportsAlt;
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -1,38 +1,5 @@
 package nom.tam.fits.header;
 
-/*-
- * #%L
- * nom.tam.fits
- * %%
- * Copyright (C) 1996 - 2024 nom-tam-fits
- * %%
- * This is free and unencumbered software released into the public domain.
- * 
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- * 
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- * #L%
- */
-
-import nom.tam.fits.HeaderCard;
-
 /**
  * Standard FITS keywords for defining world coordinate systems (WCS). Many (but not all) keywords listed here support
  * alternative coordinate systems, which can be set via the {@link #alt(char)} method.
@@ -969,14 +936,11 @@ public enum WCS implements IFitsHeader {
      * 
      * @throws IllegalArgumentException      if the marker is outside of the legal range of 'A' through 'Z' (case
      *                                           insensitive).
-     * @throws IllegalStateException         if the keyword with the alternate coordinate marker exceeeds the maximum
-     *                                           8-byre length of standard FITS keywords. You might want to use an
-     *                                           equivalent shorter alternative keyword.
      * @throws UnsupportedOperationException if the keyword does not support alternative coordinate systems
      * 
      * @see                                  #supportsAlt()
      */
-    public IFitsHeader alt(char c) throws IllegalArgumentException, IllegalStateException, UnsupportedOperationException {
+    public IFitsHeader alt(char c) throws IllegalArgumentException, UnsupportedOperationException {
         if (!supportsAlt) {
             throw new UnsupportedOperationException("WCS keyword " + key.key() + " does not support alternatives.");
         }
@@ -988,11 +952,6 @@ public enum WCS implements IFitsHeader {
 
         StringBuffer headerName = new StringBuffer(key.key());
         headerName.append(Character.toUpperCase(c));
-
-        if (headerName.length() > HeaderCard.MAX_KEYWORD_LENGTH) {
-            throw new IllegalStateException(
-                    "Alternate keyword " + headerName.toString() + " is too long. Use shorter equivalent instead.");
-        }
 
         return new FitsHeaderImpl(headerName.toString(), status(), hdu(), valueType(), comment());
     }

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -174,7 +174,6 @@ public enum CXCExt implements IFitsHeader {
      */
     TSTOP("add TIMEZERO and MJDREF for absolute TT");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     CXCExt(String comment) {
@@ -182,33 +181,8 @@ public enum CXCExt implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
+    public final IFitsHeader impl() {
+        return key;
     }
 
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
-    }
 }

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -87,7 +87,6 @@ public enum CXCStclSharedExt implements IFitsHeader {
      */
     TSTOP("add TIMEZERO and MJDREF for absolute TT");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     CXCStclSharedExt(String comment) {
@@ -95,33 +94,8 @@ public enum CXCStclSharedExt implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
+    public final IFitsHeader impl() {
+        return key;
     }
 
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
-    }
 }

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -222,11 +222,12 @@ public enum MaxImDLExt implements IFitsHeader {
     private final IFitsHeader key;
 
     MaxImDLExt(String key, VALUE valueType, String comment) {
-        this.key = new FitsHeaderImpl(key, IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType, comment);
+        this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType,
+                comment);
     }
 
     MaxImDLExt(VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType, comment);
+        this(null, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -219,7 +219,6 @@ public enum MaxImDLExt implements IFitsHeader {
      */
     YBAYROFF(VALUE.REAL, "Y offset of Bayer array");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     MaxImDLExt(String key, VALUE valueType, String comment) {
@@ -231,34 +230,8 @@ public enum MaxImDLExt implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
@@ -7947,11 +7947,11 @@ public enum NOAOExt implements IFitsHeader {
     private final IFitsHeader key;
 
     NOAOExt(HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.NOAO, hdu, valueType, comment);
+        this(null, hdu, valueType, comment);
     }
 
     NOAOExt(String key, HDU hdu, VALUE valueType, String comment) {
-        this.key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.NOAO, hdu, valueType, comment);
+        this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.NOAO, hdu, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
@@ -7944,7 +7944,6 @@ public enum NOAOExt implements IFitsHeader {
      */
     MJD_OBS("MJD-OBS", HDU.PRIMARY_EXTENSION, VALUE.REAL, "MJD of exposure start");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     NOAOExt(HDU hdu, VALUE valueType, String comment) {
@@ -7956,33 +7955,8 @@ public enum NOAOExt implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
+    public final IFitsHeader impl() {
+        return key;
     }
 
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
-    }
 }

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -196,11 +196,11 @@ public enum SBFitsExt implements IFitsHeader {
     private final IFitsHeader key;
 
     SBFitsExt(String key, VALUE valueType, String comment) {
-        this.key = new FitsHeaderImpl(key, IFitsHeader.SOURCE.SBIG, HDU.IMAGE, valueType, comment);
+        this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.SBIG, HDU.IMAGE, valueType, comment);
     }
 
     SBFitsExt(VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.SBIG, HDU.IMAGE, valueType, comment);
+        this(null, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -193,7 +193,6 @@ public enum SBFitsExt implements IFitsHeader {
      */
     YPIXSZ(VALUE.REAL, "Pixel height in microns");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     SBFitsExt(String key, VALUE valueType, String comment) {
@@ -205,34 +204,8 @@ public enum SBFitsExt implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
-    }
-
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
+    public final IFitsHeader impl() {
+        return key;
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -214,7 +214,6 @@ public enum STScIExt implements IFitsHeader {
      */
     MJD_OBS("MJD-OBS", "MJD of exposure start");
 
-    @SuppressWarnings("CPD-START")
     private final IFitsHeader key;
 
     STScIExt(String comment) {
@@ -226,33 +225,8 @@ public enum STScIExt implements IFitsHeader {
     }
 
     @Override
-    public String comment() {
-        return key.comment();
+    public final IFitsHeader impl() {
+        return key;
     }
 
-    @Override
-    public HDU hdu() {
-        return key.hdu();
-    }
-
-    @Override
-    public String key() {
-        return key.key();
-    }
-
-    @Override
-    public IFitsHeader n(int... number) {
-        return key.n(number);
-    }
-
-    @Override
-    public SOURCE status() {
-        return key.status();
-    }
-
-    @Override
-    @SuppressWarnings("CPD-END")
-    public VALUE valueType() {
-        return key.valueType();
-    }
 }

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -217,11 +217,11 @@ public enum STScIExt implements IFitsHeader {
     private final IFitsHeader key;
 
     STScIExt(String comment) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
+        this(null, comment);
     }
 
     STScIExt(String key, String comment) {
-        this.key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
+        this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
     }
 
     @Override

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -143,17 +143,24 @@ FITS.
 <a name="deprecated-methods"></a>
 ## Compatibility with prior releases
 
-We strive to maintain backwards compatibility with earlier releases of this library, and to an overwhelming extent 
-we continue to deliver on that. However, in a few corner cases we had no choice but to change the API and behavior 
+We strive to maintain API compatibility with earlier releases of this library, and to an overwhelming extent 
+we continue to deliver on that. However, in a few corner cases we had no choice but to change the API and/or behavior 
 slightly to fix bugs, nagging inconsistencies, or non-compliance to the FITS standard. Such changes are generally 
 rare, and typically affect some of the more obscure features of the library -- often classes and methods that probably 
 should never have been expossed to users in the first place. Most typical users (and use cases) of this library will 
 never see a difference, but some of the more advanced users may find changes that would require some small 
 modifications to their application in how they use __nom-tam-fits__ with recent releases. If you find yourself to be 
 one of the ones affected, please know that the decision to 'break' previously existing functionality was not taken 
-lightly, and was done only because it was inavoidable on order to make the library function better overall.
+lightly, and was done only because it was inavoidable in order to make the library function better overall.
 
-Starting with version __1.16__, we started deprecating some of the older API, either because methods were 
+Note, that as of __1.16__ we offer only API compatibility to earlier releases, but not binary compatilibility. In 
+practical terms it means that you cannot simply drop-in replace you JAR file, from say version __1.15.2__ to 
+__1.19.0__. Instead, you are expected to (re)compile your application with the JAR version of this library that you 
+intend to use. This is because some method signatures have changed to use an encompassing argument type, such as 
+`Number` instead of the previously separate `byte`, `short`, `int`, `long`, `float`, `double` methods. (These 
+otherwise changes harmless API changes improve consistency across numerical types.)
+
+Starting with version __1.16__, we also started deprecating some of the older API, either because methods were 
 ill-conceived, confusing, or generaly unsafe to use; or because they were internals of the library that should never 
 have been exposed to users in the first place. Rest assured, the deprecations do not cripple the intended 
 functionality of the library. If anything they make the library less confusing and safer to use. The Javadoc API 
@@ -161,6 +168,8 @@ documentation mentions alternatives for the methods that were deprecated, as app
 works, you should still be able to compile your old code with deprecations enabled in the compiler options. Rest 
 assured, all deprecated methods, no matter how ill-conceived or dodgy they may be, will be supported in all
 future releases prior to version __2.0__ of the library.
+
+
 
 
 -----------------------------------------------------------------------------

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1025,15 +1025,18 @@ these under the `nom.tam.fits.header` package:
 
  * `Standard` -- [keywords defined by the FITS standard](https://heasarc.gsfc.nasa.gov/docs/fcg/standard_dict.html). 
    Some of the standard keywords are broken out into separate enumerations by theme, as listed below:
-   * `DataDescription` -- FITS standard keywords for describing the data content
-   * `InstrumentDescription` -- Standard keywords for describing the instrumentation used for observing
-   * `ObservationDescription` -- Standard keywords that describe the observation
-   * `ObservationDurationDescription` -- Standard keywords for the timing of observations
+   * `WCS` -- Standard FITS Word coordinate system (WCS) keywords
+   * `DateTime` -- Standard date-time related FITS keywords
    * `Compression` -- Standard keywords used for describing compressed data
    * `Checksum` -- Standard keywords used for data checksumming
  * `HierarchicalGrouping` -- Keywords for the 
     [Hierarchical Grouping Convention](https://fits.gsfc.nasa.gov/registry/grouping.html)
  * `NonStandard` -- Commonly used and recognized keywords that are not strictly part of the FITS standard
+   Some commonly used conventions are broken out into separate enumerations by theme, as listed below:
+   * `DataDescription` -- Conventional keywords for describing the data content
+   * `InstrumentDescription` -- Conventional keywords for describing the instrumentation used for observing
+   * `ObservationDescription` -- Commonly used keywords that describe the observation
+   * `ObservationDurationDescription` -- Commonly used keywords for the timing of observations
  
 Additionally, many organisations (or groups of organisations) have defined their own sets of FITS keywords. Some of 
 these can be found under the `nom.tam.fits-header.extra` package, such as:

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -5,8 +5,10 @@ import java.io.ByteArrayOutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 
+import nom.tam.fits.header.DateTime;
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.Standard;
+import nom.tam.fits.header.WCS;
 import nom.tam.util.FitsOutputStream;
 
 /*
@@ -126,5 +128,27 @@ public class HeaderProtectedTest {
     @Test(expected = IllegalArgumentException.class)
     public void testKeyIndexTooLarge() {
         Standard.TFORMn.n(1000);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWCSInvalidAlt() {
+        WCS.WCSNAME.alt('0');
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testWCSNoAlt() {
+        WCS.OBSGEO_X.alt('A');
+    }
+
+    @Test
+    public void testWCSAlt() {
+        Assert.assertEquals("WCSNAMEA", WCS.WCSNAME.alt('A').key());
+        Assert.assertEquals("WCSNAMEZ", WCS.WCSNAME.alt('Z').key());
+    }
+
+    @Test
+    public void testDateTime() {
+        Assert.assertEquals("DATE-OBS", DateTime.DATE_OBS.key());
+        Assert.assertEquals("MJDREF", DateTime.MJDREF.key());
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -155,6 +155,11 @@ public class HeaderProtectedTest {
         WCS.OBSGEO_X.alt('A');
     }
 
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testTooManyIndices() {
+        Standard.CTYPEn.n(1, 2);
+    }
+
     @Test
     public void testWCSAlt() {
         Assert.assertEquals("WCSNAME", WCS.WCSNAMEa.key());

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -6,7 +6,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import nom.tam.fits.header.DateTime;
+import nom.tam.fits.header.FitsHeaderImpl;
 import nom.tam.fits.header.GenericKey;
+import nom.tam.fits.header.IFitsHeader;
+import nom.tam.fits.header.IFitsHeader.HDU;
+import nom.tam.fits.header.IFitsHeader.SOURCE;
+import nom.tam.fits.header.IFitsHeader.VALUE;
 import nom.tam.fits.header.Standard;
 import nom.tam.fits.header.WCS;
 import nom.tam.util.FitsOutputStream;
@@ -131,17 +136,34 @@ public class HeaderProtectedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testWCSInvalidAlt() {
-        WCS.WCSNAME.alt('0');
+    public void testWCSInvalidAlt1() {
+        WCS.WCSNAME.alt((char) ('A' - 1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWCSInvalidAlt2() {
+        WCS.WCSNAME.alt((char) ('Z' + 1));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testWCSLongAlt() {
+        WCS.TPCn_n.alt('A').n(999, 999);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testWCSLongIndex() {
+        WCS.TCDn_n.n(999, 999);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testWCSNoAlt() {
+        Assert.assertFalse(WCS.OBSGEO_X.supportsAlt());
         WCS.OBSGEO_X.alt('A');
     }
 
     @Test
     public void testWCSAlt() {
+        Assert.assertTrue(WCS.WCSNAME.supportsAlt());
         Assert.assertEquals("WCSNAMEA", WCS.WCSNAME.alt('A').key());
         Assert.assertEquals("WCSNAMEZ", WCS.WCSNAME.alt('Z').key());
     }
@@ -150,5 +172,20 @@ public class HeaderProtectedTest {
     public void testDateTime() {
         Assert.assertEquals("DATE-OBS", DateTime.DATE_OBS.key());
         Assert.assertEquals("MJDREF", DateTime.MJDREF.key());
+    }
+
+    @Test
+    public void testIFitsHeaderSelfImpl() {
+        IFitsHeader key = new FitsHeaderImpl("BLAH", SOURCE.UNKNOWN, HDU.ANY, VALUE.ANY, "for testing only");
+        Assert.assertNotNull(key.impl());
+    }
+
+    @Test
+    public void testIFitsHeaderDefaultImpl() {
+        class MyKeyword implements IFitsHeader {
+
+        }
+
+        Assert.assertNull(new MyKeyword().impl());
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -157,6 +157,7 @@ public class HeaderProtectedTest {
 
     @Test
     public void testWCSAlt() {
+        Assert.assertEquals("WCSNAME", WCS.WCSNAMEa.key());
         Assert.assertEquals("WCSNAMEA", WCS.WCSNAMEa.alt('A').key());
         Assert.assertEquals("WCSNAMEZ", WCS.WCSNAMEa.alt('Z').key());
     }
@@ -176,9 +177,7 @@ public class HeaderProtectedTest {
     @Test
     public void testIFitsHeaderDefaultImpl() {
         class MyKeyword implements IFitsHeader {
-
         }
-
         Assert.assertNull(new MyKeyword().impl());
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -137,30 +137,28 @@ public class HeaderProtectedTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testWCSInvalidAlt1() {
-        WCS.WCSNAME.alt((char) ('A' - 1));
+        WCS.WCSNAMEa.alt((char) ('A' - 1));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testWCSInvalidAlt2() {
-        WCS.WCSNAME.alt((char) ('Z' + 1));
+        WCS.WCSNAMEa.alt((char) ('Z' + 1));
     }
 
     @Test(expected = IllegalStateException.class)
     public void testWCSLongIndex() {
-        WCS.TCDn_n.n(999, 999);
+        WCS.TCDn_na.n(999, 999);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testWCSNoAlt() {
-        Assert.assertFalse(WCS.OBSGEO_X.supportsAlt());
         WCS.OBSGEO_X.alt('A');
     }
 
     @Test
     public void testWCSAlt() {
-        Assert.assertTrue(WCS.WCSNAME.supportsAlt());
-        Assert.assertEquals("WCSNAMEA", WCS.WCSNAME.alt('A').key());
-        Assert.assertEquals("WCSNAMEZ", WCS.WCSNAME.alt('Z').key());
+        Assert.assertEquals("WCSNAMEA", WCS.WCSNAMEa.alt('A').key());
+        Assert.assertEquals("WCSNAMEZ", WCS.WCSNAMEa.alt('Z').key());
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -116,6 +116,15 @@ public class HeaderProtectedTest {
         Assert.assertEquals(1, GenericKey.getN(Standard.TFORMn.n(1).key()));
         Assert.assertEquals(12, GenericKey.getN(Standard.TFORMn.n(12).key()));
         Assert.assertEquals(123, GenericKey.getN(Standard.TFORMn.n(123).key()));
-        Assert.assertEquals(1234, GenericKey.getN(Standard.TFORMn.n(1234).key()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testKeyIndexNegative() {
+        Standard.TFORMn.n(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testKeyIndexTooLarge() {
+        Standard.TFORMn.n(1000);
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -146,11 +146,6 @@ public class HeaderProtectedTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testWCSLongAlt() {
-        WCS.TPCn_n.alt('A').n(999, 999);
-    }
-
-    @Test(expected = IllegalStateException.class)
     public void testWCSLongIndex() {
         WCS.TCDn_n.n(999, 999);
     }

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -208,6 +208,5 @@ public class EnumHeaderTest {
         assertSame(IFitsHeader.SOURCE.UNKNOWN, IFitsHeader.SOURCE.valueOf(IFitsHeader.SOURCE.UNKNOWN.name()));
         assertEquals(7, IFitsHeader.VALUE.values().length);
         assertSame(IFitsHeader.VALUE.ANY, IFitsHeader.VALUE.valueOf(IFitsHeader.VALUE.ANY.name()));
-        assertEquals(4, Synonyms.values().length);
     }
 }

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -56,6 +56,7 @@ import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.LongStringsNotEnabledException;
 import nom.tam.fits.LongValueException;
 import nom.tam.fits.TruncatedFileException;
+import nom.tam.fits.header.Standard;
 import nom.tam.fits.header.hierarch.BlanksDotHierarchKeyFormatter;
 import nom.tam.util.AsciiFuncs;
 import nom.tam.util.ComplexValue;
@@ -1855,4 +1856,8 @@ public class HeaderCardTest {
         Assert.assertNull(header.prevCard());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnfilledKeywordIndex() {
+        HeaderCard.create(Standard.CTYPEn, "blah");
+    }
 }


### PR DESCRIPTION
In `nom.tam.fits.header` package:

- New `WCS` enumerates all the FITS standard WCS keywords. Many WCS keywords support alternative coordinates, which are indicated with a trailing letter `A` through `Z`. These can be set via the `.alt(char)` method of WCS keywords. For example: `WCS.CTYPEn.n(1).alt('A')` generates the standard FITS keyword `CTYPE1A`. The `WCS` enum also contains constants that can be used as values, or for compositing appropriate values, e.g. for CTYPE<i>na</i> keywords.

- New `DateTime` enumerates all the FITS standard date-time keywords, and provides constant that can be used as specific recognised values for some of these.

- `Synonyms` has been extended to contain synonymous WCS keywords

- Added default methods to `IFitsHeader` to eliminate code that was duplicated over and over again.

- `IFitsHeader.n(int...)` now checks that the supplied indices are in the 0-999 range (we'll accept 0, even though it's not really proper FITS, but apears to be used nevertheless), and throw an `IllegalArgumentException` if any of the indices are out of bounds. The method now also checks that the resulting indexed keyword does not exceed the 8-byte limit of standard FITS keywords, or else will throw an `IllegalStateException`.

- Fix bad constructor for some `STScIExt` keywords.

- Specifying more indices than can be filled for an `IFitsHeader` will throw an `IndexOutOfBoundsException`.

- Attempting to create a `HeaderCard` with a standard keyword that has unfilled indices will throw an `IllegalArgumentException`.