### PR TITLE
Support for INHERIT keyword

### DIFF
--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -699,6 +699,11 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
      * Returns the FITS header component of this HDU
      * 
      * @return the associated header
+     * 
+     * @see    Fits#getPrimaryHeader()
+     * @see    Fits#getCompleteHeader(int)
+     * @see    Fits#getCompleteHeader(String)
+     * @see    Fits#getCompleteHeader(String, int)
      */
     public Header getHeader() {
         return myHeader;

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -716,9 +716,11 @@ public class Fits implements Closeable {
     }
 
     /**
-     * Returns the primary header of this FITS file, that is the header of the primary HDU in the Fits. The primary
-     * header this way will be properly configured as the primary HDU with all mandatory keywords, even if the HDU's
-     * header did not contain these entries originally.
+     * Returns the primary header of this FITS file, that is the header of the primary HDU in this Fits object. This
+     * method differs from <code>getHDU(0).getHeader()</code>, int that the primary header this way will be properly
+     * configured as the primary HDU with all mandatory keywords, even if the HDU's header did not contain these entries
+     * originally. (Subsequent calls to <code>getHDU(0).getHeader()</code> will also contain the populated mandatory
+     * keywords).
      * 
      * @return               The primary header of this FITS file/object.
      * 
@@ -726,6 +728,7 @@ public class Fits implements Closeable {
      * @throws IOException
      * 
      * @see                  #getCompleteHeader(int)
+     * @see                  BasicHDU#getHeader()
      * 
      * @since                1.19
      */
@@ -739,13 +742,14 @@ public class Fits implements Closeable {
     }
 
     /**
-     * Returns the complete header of the n<sup>th</sup> HDU in this FITS file/object. This differs from
+     * Returns the 'complete' header of the n<sup>th</sup> HDU in this FITS file/object. This differs from
      * {@link #getHDU(int)}<code>.getHeader()</code> in two important ways:
      * <ul>
      * <li>The header will be populated with the mandatory FITS keywords based on whether it is that of a primary or
-     * extension HDU in the Fits, and the type of HDU it is.</li>
-     * <li>If the header contains the INHERIT keyword, a new header object is returned, which merges the non-conflicting
-     * primary header keys on top of the keywords explicitly defined in the HDU already.
+     * extension HDU in this Fits, and the type of HDU it is. (Subsequent calls to <code>getHDU(n).getHeader()</code>
+     * will also include the populated mandatory keywords.)</li>
+     * <li>If the header contains the {@link Standard#INHERIT} keyword, a new header object is returned, which merges
+     * the non-conflicting primary header keys on top of the keywords explicitly defined in the HDU already.
      * </ul>
      * 
      * @param  n                         The zero-based index of the HDU.
@@ -779,33 +783,34 @@ public class Fits implements Closeable {
      * {@link #getHDU(String)}<code>.getHeader()</code> in two important ways:
      * <ul>
      * <li>The header will be populated with the mandatory FITS keywords based on whether it is that of a primary or
-     * extension HDU in the Fits, and the type of HDU it is.</li>
-     * <li>If the header contains the INHERIT keyword, a new header object is returned, which merges the non-conflicting
-     * primary header keys on top of the keywords explicitly defined in the HDU already.
+     * extension HDU in this Fits, and the type of HDU it is. (Subsequent calls to <code>getHDU(n).getHeader()</code>
+     * will also include the populated mandatory keywords.)</li>
+     * <li>If the header contains the {@link Standard#INHERIT} keyword, a new header object is returned, which merges
+     * the non-conflicting primary header keys on top of the keywords explicitly defined in the HDU already.
      * </ul>
      * 
-     * @param  name                      The HDU name
+     * @param  name                   The HDU name
      * 
-     * @return                           The completed header of the HDU. If the HDU contains the INHERIT key this
-     *                                       header will be a new header object constructed by this call to include also
-     *                                       all non-conflicting primary header keywords. Otherwise it will simply
-     *                                       return the HDUs header (after adding the mandatory keywords).
+     * @return                        The completed header of the HDU. If the HDU contains the INHERIT key this header
+     *                                    will be a new header object constructed by this call to include also all
+     *                                    non-conflicting primary header keywords. Otherwise it will simply return the
+     *                                    HDUs header (after adding the mandatory keywords).
      * 
-     * @throws FitsException             If the FITS is empty
-     * @throws IOException               If the HDU is not accessible from its source
-     * @throws IndexOutOfBoundsException If the FITS does not contain a HDU by the specified index
+     * @throws FitsException          If the FITS is empty
+     * @throws IOException            If the HDU is not accessible from its source
+     * @throws NoSuchElementException If the FITS does not contain a HDU by the specified name
      * 
-     * @see                              #getCompleteHeader(String, int)
-     * @see                              #getCompleteHeader(int)
-     * @see                              #getPrimaryHeader()
-     * @see                              #getHDU(int)
+     * @see                           #getCompleteHeader(String, int)
+     * @see                           #getCompleteHeader(int)
+     * @see                           #getPrimaryHeader()
+     * @see                           #getHDU(int)
      * 
-     * @since                            1.19
+     * @since                         1.19
      */
-    public Header getCompleteHeader(String name) throws FitsException, IOException {
+    public Header getCompleteHeader(String name) throws FitsException, IOException, NoSuchElementException {
         BasicHDU<?> hdu = getHDU(name);
         if (hdu == null) {
-            throw new FitsException("Fits contains no HDU named " + name);
+            throw new NoSuchElementException("Fits contains no HDU named " + name);
         }
         return getCompleteHeader(hdu);
     }
@@ -815,34 +820,35 @@ public class Fits implements Closeable {
      * differs from {@link #getHDU(String)}<code>.getHeader()</code> in two important ways:
      * <ul>
      * <li>The header will be populated with the mandatory FITS keywords based on whether it is that of a primary or
-     * extension HDU in the Fits, and the type of HDU it is.</li>
-     * <li>If the header contains the INHERIT keyword, a new header object is returned, which merges the non-conflicting
-     * primary header keys on top of the keywords explicitly defined in the HDU already.
+     * extension HDU in this Fits, and the type of HDU it is. (Subsequent calls to <code>getHDU(n).getHeader()</code>
+     * will also include the populated mandatory keywords.)</li>
+     * <li>If the header contains the {@link Standard#INHERIT} keyword, a new header object is returned, which merges
+     * the non-conflicting primary header keys on top of the keywords explicitly defined in the HDU already.
      * </ul>
      * 
-     * @param  name                      The HDU name
-     * @param  version                   The HDU version
+     * @param  name                   The HDU name
+     * @param  version                The HDU version
      * 
-     * @return                           The completed header of the HDU. If the HDU contains the INHERIT key this
-     *                                       header will be a new header object constructed by this call to include also
-     *                                       all non-conflicting primary header keywords. Otherwise it will simply
-     *                                       return the HDUs header (after adding the mandatory keywords).
+     * @return                        The completed header of the HDU. If the HDU contains the INHERIT key this header
+     *                                    will be a new header object constructed by this call to include also all
+     *                                    non-conflicting primary header keywords. Otherwise it will simply return the
+     *                                    HDUs header (after adding the mandatory keywords).
      * 
-     * @throws FitsException             If the FITS is empty
-     * @throws IOException               If the HDU is not accessible from its source
-     * @throws IndexOutOfBoundsException If the FITS does not contain a HDU by the specified index
+     * @throws FitsException          If the FITS is empty
+     * @throws IOException            If the HDU is not accessible from its source
+     * @throws NoSuchElementException If the FITS does not contain a HDU by the specified name and version
      * 
-     * @see                              #getCompleteHeader(String)
-     * @see                              #getCompleteHeader(int)
-     * @see                              #getPrimaryHeader()
-     * @see                              #getHDU(int)
+     * @see                           #getCompleteHeader(String)
+     * @see                           #getCompleteHeader(int)
+     * @see                           #getPrimaryHeader()
+     * @see                           #getHDU(int)
      * 
-     * @since                            1.19
+     * @since                         1.19
      */
-    public Header getCompleteHeader(String name, int version) throws FitsException, IOException {
+    public Header getCompleteHeader(String name, int version) throws FitsException, IOException, NoSuchElementException {
         BasicHDU<?> hdu = getHDU(name, version);
         if (hdu == null) {
-            throw new FitsException("Fits contains no HDU named " + name);
+            throw new NoSuchElementException("Fits contains no HDU named " + name);
         }
         return getCompleteHeader(hdu);
     }

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -18,6 +18,7 @@ import nom.tam.fits.FitsFactory.FitsSettings;
 import nom.tam.fits.header.Bitpix;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.IFitsHeader.VALUE;
+import nom.tam.fits.header.Standard;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.AsciiFuncs;
@@ -328,6 +329,10 @@ public class Header implements FitsElement {
         while (c.hasNext()) {
             HeaderCard card = c.next();
             if (card.isCommentStyleCard() || !containsKey(card.getKey())) {
+                if (card.getKey().equals(Standard.SIMPLE.key()) || card.getKey().equals(Standard.XTENSION.key())) {
+                    // Do not merge SIMPLE / XTENSION -- these are private matters...
+                    continue;
+                }
                 addLine(card.copy());
             }
         }

--- a/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
+++ b/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
@@ -32,14 +32,12 @@
 package nom.tam.fits;
 
 /**
- * The keyword is a HIERARCH-style long FITS keyword but the library does not have the hierarch support enabled at
- * present.
+ * The keyword is a HIERARCH-style long FITS keyword but the library does not
+ * have the hierarch support enabled at present.
  * 
  * @author Attila Kovacs
- * 
- * @see    FitsFactory#setUseHierarch(boolean)
- * 
- * @since  1.16
+ * @see FitsFactory#setUseHierarch(boolean)
+ * @since 1.16
  */
 public class HierarchNotEnabledException extends HeaderCardException {
 
@@ -53,10 +51,11 @@ public class HierarchNotEnabledException extends HeaderCardException {
     }
 
     /**
-     * Instantiates a new exception for a HIERARCH-style header keyword, when support for the hierarch convention is not
-     * enabled.
+     * Instantiates a new exception for a HIERARCH-style header keyword, when
+     * support for the hierarch convention is not enabled.
      * 
-     * @param key the HIERARCH-style FITS keyword.
+     * @param key
+     *            the HIERARCH-style FITS keyword.
      */
     public HierarchNotEnabledException(String key) {
         super(getMessage(key));

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -529,7 +529,15 @@ public enum Standard implements IFitsHeader {
      * for an extension key and must not appear in the primary key. For an extension that is not a standard extension,
      * the type name must not be the same as that of a standard extension.
      */
-    XTENSION(SOURCE.MANDATORY, HDU.EXTENSION, VALUE.STRING, "marks beginning of new HDU");
+    XTENSION(SOURCE.MANDATORY, HDU.EXTENSION, VALUE.STRING, "marks beginning of new HDU"),
+
+    /**
+     * If set to <code>true</code>, it indicates that the HDU should inherit all non-confliucting keywords from the
+     * primary HDU.
+     * 
+     * @since 1.19
+     */
+    INHERIT(SOURCE.RESERVED, HDU.EXTENSION, VALUE.LOGICAL, "Inherit primary header entries");
 
     /**
      * A shorthand for {@link #NAXISn}<code>.n(1)</code>, that is the regular dimension along the first, fastest FITS

--- a/src/main/java/nom/tam/util/HashedList.java
+++ b/src/main/java/nom/tam/util/HashedList.java
@@ -110,7 +110,11 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
 
         @Override
         public VALUE end() {
-            current = Math.max(0, HashedList.this.ordered.size() - 1);
+            current = HashedList.this.ordered.size() - 1;
+            if (current < 0) {
+                current = 0;
+                return null;
+            }
             return next();
         }
 
@@ -127,7 +131,7 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
         @Override
         public VALUE next() {
             if (current < 0 || current >= HashedList.this.ordered.size()) {
-                throw new NoSuchElementException("Outside list");
+                throw new NoSuchElementException("Outside list: " + current);
             }
             VALUE entry = HashedList.this.ordered.get(current);
             current++;

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -143,17 +143,24 @@ FITS.
 <a name="deprecated-methods"></a>
 ## Compatibility with prior releases
 
-We strive to maintain backwards compatibility with earlier releases of this library, and to an overwhelming extent 
-we continue to deliver on that. However, in a few corner cases we had no choice but to change the API and behavior 
+We strive to maintain API compatibility with earlier releases of this library, and to an overwhelming extent 
+we continue to deliver on that. However, in a few corner cases we had no choice but to change the API and/or behavior 
 slightly to fix bugs, nagging inconsistencies, or non-compliance to the FITS standard. Such changes are generally 
 rare, and typically affect some of the more obscure features of the library -- often classes and methods that probably 
 should never have been expossed to users in the first place. Most typical users (and use cases) of this library will 
 never see a difference, but some of the more advanced users may find changes that would require some small 
 modifications to their application in how they use __nom-tam-fits__ with recent releases. If you find yourself to be 
 one of the ones affected, please know that the decision to 'break' previously existing functionality was not taken 
-lightly, and was done only because it was inavoidable on order to make the library function better overall.
+lightly, and was done only because it was inavoidable in order to make the library function better overall.
 
-Starting with version __1.16__, we started deprecating some of the older API, either because methods were 
+Note, that as of __1.16__ we offer only API compatibility to earlier releases, but not binary compatilibility. In 
+practical terms it means that you cannot simply drop-in replace you JAR file, from say version __1.15.2__ to 
+__1.19.0__. Instead, you are expected to (re)compile your application with the JAR version of this library that you 
+intend to use. This is because some method signatures have changed to use an encompassing argument type, such as 
+`Number` instead of the previously separate `byte`, `short`, `int`, `long`, `float`, `double` methods. (These 
+otherwise changes harmless API changes improve consistency across numerical types.)
+
+Starting with version __1.16__, we also started deprecating some of the older API, either because methods were 
 ill-conceived, confusing, or generaly unsafe to use; or because they were internals of the library that should never 
 have been exposed to users in the first place. Rest assured, the deprecations do not cripple the intended 
 functionality of the library. If anything they make the library less confusing and safer to use. The Javadoc API 
@@ -161,6 +168,8 @@ documentation mentions alternatives for the methods that were deprecated, as app
 works, you should still be able to compile your old code with deprecations enabled in the compiler options. Rest 
 assured, all deprecated methods, no matter how ill-conceived or dodgy they may be, will be supported in all
 future releases prior to version __2.0__ of the library.
+
+
 
 
 -----------------------------------------------------------------------------

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -956,6 +956,11 @@ the `TELESCOP` key.
   String telescope =  header.getStringValue("TELESCOP");
 ```
 
+Note, that as of version __1.19__ you might want to use one of the `Fits.getCompleteHeader(...)` methods when 
+inspecting headers of HDUs stored in the FITS file, since the header returned by these methods would also contain 
+keywords indirectly inherited from the primary HDU, when the `INHERIT` keywords is used and set to `T` (true) in the 
+header of the specified HDU extension.
+
 Or if we want to know the right ascension (R.A.) coordinate of the reference position in the image:
 
 ```java

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -47,6 +47,7 @@ import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.HeaderCommentsMap;
 import nom.tam.fits.ImageData;
 import nom.tam.fits.ImageHDU;
+import nom.tam.fits.NullDataHDU;
 import nom.tam.fits.RandomGroupsData;
 import nom.tam.fits.RandomGroupsHDU;
 import nom.tam.fits.UndefinedData;
@@ -1399,6 +1400,101 @@ public class BaseFitsTest {
         Assert.assertTrue(file.setReadOnly());
         // Create a Fits object from the read-only file.
         Fits fits = new Fits(fileName);
+    }
+
+    @Test
+    public void testGetPrimaryHDU() throws Exception {
+        Fits fits = new Fits();
+        BasicHDU<?> primary = new NullDataHDU();
+
+        fits.addHDU(primary);
+        fits.addHDU(ImageData.from(new int[10][10]).toHDU());
+
+        Assert.assertEquals(primary.getHeader(), fits.getPrimaryHeader());
+        Assert.assertTrue(fits.getPrimaryHeader().containsKey(Standard.SIMPLE));
+    }
+
+    @Test(expected = FitsException.class)
+    public void testGetPrimaryHeaderEmpty() throws Exception {
+        Fits fits = new Fits();
+        fits.getPrimaryHeader();
+    }
+
+    @Test
+    public void testGetCompleteHeaderInherit() throws Exception {
+        Fits fits = new Fits();
+        BasicHDU<?> primary = new NullDataHDU();
+        primary.addValue("TEST", "blah", "no comment");
+
+        BasicHDU<?> im = ImageData.from(new int[10][10]).toHDU();
+        im.addValue(Standard.INHERIT, true);
+
+        fits.addHDU(primary);
+        fits.addHDU(im);
+
+        Assert.assertEquals(primary.getHeader(), fits.getCompleteHeader(0));
+        Assert.assertTrue(fits.getCompleteHeader(0).containsKey("TEST"));
+
+        Assert.assertNotEquals(im.getHeader(), fits.getCompleteHeader(1));
+        Assert.assertTrue(fits.getCompleteHeader(1).containsKey("TEST"));
+        Assert.assertFalse(fits.getCompleteHeader(1).containsKey(Standard.SIMPLE));
+    }
+
+    @Test
+    public void testGetCompleteHeaderNoInherit() throws Exception {
+        Fits fits = new Fits();
+        BasicHDU<?> primary = new NullDataHDU();
+        BasicHDU<?> im = ImageData.from(new int[10][10]).toHDU();
+
+        fits.addHDU(primary);
+        fits.addHDU(im);
+
+        Assert.assertEquals(primary.getHeader(), fits.getCompleteHeader(0));
+        Assert.assertTrue(fits.getCompleteHeader(0).containsKey(Standard.SIMPLE));
+
+        Assert.assertEquals(im.getHeader(), fits.getCompleteHeader(1));
+        Assert.assertTrue(fits.getCompleteHeader(1).containsKey(Standard.XTENSION));
+    }
+
+    @Test
+    public void testGetCompleteHeaderByName() throws Exception {
+        Fits fits = new Fits();
+        BasicHDU<?> primary = new NullDataHDU();
+        primary.addValue("TEST", "blah", "no comment");
+
+        BasicHDU<?> im = ImageData.from(new int[10][10]).toHDU();
+        im.addValue(Standard.EXTNAME, "TEST");
+
+        fits.addHDU(new NullDataHDU());
+        fits.addHDU(im);
+
+        Assert.assertEquals(im.getHeader(), fits.getCompleteHeader("TEST"));
+    }
+
+    @Test
+    public void testGetCompleteHeaderByNameVersion() throws Exception {
+        Fits fits = new Fits();
+        BasicHDU<?> primary = new NullDataHDU();
+        primary.addValue("TEST", "blah", "no comment");
+
+        BasicHDU<?> im1 = ImageData.from(new int[10][10]).toHDU();
+        im1.addValue(Standard.EXTNAME, "TEST");
+
+        BasicHDU<?> im2 = ImageData.from(new int[10][10]).toHDU();
+        im2.addValue(Standard.EXTNAME, "TEST");
+        im2.addValue(Standard.EXTVER, "2");
+
+        fits.addHDU(new NullDataHDU());
+        fits.addHDU(im1);
+        fits.addHDU(im2);
+
+        Assert.assertEquals(im2.getHeader(), fits.getCompleteHeader("TEST", 2));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testGetCompleteHeaderIndexOutOfBounds() throws Exception {
+        Fits fits = new Fits();
+        fits.getCompleteHeader(0);
     }
 
     private static class TestRandomAccessFileIO extends java.io.RandomAccessFile implements RandomAccessFileIO {

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
+import java.util.NoSuchElementException;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -1471,6 +1472,12 @@ public class BaseFitsTest {
         Assert.assertEquals(im.getHeader(), fits.getCompleteHeader("TEST"));
     }
 
+    @Test(expected = NoSuchElementException.class)
+    public void testGetCompleteHeaderByNameException() throws Exception {
+        Fits fits = new Fits();
+        fits.getCompleteHeader("TEST");
+    }
+
     @Test
     public void testGetCompleteHeaderByNameVersion() throws Exception {
         Fits fits = new Fits();
@@ -1489,6 +1496,26 @@ public class BaseFitsTest {
         fits.addHDU(im2);
 
         Assert.assertEquals(im2.getHeader(), fits.getCompleteHeader("TEST", 2));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetCompleteHeaderByNameVersionException() throws Exception {
+        Fits fits = new Fits();
+        BasicHDU<?> primary = new NullDataHDU();
+        primary.addValue("TEST", "blah", "no comment");
+
+        BasicHDU<?> im1 = ImageData.from(new int[10][10]).toHDU();
+        im1.addValue(Standard.EXTNAME, "TEST");
+
+        BasicHDU<?> im2 = ImageData.from(new int[10][10]).toHDU();
+        im2.addValue(Standard.EXTNAME, "TEST");
+        im2.addValue(Standard.EXTVER, "2");
+
+        fits.addHDU(new NullDataHDU());
+        fits.addHDU(im1);
+        fits.addHDU(im2);
+
+        fits.getCompleteHeader("TEST", 3);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)


### PR DESCRIPTION
Add the following convenience methods:

- `Fits.getPrimaryHeader()` to get easy access to the primary header in the FITS. Unlike `Fits.getHDU(0).getHeader()` it will also populate the mandatory FITS keywords for the primary HDU's header (s.t. subsequent calls to  `Fits.getHDU(0).getHeader()` would also have those even if they weren't present before).
- `Fits.getCompleteHeader(...)` methods, which can retrieve completed headers for individual HDUs. Like above, the headers returned this way will be updated to include the mandatory FITS keywords. And, if the header has `INHERIT` set to `true`, the call will return an independent new header that is composed of the entries explicitly defined in the selected HDU, with all non-conflicting primary keys added also.

This PR also contains some fixes to `HashedList`.