### PR TITLE
Standardized keyword and value checking

### DIFF
--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -137,8 +137,15 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
      * @param      myData   the corresponding data object
      */
     protected BasicHDU(Header myHeader, DataClass myData) {
-        this.myHeader = myHeader;
+        setHeader(myHeader);
         this.myData = myData;
+    }
+
+    private void setHeader(Header header) {
+        this.myHeader = header;
+        if (header != null) {
+            this.myHeader.assignTo(this);
+        }
     }
 
     /**
@@ -896,7 +903,7 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
     @Override
     @SuppressWarnings({"unchecked", "deprecation"})
     public void read(ArrayDataInput stream) throws FitsException, IOException {
-        myHeader = Header.readHeader(stream);
+        setHeader(Header.readHeader(stream));
         myData = (DataClass) FitsFactory.dataFactory(myHeader);
         myData.read(stream);
     }
@@ -934,7 +941,10 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
             throw new FitsException("Invalid attempt to make HDU of type:" + this.getClass().getName() + " primary.");
         }
 
+        Header.KeywordCheck mode = myHeader.getKeywordChecking();
+        myHeader.setKeywordChecking(Header.KeywordCheck.DATA_TYPE);
         myHeader.setRequiredKeys(value ? null : getCanonicalXtension());
+        myHeader.setKeywordChecking(mode);
     }
 
     /**
@@ -957,7 +967,7 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
     @Override
     public void write(ArrayDataOutput stream) throws FitsException {
         if (myHeader == null) {
-            myHeader = new Header();
+            setHeader(new Header());
         }
 
         if (stream instanceof FitsOutput) {

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -941,10 +941,10 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
             throw new FitsException("Invalid attempt to make HDU of type:" + this.getClass().getName() + " primary.");
         }
 
-        Header.KeywordCheck mode = myHeader.getKeywordCheckingPolicy();
-        myHeader.setKeywordCheckingPolicy(Header.KeywordCheck.DATA_TYPE);
+        Header.KeywordCheck mode = myHeader.getKeywordChecking();
+        myHeader.setKeywordChecking(Header.KeywordCheck.DATA_TYPE);
         myHeader.setRequiredKeys(value ? null : getCanonicalXtension());
-        myHeader.setKeywordCheckingPolicy(mode);
+        myHeader.setKeywordChecking(mode);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -941,10 +941,10 @@ public abstract class BasicHDU<DataClass extends Data> implements FitsElement {
             throw new FitsException("Invalid attempt to make HDU of type:" + this.getClass().getName() + " primary.");
         }
 
-        Header.KeywordCheck mode = myHeader.getKeywordChecking();
-        myHeader.setKeywordChecking(Header.KeywordCheck.DATA_TYPE);
+        Header.KeywordCheck mode = myHeader.getKeywordCheckingPolicy();
+        myHeader.setKeywordCheckingPolicy(Header.KeywordCheck.DATA_TYPE);
         myHeader.setRequiredKeys(value ? null : getCanonicalXtension());
-        myHeader.setKeywordChecking(mode);
+        myHeader.setKeywordCheckingPolicy(mode);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -1372,7 +1372,7 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
         }
 
         HeaderCard card = header.getCard(Standard.NAXIS1);
-        card.setValue(String.valueOf(rowLen));
+        card.setValue(rowLen);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -219,9 +219,9 @@ public class Header implements FitsElement {
     /** The keyword checking mode used by the library until the user changes it it. */
     public static final KeywordCheck DEFAULT_KEYWORD_CHECK_POLICY = KeywordCheck.DATA_TYPE;
 
-    private static KeywordCheck defaultCheckMode = DEFAULT_KEYWORD_CHECK_POLICY;
+    private static KeywordCheck defaultKeyCheck = DEFAULT_KEYWORD_CHECK_POLICY;
 
-    private KeywordCheck checkMode = defaultCheckMode;
+    private KeywordCheck keyCheck = defaultKeyCheck;
 
     /**
      * Create a header by reading the information from the input stream.
@@ -414,7 +414,7 @@ public class Header implements FitsElement {
      * @since        1.19
      */
     public void setKeywordCheckingPolicy(KeywordCheck policy) {
-        checkMode = policy;
+        keyCheck = policy;
     }
 
     /**
@@ -431,7 +431,7 @@ public class Header implements FitsElement {
      * @since        1.19
      */
     public static void setDefaultKeywordCheckingPolicy(KeywordCheck policy) {
-        defaultCheckMode = policy;
+        defaultKeyCheck = policy;
     }
 
     /**
@@ -444,11 +444,11 @@ public class Header implements FitsElement {
      * @since  1.19
      */
     public final KeywordCheck getKeywordCheckingPolicy() {
-        return checkMode;
+        return keyCheck;
     }
 
     private void checkKeyword(IFitsHeader keyword) throws IllegalArgumentException {
-        if (checkMode == KeywordCheck.NONE || owner == null) {
+        if (keyCheck == KeywordCheck.NONE || owner == null) {
             return;
         }
 
@@ -457,7 +457,7 @@ public class Header implements FitsElement {
             return;
         case EXTENSION:
         case PRIMARY:
-            if (checkMode == KeywordCheck.STRICT && keyword.status() == IFitsHeader.SOURCE.MANDATORY) {
+            if (keyCheck == KeywordCheck.STRICT && keyword.status() == IFitsHeader.SOURCE.MANDATORY) {
                 throw new IllegalArgumentException("Keyword " + keyword + " should be set by the library only");
             }
             return;

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -218,7 +218,10 @@ public class Header implements FitsElement {
         STRICT
     }
 
-    private static KeywordCheck defaultCheckMode = KeywordCheck.DATA_TYPE;
+    /** The keyword checking mode used by the library until the user changes it it. */
+    public static final KeywordCheck DEFAULT_KEYWORD_CHECK_MODE = KeywordCheck.DATA_TYPE;
+
+    private static KeywordCheck defaultCheckMode = DEFAULT_KEYWORD_CHECK_MODE;
 
     private KeywordCheck checkMode = defaultCheckMode;
 
@@ -456,7 +459,7 @@ public class Header implements FitsElement {
             return;
         case EXTENSION:
         case PRIMARY:
-            if (checkMode == KeywordCheck.STRICT) {
+            if (checkMode == KeywordCheck.STRICT && keyword.status() == IFitsHeader.SOURCE.MANDATORY) {
                 throw new IllegalArgumentException("Keyword " + keyword + " should be set by the library only");
             }
             return;
@@ -471,6 +474,7 @@ public class Header implements FitsElement {
             }
             break;
         case TABLE:
+            System.err.println("### keyword " + keyword.key() + ", hdu " + owner.getClass().getName());
             if (owner instanceof TableHDU) {
                 return;
             }
@@ -489,7 +493,6 @@ public class Header implements FitsElement {
         // TODO unclear what checking we should do for these type of keywords.
         // return;
         default:
-            System.err.println("### keyword " + keyword.key() + ", hdu " + owner.getClass().getName());
             return;
         }
 

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -403,13 +403,14 @@ public class Header implements FitsElement {
      * will throw an {@link IllegalArgumentException} if the specified keyword is not allowed for that type of HDU.
      * </p>
      * <p>
-     * This method changes the keyword checking mode for this header instance only. If you want to change the mode for
-     * all newly created headers globally, use {@link #setDefaultKeywordCheckingPolicy(KeywordCheck)} instead.
+     * This method changes the keyword checking policy for this header instance only. If you want to change the policy
+     * for all newly created headers globally, use {@link #setDefaultKeywordCheckingPolicy(KeywordCheck)} instead.
      * </p>
      * 
-     * @param policy The keyword checking mode to use.
+     * @param policy The keyword checking policy to use.
      * 
      * @see          #getKeywordCheckingPolicy()
+     * @see          HeaderCard#setValueCheckingPolicy(nom.tam.fits.HeaderCard.ValueCheck)
      * 
      * @since        1.19
      */
@@ -418,15 +419,16 @@ public class Header implements FitsElement {
     }
 
     /**
-     * Sets the default mode for built-in standard keyword checking mode for new headers. When populating the header
+     * Sets the default policy for built-in standard keyword checking mode for new headers. When populating the header
      * using {@link IFitsHeader} keywords the library will check if the given keyword is appropriate for the type of HDU
      * that the header represents, and will throw an {@link IllegalArgumentException} if the specified keyword is not
      * allowed for that type of HDU.
      * 
-     * @param policy The keyword checking mode to use.
+     * @param policy The keyword checking policy to use.
      * 
      * @see          #setKeywordCheckingPolicy(KeywordCheck)
      * @see          #getKeywordCheckingPolicy()
+     * @see          HeaderCard#setValueCheckingPolicy(nom.tam.fits.HeaderCard.ValueCheck)
      * 
      * @since        1.19
      */
@@ -435,9 +437,9 @@ public class Header implements FitsElement {
     }
 
     /**
-     * Returns the current keyword checking mode.
+     * Returns the current keyword checking policy.
      * 
-     * @return the current keyword checking mode
+     * @return the current keyword checking policy
      * 
      * @see    #setKeywordCheckingPolicy(KeywordCheck)
      * 
@@ -453,6 +455,7 @@ public class Header implements FitsElement {
         }
 
         switch (keyword.hdu()) {
+
         case ANY:
             return;
         case EXTENSION:

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -198,7 +198,7 @@ public class Header implements FitsElement {
     private BasicHDU<?> owner;
 
     /**
-     * Keyword checking mode when adding standardized keywords via the {@link IFitsHeader} interface.
+     * Keyword checking policy when adding standardized keywords via the {@link IFitsHeader} interface.
      * 
      * @author Attila Kovacs
      * 

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -216,7 +216,11 @@ public class Header implements FitsElement {
         STRICT
     }
 
-    /** The keyword checking mode used by the library until the user changes it it. */
+    /**
+     * The keyword checking mode used by the library until the user changes it it.
+     *
+     * @since 1.19
+     */
     public static final KeywordCheck DEFAULT_KEYWORD_CHECK_POLICY = KeywordCheck.DATA_TYPE;
 
     private static KeywordCheck defaultKeyCheck = DEFAULT_KEYWORD_CHECK_POLICY;

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -198,13 +198,11 @@ public class Header implements FitsElement {
     private BasicHDU<?> owner;
 
     /**
-     * Keyword checking mode when adding standardized keywords. When using
-     * <code>Header.addValue(IFitsHeader, ...)</code> or <code>BasicHDU.addValue(IFitsHeader, ...)</code> methods to
-     * populate the header, it will check if the given keyword is appropriate for the type of HDU that the header
-     * represents, those methods will throw an {@link IllegalArgumentException} if the specified keyword is not allowed
-     * for that type of HDU.
+     * Keyword checking mode when adding standardized keywords via the {@link IFitsHeader} interface.
      * 
      * @author Attila Kovacs
+     * 
+     * @since  1.19
      */
     public enum KeywordCheck {
         /** No keyword checking will be performed. */
@@ -219,9 +217,9 @@ public class Header implements FitsElement {
     }
 
     /** The keyword checking mode used by the library until the user changes it it. */
-    public static final KeywordCheck DEFAULT_KEYWORD_CHECK_MODE = KeywordCheck.DATA_TYPE;
+    public static final KeywordCheck DEFAULT_KEYWORD_CHECK_POLICY = KeywordCheck.DATA_TYPE;
 
-    private static KeywordCheck defaultCheckMode = DEFAULT_KEYWORD_CHECK_MODE;
+    private static KeywordCheck defaultCheckMode = DEFAULT_KEYWORD_CHECK_POLICY;
 
     private KeywordCheck checkMode = defaultCheckMode;
 
@@ -384,7 +382,7 @@ public class Header implements FitsElement {
      * @throws IllegalArgumentException if the current keyword checking mode does not allow the headercard with its
      *                                      standard keyword in the header.
      * 
-     * @sa                              {@link #setKeywordChecking(KeywordCheck)}
+     * @sa                              {@link #setKeywordCheckingPolicy(KeywordCheck)}
      */
     public void addLine(HeaderCard fcard) throws IllegalArgumentException {
         if (fcard == null) {
@@ -406,17 +404,17 @@ public class Header implements FitsElement {
      * </p>
      * <p>
      * This method changes the keyword checking mode for this header instance only. If you want to change the mode for
-     * all newly created headers globally, use {@link #setDefaultKeywordChecking(KeywordCheck)} instead.
+     * all newly created headers globally, use {@link #setDefaultKeywordCheckingPolicy(KeywordCheck)} instead.
      * </p>
      * 
-     * @param mode The keyword checking mode to use.
+     * @param policy The keyword checking mode to use.
      * 
-     * @see        #getKeywordChecking()
+     * @see          #getKeywordCheckingPolicy()
      * 
-     * @since      1.19
+     * @since        1.19
      */
-    public void setKeywordChecking(KeywordCheck mode) {
-        checkMode = mode;
+    public void setKeywordCheckingPolicy(KeywordCheck policy) {
+        checkMode = policy;
     }
 
     /**
@@ -425,15 +423,15 @@ public class Header implements FitsElement {
      * that the header represents, and will throw an {@link IllegalArgumentException} if the specified keyword is not
      * allowed for that type of HDU.
      * 
-     * @param mode The keyword checking mode to use.
+     * @param policy The keyword checking mode to use.
      * 
-     * @see        #setKeywordChecking(KeywordCheck)
-     * @see        #getKeywordChecking()
+     * @see          #setKeywordCheckingPolicy(KeywordCheck)
+     * @see          #getKeywordCheckingPolicy()
      * 
-     * @since      1.19
+     * @since        1.19
      */
-    public static void setDefaultKeywordChecking(KeywordCheck mode) {
-        defaultCheckMode = mode;
+    public static void setDefaultKeywordCheckingPolicy(KeywordCheck policy) {
+        defaultCheckMode = policy;
     }
 
     /**
@@ -441,11 +439,11 @@ public class Header implements FitsElement {
      * 
      * @return the current keyword checking mode
      * 
-     * @see    #setKeywordChecking(KeywordCheck)
+     * @see    #setKeywordCheckingPolicy(KeywordCheck)
      * 
      * @since  1.19
      */
-    public final KeywordCheck getKeywordChecking() {
+    public final KeywordCheck getKeywordCheckingPolicy() {
         return checkMode;
     }
 

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -198,7 +198,7 @@ public class Header implements FitsElement {
     private BasicHDU<?> owner;
 
     /**
-     * Keyword checking policy when adding standardized keywords via the {@link IFitsHeader} interface.
+     * Keyword checking mode when adding standardized keywords via the {@link IFitsHeader} interface.
      * 
      * @author Attila Kovacs
      * 
@@ -382,7 +382,7 @@ public class Header implements FitsElement {
      * @throws IllegalArgumentException if the current keyword checking mode does not allow the headercard with its
      *                                      standard keyword in the header.
      * 
-     * @sa                              {@link #setKeywordCheckingPolicy(KeywordCheck)}
+     * @sa                              {@link #setKeywordChecking(KeywordCheck)}
      */
     public void addLine(HeaderCard fcard) throws IllegalArgumentException {
         if (fcard == null) {
@@ -403,49 +403,49 @@ public class Header implements FitsElement {
      * will throw an {@link IllegalArgumentException} if the specified keyword is not allowed for that type of HDU.
      * </p>
      * <p>
-     * This method changes the keyword checking policy for this header instance only. If you want to change the policy
-     * for all newly created headers globally, use {@link #setDefaultKeywordCheckingPolicy(KeywordCheck)} instead.
+     * This method changes the keyword checking mode for this header instance only. If you want to change the mode for
+     * all newly created headers globally, use {@link #setDefaultKeywordChecking(KeywordCheck)} instead.
      * </p>
      * 
-     * @param policy The keyword checking policy to use.
+     * @param mode The keyword checking mode to use.
      * 
-     * @see          #getKeywordCheckingPolicy()
-     * @see          HeaderCard#setValueCheckingPolicy(nom.tam.fits.HeaderCard.ValueCheck)
+     * @see        #getKeywordChecking()
+     * @see        HeaderCard#setValueCheckingPolicy(nom.tam.fits.HeaderCard.ValueCheck)
      * 
-     * @since        1.19
+     * @since      1.19
      */
-    public void setKeywordCheckingPolicy(KeywordCheck policy) {
-        keyCheck = policy;
+    public void setKeywordChecking(KeywordCheck mode) {
+        keyCheck = mode;
     }
 
     /**
-     * Sets the default policy for built-in standard keyword checking mode for new headers. When populating the header
+     * Sets the default mode of built-in standard keyword checking mode for new headers. When populating the header
      * using {@link IFitsHeader} keywords the library will check if the given keyword is appropriate for the type of HDU
      * that the header represents, and will throw an {@link IllegalArgumentException} if the specified keyword is not
      * allowed for that type of HDU.
      * 
-     * @param policy The keyword checking policy to use.
+     * @param mode The keyword checking policy to use.
      * 
-     * @see          #setKeywordCheckingPolicy(KeywordCheck)
-     * @see          #getKeywordCheckingPolicy()
-     * @see          HeaderCard#setValueCheckingPolicy(nom.tam.fits.HeaderCard.ValueCheck)
+     * @see        #setKeywordChecking(KeywordCheck)
+     * @see        #getKeywordChecking()
+     * @see        HeaderCard#setValueCheckingPolicy(nom.tam.fits.HeaderCard.ValueCheck)
      * 
-     * @since        1.19
+     * @since      1.19
      */
-    public static void setDefaultKeywordCheckingPolicy(KeywordCheck policy) {
-        defaultKeyCheck = policy;
+    public static void setDefaultKeywordChecking(KeywordCheck mode) {
+        defaultKeyCheck = mode;
     }
 
     /**
-     * Returns the current keyword checking policy.
+     * Returns the current keyword checking mode.
      * 
-     * @return the current keyword checking policy
+     * @return the current keyword checking mode
      * 
-     * @see    #setKeywordCheckingPolicy(KeywordCheck)
+     * @see    #setKeywordChecking(KeywordCheck)
      * 
      * @since  1.19
      */
-    public final KeywordCheck getKeywordCheckingPolicy() {
+    public final KeywordCheck getKeywordChecking() {
         return keyCheck;
     }
 

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -901,7 +901,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
             checkValueType(IFitsHeader.VALUE.REAL);
         } catch (ValueTypeException e) {
             if (update instanceof Float || update instanceof Double || update instanceof BigDecimal
-                    || update instanceof BigDecimal) {
+                    || update instanceof BigInteger) {
                 throw e;
             }
             checkValueType(IFitsHeader.VALUE.INTEGER);

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -1374,7 +1374,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @param policy the new polict to use for checking value types.
      * 
      * @see          #getValueCheckingPolicy()
-     * @see          Header#setKeywordCheckingPolicy(nom.tam.fits.Header.KeywordCheck)
+     * @see          Header#setKeywordChecking(nom.tam.fits.Header.KeywordCheck)
      * 
      * @since        1.19
      */

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -900,16 +900,8 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         try {
             checkValueType(IFitsHeader.VALUE.REAL);
         } catch (ValueTypeException e) {
-            if (update instanceof Float) {
-                throw e;
-            }
-            if (update instanceof Double) {
-                throw e;
-            }
-            if (update instanceof BigDecimal) {
-                throw e;
-            }
-            if (update instanceof BigInteger) {
+            if (update instanceof Float || update instanceof Double || update instanceof BigDecimal
+                    || update instanceof BigInteger) {
                 throw e;
             }
             checkValueType(IFitsHeader.VALUE.INTEGER);

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -900,8 +900,16 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         try {
             checkValueType(IFitsHeader.VALUE.REAL);
         } catch (ValueTypeException e) {
-            if (update instanceof Float || update instanceof Double || update instanceof BigDecimal
-                    || update instanceof BigInteger) {
+            if (update instanceof Float) {
+                throw e;
+            }
+            if (update instanceof Double) {
+                throw e;
+            }
+            if (update instanceof BigDecimal) {
+                throw e;
+            }
+            if (update instanceof BigInteger) {
                 throw e;
             }
             checkValueType(IFitsHeader.VALUE.INTEGER);

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -1360,13 +1360,23 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @return the current value type checking policy
      * 
      * @since  1.19
+     * 
+     * @see    #setValueCheckingPolicy(ValueCheck)
      */
     public static ValueCheck getValueCheckingPolicy() {
         return valueCheck;
     }
 
     /**
-     * @param policy
+     * Sets the policy to used for checking if set values conform to the expected types for cards that use standardized
+     * FITS keywords via the {@link IFitsHeader} interface.
+     * 
+     * @param policy the new polict to use for checking value types.
+     * 
+     * @see          #getValueCheckingPolicy()
+     * @see          Header#setKeywordCheckingPolicy(nom.tam.fits.Header.KeywordCheck)
+     * 
+     * @since        1.19
      */
     public static void setValueCheckingPolicy(ValueCheck policy) {
         valueCheck = policy;

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -116,6 +116,8 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
     /** The comment part of the card (set to null if there's no comment) */
     private String comment;
 
+    private IFitsHeader standardKey;
+
     /**
      * The Java class associated to the value
      *
@@ -1275,6 +1277,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
             }
         }
         key = newKey;
+        standardKey = null;
     }
 
     /**
@@ -1411,7 +1414,12 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
 
         LOG.log(Level.WARNING, "[" + key + "] with unexpected value type.",
                 new IllegalArgumentException("Expected " + type + ", got " + key.valueType()));
+
         return false;
+    }
+
+    final IFitsHeader getStandardKey() {
+        return standardKey;
     }
 
     /**
@@ -1434,7 +1442,9 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         checkType(key, VALUE.LOGICAL);
 
         try {
-            return new HeaderCard(key.key(), value, key.comment());
+            HeaderCard hc = new HeaderCard(key.key(), value, key.comment());
+            hc.standardKey = key;
+            return hc;
         } catch (HeaderCardException e) {
             throw new IllegalArgumentException("Invalid sconventional key [" + key.key() + "]", e);
         }
@@ -1472,7 +1482,9 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         }
 
         try {
-            return new HeaderCard(key.key(), value, key.comment());
+            HeaderCard hc = new HeaderCard(key.key(), value, key.comment());
+            hc.standardKey = key;
+            return hc;
         } catch (HeaderCardException e) {
             throw new IllegalArgumentException("Invalid conventional key [" + key.key() + "]", e);
         }
@@ -1497,7 +1509,9 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         checkType(key, VALUE.COMPLEX);
 
         try {
-            return new HeaderCard(key.key(), value, key.comment());
+            HeaderCard hc = new HeaderCard(key.key(), value, key.comment());
+            hc.standardKey = key;
+            return hc;
         } catch (HeaderCardException e) {
             throw new IllegalArgumentException("Invalid conventional key [" + key.key() + "]", e);
         }
@@ -1524,7 +1538,9 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         validateChars(value);
 
         try {
-            return new HeaderCard(key.key(), value, key.comment());
+            HeaderCard hc = new HeaderCard(key.key(), value, key.comment());
+            hc.standardKey = key;
+            return hc;
         } catch (HeaderCardException e) {
             throw new IllegalArgumentException("Invalid conventional key [" + key.key() + "]", e);
         }

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -136,12 +136,16 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         /** No value type checking will be performed */
         NONE,
         /** Attempting to set values of the wrong type for standardized keywords will log warnings */
-        LOG,
+        LOGGING,
         /** Throw exception when setting a value of the wrong type for a standardized keyword */
         EXCEPTION
     }
 
-    /** Default value type checking policy for cards with standardized {@link IFitsHeader} keywords. */
+    /**
+     * Default value type checking policy for cards with standardized {@link IFitsHeader} keywords.
+     * 
+     * @since 1.19
+     */
     public static final ValueCheck DEFAULT_VALUE_CHECK_POLICY = ValueCheck.EXCEPTION;
 
     private static ValueCheck valueCheck = DEFAULT_VALUE_CHECK_POLICY;
@@ -931,7 +935,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         if (t != expect) {
             ValueTypeException e = new ValueTypeException(key, t.name());
 
-            if (valueCheck == ValueCheck.LOG) {
+            if (valueCheck == ValueCheck.LOGGING) {
                 LOG.warning(e.getMessage());
             } else {
                 throw e;

--- a/src/main/java/nom/tam/fits/MismatchedValueTypeException.java
+++ b/src/main/java/nom/tam/fits/MismatchedValueTypeException.java
@@ -1,0 +1,56 @@
+package nom.tam.fits;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+/**
+ * Invalid value type used for a standard header keyword.
+ * 
+ * @author Attila Kovacs
+ * @since 1.19
+ */
+public class MismatchedValueTypeException extends HeaderCardException {
+
+    private static final long serialVersionUID = -4338698718509151861L;
+
+    /**
+     * Creates a new exception
+     * 
+     * @param key
+     *            the FITS keyword for which the exception occurred.
+     * @param valueType
+     *            the type of value that was problematic.
+     */
+    public MismatchedValueTypeException(String key, String valueType) {
+        super(key + " does not support " + valueType + " type values");
+    }
+
+}

--- a/src/main/java/nom/tam/fits/ValueTypeException.java
+++ b/src/main/java/nom/tam/fits/ValueTypeException.java
@@ -37,7 +37,7 @@ package nom.tam.fits;
  * @author Attila Kovacs
  * @since 1.19
  */
-public class MismatchedValueTypeException extends HeaderCardException {
+public class ValueTypeException extends HeaderCardException {
 
     private static final long serialVersionUID = -4338698718509151861L;
 
@@ -49,7 +49,7 @@ public class MismatchedValueTypeException extends HeaderCardException {
      * @param valueType
      *            the type of value that was problematic.
      */
-    public MismatchedValueTypeException(String key, String valueType) {
+    public ValueTypeException(String key, String valueType) {
         super(key + " does not support " + valueType + " type values");
     }
 

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -498,7 +498,6 @@ public enum Standard implements IFitsHeader {
     TFORMn(SOURCE.MANDATORY, HDU.TABLE, VALUE.STRING, "column data format", //
             replaceable("asciitable:tformN", AsciiTable.class), //
             replaceable("binarytable:tformN", BinaryTable.class) //
-
     ),
 
     /**

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1092,6 +1092,27 @@ string value of `"50"`:
 
 For best practice, try rely on the standard keywords, or those in registered conventions, when possible. 
 
+#### Keyword checking
+
+Another advantage of using the standardized keywords implementing the `IFitsHeader` interface is that the library can
+check (since __1.19__) automatically that (_a_) the keyword is appropriate for the type of HDU it is used in, and (_b_) 
+if the keyword is one of the essential keywords that should be set by the library alone without users tinkering with 
+them. If the keyword should not be used in the header belonging to a specific type of HDU under the current checking 
+policy, the library will throw an `IllegalArgumentException`.
+
+You can use `Header.setKeywordChecking()` to adjust the type of checking to be applied on a per header instance basis,
+or use the static `Header.setDEfaultKeywordChecking()` to change the default policy for all newly created headers.
+
+The `Header.KeywordCheck` enum defines the following policies that may be used:
+
+- `NONE` -- no keyword checking will be applied. You can do whatever you want without consequences. This policy is the 
+  most backward compatible one, since we have not done checking before.
+- `DATA_TYPE` -- Checks that the keyword is supported by the data type that the header is meant to describe. This is 
+  the default policy since __1.19__.
+- `STRICT` -- In addition to checking if the keyword is suitable for the data type, the library will also prevent 
+  users from setting essential keywords that really should be handled by the library alone (such as `SIMPLE` or 
+  `XTENSION`, `BITPIX`, `NAXIS` etc.).
+
 
 
 <a name="hierarch-style-header-keywords"></a>

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1114,6 +1114,14 @@ The `Header.KeywordCheck` enum defines the following policies that may be used:
   `XTENSION`, `BITPIX`, `NAXIS` etc.).
 
 
+#### Value checking
+
+The standardized keywords that implement the `IFitsHeader` interface can also specify the type of acceptable values
+to use. As of __1.19__ we will throw an appropriate exception (`IllegalArgumentException` or 
+`MismatchedValueTypeException`, depending on the method) if the user attempt to set a value of unsupported type. For
+example trying to set the value of the `Standard.TELESCOP` keyword (which expects a string value) to a boolean will
+throw an exception. 
+
 
 <a name="hierarch-style-header-keywords"></a>
 ### Hierarchical and long header keywords

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -703,6 +703,7 @@ public class HeaderTest {
     public void addValueTests() throws Exception {
         FileInputStream in = null;
         Fits fits = null;
+
         try {
             in = new FileInputStream("target/ht1.fits");
             fits = new Fits();
@@ -710,6 +711,7 @@ public class HeaderTest {
 
             BasicHDU<?> hdu = fits.getHDU(0);
             Header hdr = hdu.getHeader();
+            hdr.setKeywordChecking(Header.KeywordCheck.NONE);
 
             hdu.addValue(CTYPE1, true);
             assertEquals(hdr.getBooleanValue(CTYPE1.name()), true);
@@ -1702,23 +1704,23 @@ public class HeaderTest {
 
     @Test
     public void testKeywordCheckingNone() throws Exception {
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.NONE);
         Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
-        h.setKeywordChecking(Header.KeywordCheck.NONE);
         h.addValue(Standard.TFORMn.n(1), "blah");
         /* No exception */
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testKeywordCheckingPrimary() throws Exception {
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
-        h.setKeywordChecking(Header.KeywordCheck.STRICT);
         h.addValue(Standard.SIMPLE, true);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testKeywordCheckingExtension() throws Exception {
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
-        h.setKeywordChecking(Header.KeywordCheck.STRICT);
         h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1756,7 +1756,7 @@ public class HeaderTest {
 
     @Test
     public void testKeywordCheckingOptional() throws Exception {
-        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.DATA_TYPE);
+        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.OBJECT, "blah");
     }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.Standard;
+import nom.tam.fits.header.extra.NOAOExt;
 import nom.tam.fits.header.hierarch.BlanksDotHierarchKeyFormatter;
 import nom.tam.fits.header.hierarch.Hierarch;
 import nom.tam.util.ArrayDataOutput;
@@ -1654,5 +1655,70 @@ public class HeaderTest {
         }
 
         throw new IllegalStateException("Missing inherited comment");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testImageKeywordChecking() throws Exception {
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.addValue(Standard.BUNIT, "blah");
+    }
+
+    public void testImageKeywordCheckingGroup() throws Exception {
+        Header h = new RandomGroupsData(new Object[][] {{new int[4], new int[2]}}).toHDU().getHeader();
+        h.addValue(Standard.BUNIT, "blah");
+        /* no exception */
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRandomGroupsKeywordChecking() throws Exception {
+        Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
+        h.addValue(Standard.PTYPEn.n(1), "blah");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTableKeywordChecking() throws Exception {
+        Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
+        h.addValue(Standard.TFORMn.n(1), "blah");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAsciiTableKeywordChecking() throws Exception {
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.addValue(Standard.TBCOLn.n(1), 10);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBinbaryTableKeywordChecking() throws Exception {
+        Header h = new AsciiTable().toHDU().getHeader();
+        h.addValue(Standard.TDIMn.n(1), "blah");
+    }
+
+    @Test
+    public void testNOAOKeywordChecking() throws Exception {
+        Header h = new AsciiTable().toHDU().getHeader();
+        h.addValue(NOAOExt.AMPMJD, 60000.0);
+        /* No exception */
+    }
+
+    @Test
+    public void testKeywordCheckingNone() throws Exception {
+        Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
+        h.setKeywordChecking(Header.KeywordCheck.NONE);
+        h.addValue(Standard.TFORMn.n(1), "blah");
+        /* No exception */
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testKeywordCheckingPrimary() throws Exception {
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.setKeywordChecking(Header.KeywordCheck.STRICT);
+        h.addValue(Standard.SIMPLE, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testKeywordCheckingExtension() throws Exception {
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.setKeywordChecking(Header.KeywordCheck.STRICT);
+        h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1758,7 +1758,7 @@ public class HeaderTest {
     public void testKeywordCheckingOptional() throws Exception {
         Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
-        h.addValue(Standard.OBJECT, "blah");
+        h.addValue(NOAOExt.ADCMJD, 0.0);
     }
 
 }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -92,7 +92,7 @@ public class HeaderTest {
     @Before
     public void before() throws Exception {
         FitsFactory.setDefaults();
-        Header.setDefaultKeywordChecking(Header.DEFAULT_KEYWORD_CHECK_MODE);
+        Header.setDefaultKeywordCheckingPolicy(Header.DEFAULT_KEYWORD_CHECK_POLICY);
 
         float[][] img = new float[300][300];
         Fits f = null;
@@ -712,7 +712,7 @@ public class HeaderTest {
 
             BasicHDU<?> hdu = fits.getHDU(0);
             Header hdr = hdu.getHeader();
-            hdr.setKeywordChecking(Header.KeywordCheck.NONE);
+            hdr.setKeywordCheckingPolicy(Header.KeywordCheck.NONE);
 
             hdu.addValue(CTYPE1, true);
             assertEquals(hdr.getBooleanValue(CTYPE1.name()), true);
@@ -1720,7 +1720,7 @@ public class HeaderTest {
 
     @Test
     public void testKeywordCheckingNone() throws Exception {
-        Header.setDefaultKeywordChecking(Header.KeywordCheck.NONE);
+        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.NONE);
         Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
         h.addValue(Standard.TFORMn.n(1), "blah");
         /* No exception */
@@ -1728,14 +1728,14 @@ public class HeaderTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testKeywordCheckingPrimary() throws Exception {
-        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
+        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.SIMPLE, true);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testKeywordCheckingExtension() throws Exception {
-        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
+        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
     }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -92,7 +92,7 @@ public class HeaderTest {
     @Before
     public void before() throws Exception {
         FitsFactory.setDefaults();
-        Header.setDefaultKeywordCheckingPolicy(Header.DEFAULT_KEYWORD_CHECK_POLICY);
+        Header.setDefaultKeywordChecking(Header.DEFAULT_KEYWORD_CHECK_POLICY);
 
         float[][] img = new float[300][300];
         Fits f = null;
@@ -712,7 +712,7 @@ public class HeaderTest {
 
             BasicHDU<?> hdu = fits.getHDU(0);
             Header hdr = hdu.getHeader();
-            hdr.setKeywordCheckingPolicy(Header.KeywordCheck.NONE);
+            hdr.setKeywordChecking(Header.KeywordCheck.NONE);
 
             hdu.addValue(CTYPE1, true);
             assertEquals(hdr.getBooleanValue(CTYPE1.name()), true);
@@ -1720,7 +1720,7 @@ public class HeaderTest {
 
     @Test
     public void testKeywordCheckingNone() throws Exception {
-        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.NONE);
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.NONE);
         Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
         h.addValue(Standard.TFORMn.n(1), "blah");
         /* No exception */
@@ -1728,35 +1728,35 @@ public class HeaderTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testKeywordCheckingPrimaryException() throws Exception {
-        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.SIMPLE, true);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testKeywordCheckingExtensionException() throws Exception {
-        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testStrictKeywordCheckingExtension() throws Exception {
-        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
     }
 
     @Test
     public void testKeywordCheckingPrimary() throws Exception {
-        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.DATA_TYPE);
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.DATA_TYPE);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.SIMPLE, true);
     }
 
     @Test
     public void testKeywordCheckingOptional() throws Exception {
-        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(NOAOExt.ADCMJD, 0.0);
     }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1727,16 +1727,38 @@ public class HeaderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testKeywordCheckingPrimary() throws Exception {
+    public void testKeywordCheckingPrimaryException() throws Exception {
         Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.SIMPLE, true);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testKeywordCheckingExtension() throws Exception {
+    public void testKeywordCheckingExtensionException() throws Exception {
         Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
     }
+
+    @Test
+    public void testKeywordCheckingPrimary() throws Exception {
+        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.DATA_TYPE);
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.addValue(Standard.SIMPLE, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStrictKeywordCheckingExtension() throws Exception {
+        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
+    }
+
+    @Test
+    public void testKeywordCheckingOptional() throws Exception {
+        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.DATA_TYPE);
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.addValue(Standard.OBJECT, "blah");
+    }
+
 }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -92,6 +92,7 @@ public class HeaderTest {
     @Before
     public void before() throws Exception {
         FitsFactory.setDefaults();
+        Header.setDefaultKeywordChecking(Header.DEFAULT_KEYWORD_CHECK_MODE);
 
         float[][] img = new float[300][300];
         Fits f = null;
@@ -1659,12 +1660,14 @@ public class HeaderTest {
         throw new IllegalStateException("Missing inherited comment");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testImageKeywordChecking() throws Exception {
-        Header h = new BinaryTable().toHDU().getHeader();
+        Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
         h.addValue(Standard.BUNIT, "blah");
+        /* no exception */
     }
 
+    @Test
     public void testImageKeywordCheckingGroup() throws Exception {
         Header h = new RandomGroupsData(new Object[][] {{new int[4], new int[2]}}).toHDU().getHeader();
         h.addValue(Standard.BUNIT, "blah");
@@ -1672,25 +1675,38 @@ public class HeaderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testRandomGroupsKeywordChecking() throws Exception {
+    public void testImageKeywordCheckingException() throws Exception {
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.addValue(Standard.BUNIT, "blah");
+    }
+
+    @Test
+    public void testGroupKeywordChecking() throws Exception {
+        Header h = new RandomGroupsData(new Object[][] {{new int[4], new int[2]}}).toHDU().getHeader();
+        h.addValue(Standard.PTYPEn.n(1), "blah");
+        /* no exception */
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGroupsKeywordCheckingException() throws Exception {
         Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
         h.addValue(Standard.PTYPEn.n(1), "blah");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testTableKeywordChecking() throws Exception {
+    public void testTableKeywordCheckingException() throws Exception {
         Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
         h.addValue(Standard.TFORMn.n(1), "blah");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testAsciiTableKeywordChecking() throws Exception {
+    public void testAsciiTableKeywordCheckingException() throws Exception {
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.TBCOLn.n(1), 10);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testBinbaryTableKeywordChecking() throws Exception {
+    public void testBinbaryTableKeywordCheckingException() throws Exception {
         Header h = new AsciiTable().toHDU().getHeader();
         h.addValue(Standard.TDIMn.n(1), "blah");
     }

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1740,18 +1740,18 @@ public class HeaderTest {
         h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
     }
 
-    @Test
-    public void testKeywordCheckingPrimary() throws Exception {
-        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.DATA_TYPE);
-        Header h = new BinaryTable().toHDU().getHeader();
-        h.addValue(Standard.SIMPLE, true);
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void testStrictKeywordCheckingExtension() throws Exception {
         Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
+    }
+
+    @Test
+    public void testKeywordCheckingPrimary() throws Exception {
+        Header.setDefaultKeywordCheckingPolicy(Header.KeywordCheck.DATA_TYPE);
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.addValue(Standard.SIMPLE, true);
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/KeyTypeTest.java
+++ b/src/test/java/nom/tam/fits/KeyTypeTest.java
@@ -40,6 +40,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import nom.tam.fits.header.IFitsHeader;
@@ -47,6 +48,11 @@ import nom.tam.fits.header.Standard;
 import nom.tam.util.ComplexValue;
 
 public class KeyTypeTest {
+
+    @Before
+    public void before() {
+        HeaderCard.setValueCheckingPolicy(HeaderCard.ValueCheck.LOG);
+    }
 
     private class ComplexKey implements IFitsHeader {
         String name;

--- a/src/test/java/nom/tam/fits/KeyTypeTest.java
+++ b/src/test/java/nom/tam/fits/KeyTypeTest.java
@@ -51,7 +51,7 @@ public class KeyTypeTest {
 
     @Before
     public void before() {
-        HeaderCard.setValueCheckingPolicy(HeaderCard.ValueCheck.LOG);
+        HeaderCard.setValueCheckingPolicy(HeaderCard.ValueCheck.LOGGING);
     }
 
     private class ComplexKey implements IFitsHeader {

--- a/src/test/java/nom/tam/fits/test/HeaderCardStaticTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardStaticTest.java
@@ -151,9 +151,9 @@ public class HeaderCardStaticTest {
         assertEquals(Long.class, hc.valueType());
         assertEquals(4000000000L, hc.getValue(Long.class, -1L).longValue());
 
-        hc = HeaderCard.create(Standard.BUNIT, 3.002f);
+        hc = HeaderCard.create(Standard.BZERO, 3.002f);
         assertTrue(hc.isKeyValuePair());
-        assertEquals(Standard.BUNIT.key(), hc.getKey());
+        assertEquals(Standard.BZERO.key(), hc.getKey());
         assertEquals(Float.class, hc.valueType());
         assertEquals(3.002f, hc.getValue(Float.class, 0.0f).floatValue(), 1e-6);
 
@@ -220,7 +220,7 @@ public class HeaderCardStaticTest {
         assertNull(hc);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testCreateWrongValueTypeFitsCard1() throws Exception {
         HeaderCard hc = HeaderCard.create(new CustomIFitsHeader("TEST", null, VALUE.STRING), 1);
         assertNotNull(hc);

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -1860,4 +1860,25 @@ public class HeaderCardTest {
     public void testUnfilledKeywordIndex() {
         HeaderCard.create(Standard.CTYPEn, "blah");
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIntegerKeyValueException() {
+        HeaderCard.create(Standard.NAXIS, 3.1415);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDecimalKeyValueException() {
+        HeaderCard.create(Standard.BSCALE, new ComplexValue(1.0, 0.0));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLogicalKeyValueException() {
+        HeaderCard.create(Standard.SIMPLE, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStringKeyValueException() {
+        HeaderCard.create(Standard.EXTNAME, 0);
+    }
+
 }

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -1931,6 +1931,12 @@ public class HeaderCardTest {
     }
 
     @Test
+    public void testSetStandardInteger() {
+        HeaderCard hc = HeaderCard.create(Standard.BZERO, 1);
+        Assert.assertEquals(1, (int) hc.getValue(Integer.class, 0));
+    }
+
+    @Test
     public void testGetValueCheckPolicy() {
         for (HeaderCard.ValueCheck policy : HeaderCard.ValueCheck.values()) {
             HeaderCard.setValueCheckingPolicy(policy);

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -68,6 +68,7 @@ public class HeaderCardTest {
     @Before
     public void before() {
         FitsFactory.setDefaults();
+        HeaderCard.setValueCheckingPolicy(HeaderCard.DEFAULT_VALUE_CHECK_POLICY);
     }
 
     @After
@@ -1879,6 +1880,62 @@ public class HeaderCardTest {
     @Test(expected = IllegalArgumentException.class)
     public void testStringKeyValueException() {
         HeaderCard.create(Standard.EXTNAME, 0);
+    }
+
+    @Test
+    public void testIntegerKeyValueIgnore() {
+        HeaderCard.setValueCheckingPolicy(HeaderCard.ValueCheck.NONE);
+        HeaderCard.create(Standard.NAXIS, 3.1415);
+    }
+
+    @Test
+    public void testDecimalKeyValueIgnore() {
+        HeaderCard.setValueCheckingPolicy(HeaderCard.ValueCheck.NONE);
+        HeaderCard.create(Standard.BSCALE, new ComplexValue(1.0, 0.0));
+    }
+
+    @Test
+    public void testLogicalKeyValueIgnore() {
+        HeaderCard.setValueCheckingPolicy(HeaderCard.ValueCheck.NONE);
+        HeaderCard.create(Standard.SIMPLE, 0);
+    }
+
+    @Test
+    public void testStringKeyValueIgnore() {
+        HeaderCard.setValueCheckingPolicy(HeaderCard.ValueCheck.NONE);
+        HeaderCard.create(Standard.EXTNAME, 0);
+    }
+
+    @Test
+    public void testSetStandardFloat() {
+        HeaderCard hc = HeaderCard.create(Standard.BZERO, 1.0F);
+        Assert.assertEquals(1.0F, hc.getValue(Float.class, 0.0F), 1e-6);
+    }
+
+    @Test
+    public void testSetStandardDouble() {
+        HeaderCard hc = HeaderCard.create(Standard.BZERO, 1.0);
+        Assert.assertEquals(1.0, hc.getValue(Double.class, 0.0), 1e-12);
+    }
+
+    @Test
+    public void testSetStandardBigDecimal() {
+        HeaderCard hc = HeaderCard.create(Standard.BZERO, new BigDecimal("1.0"));
+        Assert.assertEquals(1.0, hc.getValue(Double.class, 0.0), 1e-12);
+    }
+
+    @Test
+    public void testSetStandardBigInteger() {
+        HeaderCard hc = HeaderCard.create(Standard.BZERO, new BigInteger("1"));
+        Assert.assertEquals(1.0, hc.getValue(Double.class, 0.0), 1e-12);
+    }
+
+    @Test
+    public void testGetValueCheckPolicy() {
+        for (HeaderCard.ValueCheck policy : HeaderCard.ValueCheck.values()) {
+            HeaderCard.setValueCheckingPolicy(policy);
+            Assert.assertEquals(policy.name(), policy, HeaderCard.getValueCheckingPolicy());
+        }
     }
 
 }

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -1906,27 +1906,27 @@ public class HeaderCardTest {
         HeaderCard.create(Standard.EXTNAME, 0);
     }
 
-    @Test
-    public void testSetStandardFloat() {
-        HeaderCard hc = HeaderCard.create(Standard.BZERO, 1.0F);
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetStandardFloatException() {
+        HeaderCard hc = HeaderCard.create(Standard.NAXIS, 1.0F);
         Assert.assertEquals(1.0F, hc.getValue(Float.class, 0.0F), 1e-6);
     }
 
-    @Test
-    public void testSetStandardDouble() {
-        HeaderCard hc = HeaderCard.create(Standard.BZERO, 1.0);
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetStandardDoubleException() {
+        HeaderCard hc = HeaderCard.create(Standard.NAXIS, 1.0);
         Assert.assertEquals(1.0, hc.getValue(Double.class, 0.0), 1e-12);
     }
 
-    @Test
-    public void testSetStandardBigDecimal() {
-        HeaderCard hc = HeaderCard.create(Standard.BZERO, new BigDecimal("1.0"));
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetStandardBigDecimalException() {
+        HeaderCard hc = HeaderCard.create(Standard.NAXIS, new BigDecimal("1.0"));
         Assert.assertEquals(1.0, hc.getValue(Double.class, 0.0), 1e-12);
     }
 
-    @Test
-    public void testSetStandardBigInteger() {
-        HeaderCard hc = HeaderCard.create(Standard.BZERO, new BigInteger("1"));
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetStandardBigIntegerException() {
+        HeaderCard hc = HeaderCard.create(Standard.NAXIS, new BigInteger("1"));
         Assert.assertEquals(1.0, hc.getValue(Double.class, 0.0), 1e-12);
     }
 


### PR DESCRIPTION
Many mandatory/reserved FITS keywords are designated to be used with specific HDU types only, and should take only specific types of values. For example the `THEAP` keyword should appear only in binary table HDUs, and must have an integer value. Until now we allowed users both to add this keyword to other HDU types (say an image HDU), and/or to set say the value to a string such as `"blah"`. However, such misuse of keywords can be problematic for tools reading files produced by us, ans so we should not allow such abominations in the future (or, at least not by default).

Our `IFitsHeader` interface allows specifying the HDU type to which standardized keywords belong, but we have not used it thus far for checking if these keywords were used appropriately. From now on we will add the capability to check, and throw an `IllegalArgumentException` if one attempts to add the standardized `IFitsHeader` keyword to the header of a HDU that does not support the keyword.

The new method `Header.setKeywordChecking()` can be used to adjust what checks are applied when adding `IFitsHeader` values/cards to the header on a per instance basis, or else the static `Header.setDefaultKeywordChecking()` to set a default mode for all newly created headers.

The `Header.KeywordCheck` enum defines the following modes that may be used:

- `NONE` -- no keyword checking will be applied. You can do whatever you want without consequences. This policy is the most backward compatible one, since we have not done checking before.
- `DATA_TYPE` -- Checks that the keyword is supported by the data type that the header is meant to describe. This is the default policy.
- `STRICT` -- In addition to checking if the keyword is suitable for the data type, the library will also prevent users from setting essential keywords that really should be handled by the library alone (such as `SIMPLE` or `XTENSION`, `BITPIX`, `NAXIS` etc.).

Similarly, trying the set a values for an `IFitsHeader` keywords can check if the keyword is compatible with that type of value, and either log the issue (old behavior) or else throw an appropriate exception (new default behavior). The value checking policy can be controlled via the `Header.Card.setValueCheckingPolicy()` on a global basis. 

The `HeaderCard.ValueCheck` enum defines the following policies that may be used: 

- `NONE` -- no value type checking will be performed. You can do whatever you want without consequences. This policy is the most backward compatible one, since we have not done checking before.
- `LOGGING` -- Attempting to set values of the wrong type for `IFitsHeader` keywords will be allowed but  a warning will be logged each time.
- `EXCEPTION` --  Attempting to set values of the wrong type for `IFitsHeader` keywords will throw an appropriate exception, such as `ValueTypeException` or `IllegalArgumentException` depending on the method used. 

This PR also includes:

- Fix for some binary tables (e.g. uncompressed) had `NAXIS1` value stored as a String in previous versions.
- `HeaderCard.setValue(String)` kept blank spaces at the end of the String, whereas otherwise we discards these, since these are not significant according to the FITS standard.