### PR TITLE
Additional keyword checking and some fixes to PR #534

### DIFF
--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -386,7 +386,7 @@ public class Header implements FitsElement {
      * @throws IllegalArgumentException if the current keyword checking mode does not allow the headercard with its
      *                                      standard keyword in the header.
      * 
-     * @sa                              {@link #setKeywordChecking(KeywordCheck)}
+     * @see                             #setKeywordChecking(KeywordCheck)
      */
     public void addLine(HeaderCard fcard) throws IllegalArgumentException {
         if (fcard == null) {
@@ -458,14 +458,22 @@ public class Header implements FitsElement {
             return;
         }
 
+        if (keyCheck == KeywordCheck.STRICT && keyword.status() == IFitsHeader.SOURCE.MANDATORY) {
+            throw new IllegalArgumentException("Keyword " + keyword + " should be set by the library only");
+        }
+
         switch (keyword.hdu()) {
 
-        case ANY:
+        case PRIMARY:
+            if (owner != null && !owner.canBePrimary()) {
+                throw new IllegalArgumentException(
+                        "Keyword " + keyword + " is a primary keyword and may not be used in extensions");
+            }
             return;
         case EXTENSION:
-        case PRIMARY:
-            if (keyCheck == KeywordCheck.STRICT && keyword.status() == IFitsHeader.SOURCE.MANDATORY) {
-                throw new IllegalArgumentException("Keyword " + keyword + " should be set by the library only");
+            if (owner instanceof RandomGroupsHDU) {
+                throw new IllegalArgumentException(
+                        "Keyword " + keyword + " is an extension keyword but random groups may only be primary");
             }
             return;
         case IMAGE:
@@ -494,9 +502,6 @@ public class Header implements FitsElement {
                 return;
             }
             break;
-        // case PRIMARY_EXTENSION:
-        // TODO unclear what checking we should do for these type of keywords.
-        // return;
         default:
             return;
         }

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -458,7 +458,8 @@ public class Header implements FitsElement {
             return;
         }
 
-        if (keyCheck == KeywordCheck.STRICT && keyword.status() == IFitsHeader.SOURCE.MANDATORY) {
+        if (keyCheck == KeywordCheck.STRICT
+                && (keyword.status() == IFitsHeader.SOURCE.MANDATORY || keyword.status() == IFitsHeader.SOURCE.INTEGRAL)) {
             throw new IllegalArgumentException("Keyword " + keyword + " should be set by the library only");
         }
 

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -465,7 +465,7 @@ public class Header implements FitsElement {
         switch (keyword.hdu()) {
 
         case PRIMARY:
-            if (owner != null && !owner.canBePrimary()) {
+            if (!owner.canBePrimary()) {
                 throw new IllegalArgumentException(
                         "Keyword " + keyword + " is a primary keyword and may not be used in extensions");
             }

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -932,7 +932,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
 
     private static void checkValueType(String key, IFitsHeader.VALUE expect, IFitsHeader.VALUE valueType)
             throws ValueTypeException {
-        if (expect == null || expect == IFitsHeader.VALUE.ANY || valueCheck == ValueCheck.NONE) {
+        if (expect == IFitsHeader.VALUE.ANY || valueCheck == ValueCheck.NONE) {
             return;
         }
 

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -37,12 +37,10 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import nom.tam.fits.FitsFactory.FitsSettings;
 import nom.tam.fits.header.IFitsHeader;
-import nom.tam.fits.header.IFitsHeader.VALUE;
 import nom.tam.fits.header.NonStandard;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.AsciiFuncs;
@@ -901,13 +899,11 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @see                          #setValue(Number)
      */
     public synchronized HeaderCard setValue(Number update, int decimals) throws NumberFormatException, LongValueException {
-        try {
+
+        if (update instanceof Float || update instanceof Double || update instanceof BigDecimal
+                || update instanceof BigInteger) {
             checkValueType(IFitsHeader.VALUE.REAL);
-        } catch (ValueTypeException e) {
-            if (update instanceof Float || update instanceof Double || update instanceof BigDecimal
-                    || update instanceof BigInteger) {
-                throw e;
-            }
+        } else {
             checkValueType(IFitsHeader.VALUE.INTEGER);
         }
 
@@ -922,18 +918,30 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         return this;
     }
 
-    private void checkValueType(IFitsHeader.VALUE t) throws ValueTypeException {
-        if (standardKey == null || valueCheck == ValueCheck.NONE) {
+    private static void checkKeyword(IFitsHeader keyword) throws IllegalArgumentException {
+        if (keyword.key().contains("n")) {
+            throw new IllegalArgumentException("Keyword " + keyword.key() + " has unfilled index(es)");
+        }
+    }
+
+    private void checkValueType(IFitsHeader.VALUE valueType) throws ValueTypeException {
+        if (standardKey != null) {
+            checkValueType(key, standardKey.valueType(), valueType);
+        }
+    }
+
+    private static void checkValueType(String key, IFitsHeader.VALUE expect, IFitsHeader.VALUE valueType)
+            throws ValueTypeException {
+        if (expect == null || expect == IFitsHeader.VALUE.ANY || valueCheck == ValueCheck.NONE) {
             return;
         }
 
-        IFitsHeader.VALUE expect = standardKey.valueType();
-        if (expect == IFitsHeader.VALUE.ANY) {
-            return;
-        }
+        if (valueType != expect) {
+            if (expect == IFitsHeader.VALUE.REAL && valueType == IFitsHeader.VALUE.INTEGER) {
+                return;
+            }
 
-        if (t != expect) {
-            ValueTypeException e = new ValueTypeException(key, t.name());
+            ValueTypeException e = new ValueTypeException(key, valueType.name());
 
             if (valueCheck == ValueCheck.LOGGING) {
                 LOG.warning(e.getMessage());
@@ -944,7 +952,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
     }
 
     /**
-     * Sets a new boolean value for this card.
+     * Sets a new boolean value for this cardvalueType
      *
      * @param  update             the new value to se (can be <code>null</code>).
      *
@@ -1468,47 +1476,6 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
         }
     }
 
-    /**
-     * <p>
-     * Checks if the value type is compatible with what's expected for a standard FITS keyword and prints out debugging
-     * information if there is a mismatch.
-     * </p>
-     * <p>
-     * A type mismatch is a programmer's error that we can let pass, but the programmer should probably fix, either
-     * because the IFitsHeader was defined with an incorrect (too restrictive?) type, or because someone is trying to
-     * set a value that does not belong to the keyword... So we just print the stack trace to provide the debugging
-     * information for the developer.
-     * </p>
-     *
-     * @param  key                      The standard or conventional FITS keyword
-     * @param  type                     The type we want to use with that key
-     *
-     * @throws IllegalArgumentException if the keyword does not support the given value type, or if the keyword contains
-     *                                      an unfilled index.
-     *
-     * @since                           1.16
-     */
-    private static boolean checkType(IFitsHeader key, VALUE type) throws IllegalArgumentException {
-        if (key.key().contains("n")) {
-            throw new IllegalArgumentException("Unfilled index(es) in keyword " + key.key());
-        }
-
-        if (key.valueType() == type || key.valueType() == VALUE.ANY) {
-            return true;
-        }
-        if (key.valueType() == VALUE.COMPLEX && (type == VALUE.REAL || type == VALUE.INTEGER)) {
-            return true;
-        }
-        if (key.valueType() == VALUE.REAL && type == VALUE.INTEGER) {
-            return true;
-        }
-
-        LOG.log(Level.WARNING, "[" + key + "] with unexpected value type.",
-                new IllegalArgumentException("Expected " + type + ", got " + key.valueType()));
-
-        return false;
-    }
-
     final IFitsHeader getStandardKey() {
         return standardKey;
     }
@@ -1530,7 +1497,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @since                           1.16
      */
     public static HeaderCard create(IFitsHeader key, Boolean value) throws IllegalArgumentException {
-        checkType(key, VALUE.LOGICAL);
+        checkKeyword(key);
 
         try {
             HeaderCard hc = new HeaderCard(key.key(), (Boolean) null, key.comment());
@@ -1567,11 +1534,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @since                           1.16
      */
     public static HeaderCard create(IFitsHeader key, Number value) throws IllegalArgumentException {
-        if (value instanceof Float || value instanceof Double || value instanceof BigDecimal) {
-            checkType(key, VALUE.REAL);
-        } else {
-            checkType(key, VALUE.INTEGER);
-        }
+        checkKeyword(key);
 
         try {
             HeaderCard hc = new HeaderCard(key.key(), (Number) null, key.comment());
@@ -1599,7 +1562,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @since                           1.16
      */
     public static HeaderCard create(IFitsHeader key, ComplexValue value) throws IllegalArgumentException {
-        checkType(key, VALUE.COMPLEX);
+        checkKeyword(key);
 
         try {
             HeaderCard hc = new HeaderCard(key.key(), (ComplexValue) null, key.comment());
@@ -1628,7 +1591,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      *                                      key was ill-defined.
      */
     public static HeaderCard create(IFitsHeader key, String value) throws IllegalArgumentException {
-        checkType(key, VALUE.STRING);
+        checkKeyword(key);
         validateChars(value);
 
         try {

--- a/src/main/java/nom/tam/fits/header/Compression.java
+++ b/src/main/java/nom/tam/fits/header/Compression.java
@@ -41,14 +41,14 @@ public enum Compression implements IFitsHeader {
      * indicate that the FITS binary table extension contains a compressed BINTABLE, and that logically this extension
      * should be interpreted as a tile-compressed binary table.
      */
-    ZTABLE(HDU.ANY, VALUE.LOGICAL, ""),
+    ZTABLE(VALUE.LOGICAL, ""),
 
     /**
      * (required keyword) This keyword must have the logical value T. It indicates that the FITS binary table extension
      * contains a compressed image and that logically this extension should be interpreted as an image and not as a
      * table.
      */
-    ZIMAGE(HDU.ANY, VALUE.LOGICAL, ""),
+    ZIMAGE(VALUE.LOGICAL, ""),
 
     /**
      * (required keyword) The value field of this keyword shall contain a character string giving the name of the
@@ -56,25 +56,25 @@ public enum Compression implements IFitsHeader {
      * HCOMPRESS 1 are reserved, and the corresponding algorithms are described in a later section of this document .
      * The value RICE ONE is also reserved as an alias for RICE 1 .
      */
-    ZCMPTYPE(HDU.ANY, VALUE.STRING, ""),
+    ZCMPTYPE(VALUE.STRING, ""),
 
     /**
      * (required keyword) The value field of this keyword shall contain an integer that gives the value of the BITPIX
      * keyword in the uncompressed FITS image. 1
      */
-    ZBITPIX(HDU.ANY, VALUE.INTEGER, "", Standard.BITPIX),
+    ZBITPIX(VALUE.INTEGER, "", Standard.BITPIX),
 
     /**
      * (required keyword) The value field of this keyword shall contain an integer that gives the value of the NAXIS
      * keyword in the uncompressed FITS image.
      */
-    ZNAXIS(HDU.ANY, VALUE.INTEGER, "", Standard.NAXIS),
+    ZNAXIS(VALUE.INTEGER, "", Standard.NAXIS),
 
     /**
      * (required keywords) The value field of these keywords shall contain a positive integer that gives the value of
      * the NAXISn keywords in the uncompressed FITS image.
      */
-    ZNAXISn(HDU.ANY, VALUE.INTEGER, "", Standard.NAXISn),
+    ZNAXISn(VALUE.INTEGER, "", Standard.NAXISn),
     /**
      * (optional keywords) The value of these indexed keywords (where n ranges from 1 to ZNAXIS ) shall contain a
      * positive integer representing the number o f pixels along axis n of the compression tiles. Each tile of pixels is
@@ -87,7 +87,7 @@ public enum Compression implements IFitsHeader {
      * first pixel in the image appears in the first row of the table, and the tile containing the last pixel in the
      * image appears in the last row of the binary table.
      */
-    ZTILEn(HDU.ANY, VALUE.INTEGER, ""),
+    ZTILEn(VALUE.INTEGER, ""),
 
     /**
      * (optional keywords) These pairs of optional array keywords (where n is an integer index number starting with 1)
@@ -96,7 +96,7 @@ public enum Compression implements IFitsHeader {
      * parameters may be significant, and may be defined as part of the description of the specific decompression
      * algorithm.
      */
-    ZNAMEn(HDU.ANY, VALUE.STRING, ""),
+    ZNAMEn(VALUE.STRING, ""),
     /**
      * (optional keywords) These pairs of optional array keywords (where n is an integer index number starting with 1)
      * supply the name and value, respectively, of any algorithm-specific parameters that are needed to compress o r
@@ -104,13 +104,13 @@ public enum Compression implements IFitsHeader {
      * parameters may be significant, and may be defined as part of the description of the specific decompression
      * algorithm.
      */
-    ZVALn(HDU.ANY, VALUE.ANY, ""),
+    ZVALn(VALUE.ANY, ""),
     /**
      * (optional keyword) Used to record the name of the image compression algorithm that was used to compress the
      * optional null pixel data mask. See the “Preserving undefined pixels with lossy compression” section for more
      * details.
      */
-    ZMASKCMP(HDU.ANY, VALUE.STRING, ""),
+    ZMASKCMP(VALUE.STRING, ""),
 
     /**
      * The following optional keyword is defined to store a verbatim copy of the the value and comment field of the
@@ -118,7 +118,7 @@ public enum Compression implements IFitsHeader {
      * identical copy of the original FITS file when the image is uncompressed.preserves the original SIMPLE keyword.may
      * only be used if the original uncompressed image was contained in the primary array of the FITS file.
      */
-    ZSIMPLE(HDU.PRIMARY, VALUE.LOGICAL, "", Standard.SIMPLE),
+    ZSIMPLE(VALUE.LOGICAL, "", Standard.SIMPLE),
 
     /**
      * The following optional keyword is defined to store a verbatim copy of the the value and comment field of the
@@ -127,7 +127,7 @@ public enum Compression implements IFitsHeader {
      * keyword.may only be used if the original uncompressed image was contained in in IMAGE extension.
      */
 
-    ZTENSION(HDU.ANY, VALUE.STRING, "", Standard.XTENSION),
+    ZTENSION(VALUE.STRING, "", Standard.XTENSION),
 
     /**
      * The following optional keyword is defined to store a verbatim copy of the the value and comment field of the
@@ -135,7 +135,7 @@ public enum Compression implements IFitsHeader {
      * identical copy of the original FITS file when the image is uncompressed.preserves the original EXTEND keyword.may
      * only be used if the original uncompressed image was contained in the primary array of the FITS file.
      */
-    ZEXTEND(HDU.PRIMARY, VALUE.LOGICAL, "", Standard.EXTEND),
+    ZEXTEND(VALUE.LOGICAL, "", Standard.EXTEND),
 
     /**
      * The following optional keyword is defined to store a verbatim copy of the the value and comment field of the
@@ -144,7 +144,7 @@ public enum Compression implements IFitsHeader {
      * keyword.may only be used if the original uncompressed image was contained in the primary array of the FITS file,
      */
     @Deprecated
-    ZBLOCKED(HDU.PRIMARY, VALUE.LOGICAL, "", Standard.BLOCKED),
+    ZBLOCKED(VALUE.LOGICAL, "", Standard.BLOCKED),
 
     /**
      * The following optional keyword is defined to store a verbatim copy of the the value and comment field of the
@@ -152,7 +152,7 @@ public enum Compression implements IFitsHeader {
      * identical copy o f the original FITS file when the image is uncompressed.preserves the original PCOUNT
      * keyword.may only be used if the original uncompressed image was contained in in IMAGE extension.
      */
-    ZPCOUNT(HDU.EXTENSION, VALUE.INTEGER, "", Standard.PCOUNT),
+    ZPCOUNT(VALUE.INTEGER, "", Standard.PCOUNT),
 
     /**
      * The following optional keyword is defined to store a verbatim copy of the the value and comment field of the
@@ -160,34 +160,34 @@ public enum Compression implements IFitsHeader {
      * identical copy o f the original FITS file when the image is uncompressed.preserves the original GCOUNT
      * keyword.may only be used if the original uncompressed image was contained in in IMAGE extension.
      */
-    ZGCOUNT(HDU.EXTENSION, VALUE.INTEGER, "", Standard.GCOUNT),
+    ZGCOUNT(VALUE.INTEGER, "", Standard.GCOUNT),
 
     /**
      * The following optional keyword is defined to store a verbatim copy of the the value and comment field of the
      * corresponding keyword in the original uncompressed FITS image. These keywords can be used to reconstruct an
      * identical copy o f the original FITS file when the image is uncompressed.preserves the original CHECKSUM keyword.
      */
-    ZHECKSUM(HDU.ANY, VALUE.STRING, "", Checksum.CHECKSUM),
+    ZHECKSUM(VALUE.STRING, "", Checksum.CHECKSUM),
 
     /**
      * The following optional keyword is defined to store a verbatim copy of the the value and comment field of the
      * corresponding keyword in the original uncompressed FITS image. These keywords can be used to reconstruct an
      * identical copy o f the original FITS file when the image is uncompressed.preserves the original DATASUM
      */
-    ZDATASUM(HDU.ANY, VALUE.STRING, "", Checksum.DATASUM),
+    ZDATASUM(VALUE.STRING, "", Checksum.DATASUM),
 
     /**
      * (optional keyword) This keyword records the name of the algorithm that was used to quantize floating-point image
      * pixels into integer values which are then passed to the compression algorithm.
      */
-    ZQUANTIZ(HDU.ANY, VALUE.STRING, ""),
+    ZQUANTIZ(VALUE.STRING, ""),
 
     /**
      * (optional keyword) The value field of this keyword shall contain an integer that gives the seed value for the
      * random dithering pattern that was used when quantizing the floating-point pixel values. The value may range from
      * 1 to 100.00, inclusive.
      */
-    ZDITHER0(HDU.ANY, VALUE.INTEGER, ""),
+    ZDITHER0(VALUE.INTEGER, ""),
 
     /**
      * When using the quantization method to compress floating-point images, this header is used to store the integer
@@ -195,7 +195,7 @@ public enum Compression implements IFitsHeader {
      * value (Not a Number) in the uncompressed floating-point image. The recommended value for ZBLANK is -2147483648
      * (the largest negative 32-bit integer).
      */
-    ZBLANK(HDU.ANY, VALUE.INTEGER, ""),
+    ZBLANK(VALUE.INTEGER, ""),
 
     /**
      * The value field of this keyword shall contain an integer representing the number of rows of data from the
@@ -204,20 +204,20 @@ public enum Compression implements IFitsHeader {
      * the compressed table will only contains a single row, and the ZTILELEN and ZNAXIS2 keywords will have the same
      * value.
      */
-    ZTILELEN(HDU.ANY, VALUE.INTEGER, ""),
+    ZTILELEN(VALUE.INTEGER, ""),
 
     /**
      * The value field of these keywords shall contain the character string values of the corresponding TFORMn keywords
      * that defines the data type of column n in the original uncompressed FITS table.
      */
-    ZFORMn(HDU.ANY, VALUE.STRING, "", Standard.TFORMn),
+    ZFORMn(VALUE.STRING, "", Standard.TFORMn),
 
     /**
      * The value field of these keywords shall contain a charac- ter string giving the mnemonic name of the algorithm
      * that was used to compress column n of the table. The current allowed values are GZIP_1, GZIP_2, and RICE_1, and
      * the corresponding algorithms
      */
-    ZCTYPn(HDU.ANY, VALUE.STRING, "");
+    ZCTYPn(VALUE.STRING, "");
 
     /**
      * This is the simplest option in which no dithering is performed. The floating-point pixels are simply quantized
@@ -410,12 +410,12 @@ public enum Compression implements IFitsHeader {
 
     private final IFitsHeader uncompressedKey;
 
-    Compression(HDU hdu, VALUE valueType, String comment) {
-        this(hdu, valueType, comment, null);
+    Compression(VALUE valueType, String comment) {
+        this(valueType, comment, null);
     }
 
-    Compression(HDU hdu, VALUE valueType, String comment, IFitsHeader uncompressedKey) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.HEASARC, hdu, valueType, comment);
+    Compression(VALUE valueType, String comment, IFitsHeader uncompressedKey) {
+        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.INTEGRAL, HDU.BINTABLE, valueType, comment);
         this.uncompressedKey = uncompressedKey;
     }
 

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -92,22 +92,20 @@ public enum DataDescription implements IFitsHeader {
     HDUDOC(SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "reference to document describing the data format"),
 
     /**
-     * This keyword is synonymous to the standard EXTLEVEL keyword except that it may also be used in the primary key.
-     * It is recommended that the HDULEVEL and EXTLEVEL keywords should not both be given in the same HDU key, but if
-     * they are, then the HDULEVEL keyword will have precedence.
+     * This keyword is synonymous to the standard EXTLEVEL. It is recommended that the HDULEVEL and EXTLEVEL keywords
+     * should not both be given in the same HDU key, but if they are, then the HDULEVEL keyword will have precedence.
      */
     HDULEVEL(SOURCE.UNKNOWN, HDU.ANY, VALUE.INTEGER, "hierarchical level of the HDU"),
     /**
-     * This keyword is synonymous to the standard EXTNAME keyword except that it may also be used in the primary key. It
-     * is recommended that the HDUNAME and EXTNAME keywords should not both be given in the same HDU key, but if they
-     * are, then the HDUNAME keyword will have precedence.
+     * This keyword is synonymous to the standard EXTNAME keyword except. It is recommended that the HDUNAME and EXTNAME
+     * keywords should not both be given in the same HDU key, but if they are, then the HDUNAME keyword will have
+     * precedence.
      */
     HDUNAME(SOURCE.UNKNOWN, HDU.ANY, VALUE.STRING, "descriptive name of the HDU"),
 
     /**
-     * This keyword is synonymous to the standard EXTVER keyword except that it may also be used in the primary key. It
-     * is recommended that the HDUVER and EXTVER keywords should not both be given in the same HDU key, but if they are,
-     * then the HDUVER keyword will have precedence.
+     * This keyword is synonymous to the standard EXTVER keyword. It is recommended that the HDUVER and EXTVER keywords
+     * should not both be given in the same HDU key, but if they are, then the HDUVER keyword will have precedence.
      */
     HDUVER(SOURCE.UNKNOWN, HDU.ANY, VALUE.INTEGER, "version number of the HDU"),
     /**

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -51,7 +51,7 @@ public enum DataDescription implements IFitsHeader {
      * CREATOR keyword in that it give the name and version of the overall processing system and not just the name and
      * version of a single program.
      */
-    CONFIGUR(SOURCE.INTEGRAL, HDU.ANY, VALUE.STRING, "software configuration used to process the data"),
+    CONFIGUR(SOURCE.UNKNOWN, HDU.ANY, VALUE.STRING, "software configuration used to process the data"),
     /**
      * The value field shall contain a character string giving the name, and optionally, the version of the program that
      * originally created the current FITS HDU. This keyword is synonymous with the PROGRAM keyword. Example: 'TASKNAME

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -45,7 +45,25 @@ public interface IFitsHeader {
 
     /** An enumeration of HDU types in which a header keyword may be used. */
     enum HDU {
-        ANY, ASCII_TABLE, BINTABLE, EXTENSION, GROUPS, IMAGE, PRIMARY, PRIMARY_EXTENSION, TABLE
+        /** keyword may be used in any HDU */
+        ANY,
+        /** image and/or random groups keywords */
+        IMAGE,
+        /** keyword for random groups only */
+        GROUPS,
+        /** Generic table keyword, can be used both in ASCII and binary tables */
+        TABLE,
+        /** keyword for ASCII tables only */
+        ASCII_TABLE,
+        /** keyword for binary tables */
+        BINTABLE,
+        /** keyword must appear in the primary HDU only */
+        PRIMARY,
+        /** keyword must appear in extension HDUs only */
+        EXTENSION,
+        /** @deprecated Use {@link #ANY} instead */
+        PRIMARY_EXTENSION;
+
     }
 
     /** Documentation sources for the various known conventions. */
@@ -129,7 +147,26 @@ public interface IFitsHeader {
 
     /** Values types to which implementing keywords can be restricted to. */
     enum VALUE {
-        INTEGER, LOGICAL, NONE, REAL, COMPLEX, STRING, ANY
+        /** The keyword takes no value (i.e. END or comment-style keywords */
+        NONE,
+
+        /** keyword expects a logical 'T' or 'F' value */
+        LOGICAL,
+
+        /** keyword expects a String value */
+        STRING,
+
+        /** keyword expects an integer type value */
+        INTEGER,
+
+        /** keyword expects a floating-point value (integers allowed). */
+        REAL,
+
+        /** keyword expects a complex value */
+        COMPLEX,
+
+        /** The keyword may be used with any value type */
+        ANY
     }
 
     /**

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -90,11 +90,11 @@ public interface IFitsHeader {
          */
         HEASARC("http://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/ofwg_recomm/r13.html"),
         /**
-         * integral.
+         * The keyword is integral to the workings of the library. Users should not attempt set set or modify.
          */
         INTEGRAL(null),
         /**
-         * Mandatory keywords defined by the fits standard.
+         * Mandatory keywords defined by the FITS standard.
          */
         MANDATORY("http://heasarc.gsfc.nasa.gov/docs/fcg/standard_dict.html"),
         /**

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -254,14 +254,14 @@ public enum Standard implements IFitsHeader {
      * treated as if the value were 1. This keyword is used to describe an extension and should not appear in the
      * primary key.RANGE: [1:] DEFAULT: 1
      */
-    EXTLEVEL(SOURCE.RESERVED, HDU.EXTENSION, VALUE.INTEGER, "hierarchical level of the extension"),
+    EXTLEVEL(SOURCE.RESERVED, HDU.ANY, VALUE.INTEGER, "hierarchical level of the extension"),
 
     /**
      * The value field shall contain a character string, to be used to distinguish among different extensions of the
      * same type, i.e., with the same value of XTENSION, in a FITS file. This keyword is used to describe an extension
-     * and should not appear in the primary key.
+     * and but may appear in the primary header also.
      */
-    EXTNAME(SOURCE.RESERVED, HDU.EXTENSION, VALUE.STRING, "name of the extension"),
+    EXTNAME(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "name of the extension"),
 
     /**
      * The value field shall contain an integer, to be used to distinguish among different extensions in a FITS file
@@ -270,14 +270,14 @@ public enum Standard implements IFitsHeader {
      * EXTVER keyword is absent, the file should be treated as if the value were 1. This keyword is used to describe an
      * extension and should not appear in the primary key.RANGE: [1:] DEFAULT: 1
      */
-    EXTVER(SOURCE.RESERVED, HDU.EXTENSION, VALUE.INTEGER, "version of the extension"),
+    EXTVER(SOURCE.RESERVED, HDU.ANY, VALUE.INTEGER, "version of the extension"),
 
     /**
      * The value field shall contain an integer that shall be used in any way appropriate to define the data structure,
      * consistent with Eq. 5.2 in the FITS Standard. This keyword originated for use in FITS Random Groups where it
      * specifies the number of random groups present. In most other cases this keyword will have the value 1.
      */
-    GCOUNT(SOURCE.MANDATORY, HDU.EXTENSION, VALUE.INTEGER, "group count", //
+    GCOUNT(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "group count", //
             replaceable("randomgroupsdata:gcount", RandomGroupsData.class), //
             replaceable("asciitable:gcount", AsciiTable.class), //
             replaceable("basichdu:gcount", Object.class, "Required value"), //
@@ -355,7 +355,7 @@ public enum Standard implements IFitsHeader {
      * represented the number of parameters preceding each group. It has since been used in 'BINTABLE' extensions to
      * represent the size of the data heap following the main data table. In most other cases its value will be zero.
      */
-    PCOUNT(SOURCE.MANDATORY, HDU.EXTENSION, VALUE.INTEGER, "parameter count", //
+    PCOUNT(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "parameter count", //
             replaceable("asciitable:pcount", AsciiTable.class, "No group data"), //
             replaceable("basichdu:pcount", Object.class, "Required value"), //
             replaceable("binarytablehdu:pcount", BinaryTable.class, "Includes heap"), //

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -239,7 +239,7 @@ public enum Standard implements IFitsHeader {
      * NAXIS card image. The presence of this keyword with the value T in the primary key does not require that
      * extensions be present.
      */
-    EXTEND(SOURCE.RESERVED, HDU.PRIMARY, VALUE.LOGICAL, "may the FITS file contain extensions?", //
+    EXTEND(SOURCE.INTEGRAL, HDU.PRIMARY, VALUE.LOGICAL, "may the FITS file contain extensions?", //
             replaceable("basichdu:extend", BasicHDU.class, "Allow extensions"), //
             replaceable("header:extend", Object.class, "Extensions are permitted"), //
             replaceable("imagedata:extend", ImageData.class, "Extension permitted"), //
@@ -374,7 +374,7 @@ public enum Standard implements IFitsHeader {
      * coefficient of the linear term, the scaling factor between true values and group parameter values at zero offset.
      * The default value for this keyword is 1.0.
      */
-    PSCALn(SOURCE.RESERVED, HDU.GROUPS, VALUE.REAL, "parameter scaling factor"),
+    PSCALn(SOURCE.INTEGRAL, HDU.GROUPS, VALUE.REAL, "parameter scaling factor"),
 
     /**
      * This keyword is reserved for use within the FITS Random Groups structure. The value field shall contain a
@@ -384,7 +384,7 @@ public enum Standard implements IFitsHeader {
      * parameter may have more precision than the accompanying data array elements; for example, by summing two 16-bit
      * values with the first scaled relative to the other such that the sum forms a number of up to 32-bit precision.
      */
-    PTYPEn(SOURCE.RESERVED, HDU.GROUPS, VALUE.STRING, "name of random groups parameter"),
+    PTYPEn(SOURCE.INTEGRAL, HDU.GROUPS, VALUE.STRING, "name of random groups parameter"),
 
     /**
      * This keyword is reserved for use within the FITS Random Groups structure. This keyword shall be used, along with
@@ -393,7 +393,7 @@ public enum Standard implements IFitsHeader {
      * the true value corresponding to a group parameter value of zero. The default value for this keyword is 0.0. The
      * transformation equation is as follows: physical_value = PZEROn + PSCALn * group_parameter_value.DEFAULT: 0.0
      */
-    PZEROn(SOURCE.RESERVED, HDU.GROUPS, VALUE.REAL, "parameter scaling zero point"),
+    PZEROn(SOURCE.INTEGRAL, HDU.GROUPS, VALUE.REAL, "parameter scaling zero point"),
 
     /**
      * Coordinate reference frame of major/minor axes.If absent the default value is 'FK5'. This version of the keyword
@@ -506,7 +506,7 @@ public enum Standard implements IFitsHeader {
      * product of the values of NAXIS1 and NAXIS2. This keyword shall not be used if the value of PCOUNT is zero. A
      * proposed application of this keyword is presented in Appendix B.1 of the FITS Standard.
      */
-    THEAP(SOURCE.RESERVED, HDU.BINTABLE, VALUE.INTEGER, "offset to starting data heap address", //
+    THEAP(SOURCE.INTEGRAL, HDU.BINTABLE, VALUE.INTEGER, "offset to starting data heap address", //
             replaceable("binarytablehdu:theap", BinaryTable.class) //
     ),
 
@@ -517,7 +517,7 @@ public enum Standard implements IFitsHeader {
      * represents an undefined value for field n of data type B, I, or J. The keyword may not be used in 'BINTABLE'
      * extensions if field n is of any other data type.
      */
-    TNULLn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "value used to indicate undefined table element"),
+    TNULLn(SOURCE.INTEGRAL, HDU.TABLE, VALUE.STRING, "value used to indicate undefined table element"),
 
     /**
      * This indexed keyword shall be used, along with the TZEROn keyword, when the quantity in field n does not

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -47,7 +47,6 @@ import nom.tam.fits.header.extra.STScIExt;
 public enum Synonyms {
 
     /** EQUINOX is now preferred over the old EPOCH */
-
     EQUINOX(Standard.EQUINOX, Standard.EPOCH),
 
     /** TIMESYS appears in multiple conventions */
@@ -114,6 +113,21 @@ public enum Synonyms {
      * @since 1.19
      */
     nVn_na(WCS.nVn_na, WCS.nPVn_na),
+
+    /**
+     * EXTNAME and HDUNAME are synonymous, but EXTNAME is part of the standard since 1.19
+     */
+    EXTNAME(Standard.EXTNAME, DataDescription.HDUNAME),
+
+    /**
+     * EXTVER and HDUVER are synonymous, but EXTVER is part of the standard since 1.19
+     */
+    EXTVER(Standard.EXTVER, DataDescription.HDUVER),
+
+    /**
+     * EXTLEVEL and HDULEVEL are synonymous, but EXTLEVEL is part of the standard since 1.19
+     */
+    EXTLEVEL(Standard.EXTLEVEL, DataDescription.HDULEVEL),
 
     /** DARKTIME appears in multiple conventions */
     DARKTIME(NOAOExt.DARKTIME, SBFitsExt.DARKTIME);

--- a/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
@@ -942,7 +942,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    AMPINTEG(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Amplifier integration/sample time"),
+    AMPINTEG(HDU.ANY, VALUE.REAL, "Amplifier integration/sample time"),
     /**
      * Times for the amplifier sensor measurements given as modified Julian dates. The MJDHDR keyword may be used for
      * the time at which the image header is created or the MJD-OBS keyword may be used for the time of observation.
@@ -956,7 +956,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPMJD(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPMJD(HDU.ANY, VALUE.REAL, ""),
     /**
      * Times for the amplifier sensor measurements given as modified Julian dates. The MJDHDR keyword may be used for
      * the time at which the image header is created or the MJD-OBS keyword may be used for the time of observation.
@@ -970,7 +970,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPMJDn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPMJDn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Amplifier name.
      * <p>
@@ -990,7 +990,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPPAN(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPPAN(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD amplifier position angle measurements in appropriate units.
      * <p>
@@ -1000,7 +1000,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPPANn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPPANn(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD amplifier linear position sensor measurements in appropriate units.
      * <p>
@@ -1010,7 +1010,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPPOS(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPPOS(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD amplifier linear position sensor measurements in appropriate units.
      * <p>
@@ -1020,7 +1020,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPPOSn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPPOSn(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD amplifier pressure sensor measurements in appropriate units.
      * <p>
@@ -1033,7 +1033,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPPRE(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPPRE(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD amplifier pressure sensor measurements in appropriate units.
      * <p>
@@ -1046,7 +1046,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPPREn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPPREn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Amplifier unbinned pixel read time.
      * <p>
@@ -1059,7 +1059,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none none
      * </p>
      */
-    AMPREAD(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Unbinned pixel read time"),
+    AMPREAD(HDU.ANY, VALUE.REAL, "Unbinned pixel read time"),
     /**
      * CCD amplifier sampling method used. This may also include any integration times.
      * <p>
@@ -1069,7 +1069,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    AMPSAMPL(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Amplifier sampling method"),
+    AMPSAMPL(HDU.ANY, VALUE.STRING, "Amplifier sampling method"),
     /**
      * Mapping of the CCD section to amplifier coordinates.
      * <p>
@@ -1103,7 +1103,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPTEM(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPTEM(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD amplifier temperature sensor measurements in degrees Celsius.
      * <p>
@@ -1116,7 +1116,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPTEMn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPTEMn(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD amplifier voltage sensor measurements in volts. }
      * <p>
@@ -1129,7 +1129,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPVOL(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPVOL(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD amplifier voltage sensor measurements in volts. }
      * <p>
@@ -1142,7 +1142,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    AMPVOLn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    AMPVOLn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Aperture position angle unit.
      * <p>
@@ -1532,7 +1532,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    ARCONWD(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Date CCD waveforms last compiled"),
+    ARCONWD(HDU.ANY, VALUE.STRING, "Date CCD waveforms last compiled"),
     /**
      * Arcon waveform options enabled.
      * <p>
@@ -1542,7 +1542,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    ARCONWM(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Arcon waveform options enabled"),
+    ARCONWM(HDU.ANY, VALUE.STRING, "Arcon waveform options enabled"),
     /**
      * Aperture coordinate system type for the aperture(s).
      * <p>
@@ -1607,7 +1607,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    BPM(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Bad pixels"),
+    BPM(HDU.ANY, VALUE.STRING, "Bad pixels"),
     /**
      * Camera configuration.
      * <p>
@@ -1833,7 +1833,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDDEC(HDU.PRIMARY_EXTENSION, VALUE.STRING, "CCD declination"),
+    CCDDEC(HDU.ANY, VALUE.STRING, "CCD declination"),
     /**
      * Declination unit.
      * <p>
@@ -1843,7 +1843,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDDECU(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Declination unit"),
+    CCDDECU(HDU.ANY, VALUE.STRING, "Declination unit"),
     /**
      * Epoch of the CCD center coordinates.
      * <p>
@@ -1856,7 +1856,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDEPOCH(HDU.PRIMARY_EXTENSION, VALUE.REAL, "CCD coordinate epoch"),
+    CCDEPOCH(HDU.ANY, VALUE.REAL, "CCD coordinate epoch"),
     /**
      * CCD coordinate system equinox. A value before 1984 is Besselian otherwise it is Julian.
      * <p>
@@ -1869,7 +1869,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDEQUIN(HDU.PRIMARY_EXTENSION, VALUE.REAL, "CCD coordinate equinox"),
+    CCDEQUIN(HDU.ANY, VALUE.REAL, "CCD coordinate equinox"),
     /**
      * CCD hardware version
      * <p>
@@ -1879,7 +1879,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDHWV(HDU.PRIMARY_EXTENSION, VALUE.STRING, "CCD version"),
+    CCDHWV(HDU.ANY, VALUE.STRING, "CCD version"),
     /**
      * Times for the CCD sensor measurements given as modified Julian dates. The MJDHDR keyword may be used for the time
      * at which the image header is created or the MJD-OBS keyword may be used for the time of observation.
@@ -1893,7 +1893,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDMJD(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDMJD(HDU.ANY, VALUE.REAL, ""),
     /**
      * Times for the CCD sensor measurements given as modified Julian dates. The MJDHDR keyword may be used for the time
      * at which the image header is created or the MJD-OBS keyword may be used for the time of observation.
@@ -1907,7 +1907,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDMJDn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDMJDn(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD identification.
      * <p>
@@ -1917,7 +1917,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDNAME(HDU.PRIMARY_EXTENSION, VALUE.STRING, "CCD identification"),
+    CCDNAME(HDU.ANY, VALUE.STRING, "CCD identification"),
     /**
      * Number of amplifiers used to readout the CCD. This keyword may be absent if only one amplifier is used.
      * <p>
@@ -1927,7 +1927,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDNAMPS(HDU.PRIMARY_EXTENSION, VALUE.INTEGER, "Number of amplifiers used"),
+    CCDNAMPS(HDU.ANY, VALUE.INTEGER, "Number of amplifiers used"),
     /**
      * CCD position angle measurements in appropriate units.
      * <p>
@@ -1937,7 +1937,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDPAN(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDPAN(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD position angle measurements in appropriate units.
      * <p>
@@ -1947,7 +1947,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDPANn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDPANn(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD linear position sensor measurements in appropriate units.
      * <p>
@@ -1957,7 +1957,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDPOS(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDPOS(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD linear position sensor measurements in appropriate units.
      * <p>
@@ -1967,7 +1967,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDPOSn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDPOSn(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD pressure sensor measurements in appropriate units.
      * <p>
@@ -1980,7 +1980,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDPRE(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDPRE(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD pressure sensor measurements in appropriate units.
      * <p>
@@ -1993,7 +1993,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDPREn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDPREn(HDU.ANY, VALUE.REAL, ""),
     /**
      * The actual format size of the CCD. This is the same as the CCDSIZE keyword except in the case of drift scanning.
      * <p>
@@ -2003,7 +2003,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDPSIZE(HDU.PRIMARY_EXTENSION, VALUE.STRING, "CCD size"),
+    CCDPSIZE(HDU.ANY, VALUE.STRING, "CCD size"),
     /**
      * Right ascension of the CCD center.
      * <p>
@@ -2016,7 +2016,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDRA(HDU.PRIMARY_EXTENSION, VALUE.STRING, "CCD right ascension"),
+    CCDRA(HDU.ANY, VALUE.STRING, "CCD right ascension"),
     /**
      * CCD coordinate system type.
      * <p>
@@ -2026,7 +2026,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDRADEC(HDU.PRIMARY_EXTENSION, VALUE.STRING, "CCD coordinate system"),
+    CCDRADEC(HDU.ANY, VALUE.STRING, "CCD coordinate system"),
     /**
      * Right ascension unit.
      * <p>
@@ -2036,7 +2036,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDRAU(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Right ascension unit"),
+    CCDRAU(HDU.ANY, VALUE.STRING, "Right ascension unit"),
     /**
      * The unbinned section of the logical CCD pixel raster covered by the amplifier readout in section notation. The
      * section must map directly to the specified data section through the binning and CCD to image coordiante
@@ -2061,7 +2061,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDSIZE(HDU.PRIMARY_EXTENSION, VALUE.STRING, "CCD size"),
+    CCDSIZE(HDU.ANY, VALUE.STRING, "CCD size"),
     /**
      * CCD on-chip summing given as two or four integer numbers. These define the summing of CCD pixels in the amplifier
      * readout order. The first two numbers give the number of pixels summed in the serial and parallel directions
@@ -2087,7 +2087,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CCDSWV(HDU.PRIMARY_EXTENSION, VALUE.STRING, "CCD software version"),
+    CCDSWV(HDU.ANY, VALUE.STRING, "CCD software version"),
     /**
      * CCD temperature sensor measurements in degrees Celsius.
      * <p>
@@ -2100,7 +2100,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDTEM(HDU.PRIMARY_EXTENSION, VALUE.REAL, "CCD temperature"),
+    CCDTEM(HDU.ANY, VALUE.REAL, "CCD temperature"),
     /**
      * CCD temperature sensor measurements in degrees Celsius.
      * <p>
@@ -2113,7 +2113,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDTEMn(HDU.PRIMARY_EXTENSION, VALUE.REAL, "CCD temperature"),
+    CCDTEMn(HDU.ANY, VALUE.REAL, "CCD temperature"),
     /**
      * CCD voltage sensor measurements in volts.
      * <p>
@@ -2126,7 +2126,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDVOL(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDVOL(HDU.ANY, VALUE.REAL, ""),
     /**
      * CCD voltage sensor measurements in volts.
      * <p>
@@ -2139,7 +2139,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    CCDVOLn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    CCDVOLn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Spectrum coordinate matrix. World coordinate axis 1 is defined to be the dispersion and the other axes are
      * spatial. The matrix implies a dispersion axis in the image coordinates.
@@ -2589,7 +2589,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CONHWV(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Controller hardware version"),
+    CONHWV(HDU.ANY, VALUE.STRING, "Controller hardware version"),
     /**
      * Controller status.
      * <p>
@@ -2599,7 +2599,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CONSTAT(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Controller status"),
+    CONSTAT(HDU.ANY, VALUE.STRING, "Controller status"),
     /**
      * Controller software version.
      * <p>
@@ -2609,7 +2609,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CONSWV(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Controller software version"),
+    CONSWV(HDU.ANY, VALUE.STRING, "Controller software version"),
     /**
      * Detector controller name.
      * <p>
@@ -2619,7 +2619,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CONTROLR(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Detector controller"),
+    CONTROLR(HDU.ANY, VALUE.STRING, "Detector controller"),
     /**
      * Correctors in the optical path.
      * <p>
@@ -2659,7 +2659,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CROSUNIT(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Declination unit"),
+    CROSUNIT(HDU.ANY, VALUE.STRING, "Declination unit"),
     /**
      * Default cross dispersion coordinate value.
      * <p>
@@ -2672,7 +2672,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    CROSVAL(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Cross dispersion coordinate"),
+    CROSVAL(HDU.ANY, VALUE.REAL, "Cross dispersion coordinate"),
     /**
      * Reference spectrum pixel coordinate. Generally this should be the at the center of the spectrum. In raw data the
      * spectrum position(s) may be predicted apart from an offset that will be determined during data reduction.
@@ -2906,7 +2906,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DARKTIME(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Dark time"),
+    DARKTIME(HDU.ANY, VALUE.REAL, "Dark time"),
     /**
      * Mapping of the CCD section to image coordinates.
      * <p>
@@ -2926,7 +2926,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DATEEND(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Date at end of exposure"),
+    DATEEND(HDU.ANY, VALUE.STRING, "Date at end of exposure"),
     /**
      * Date header creation. The format follows the FITS 'date' standard.
      * <p>
@@ -2936,7 +2936,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DATEHDR(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Date of header creation"),
+    DATEHDR(HDU.ANY, VALUE.STRING, "Date of header creation"),
     /**
      * Default date for the observation. This keyword is generally not used and is DATE-OBS keyword for the start of the
      * exposure on the detector is used.
@@ -2947,7 +2947,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DATEOBS(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Date of observation"),
+    DATEOBS(HDU.ANY, VALUE.STRING, "Date of observation"),
     /**
      * Projected position angle of the positive declination axis on the detector. The position angle is measured
      * clockwise from the image y axis.
@@ -2971,7 +2971,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DECUNIT(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Declination unit"),
+    DECUNIT(HDU.ANY, VALUE.STRING, "Declination unit"),
     /**
      * Detector configuration.
      * <p>
@@ -3157,7 +3157,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DETRA(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Detector right ascension"),
+    DETRA(HDU.ANY, VALUE.STRING, "Detector right ascension"),
     /**
      * Detector coordinate system type.
      * <p>
@@ -3177,7 +3177,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DETRAU(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Right ascension unit"),
+    DETRAU(HDU.ANY, VALUE.STRING, "Right ascension unit"),
     /**
      * Mapping of the CCD section to detector coordinates.
      * <p>
@@ -3290,7 +3290,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DEWHWV(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Dewar hardware"),
+    DEWHWV(HDU.ANY, VALUE.STRING, "Dewar hardware"),
     /**
      * Times for the dewar sensor measurements given as modified Julian dates. The MJDHDR keyword may be used for the
      * time at which the image header is created or the MJD-OBS keyword may be used for the time of observation.
@@ -3304,7 +3304,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWMJD(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWMJD(HDU.ANY, VALUE.REAL, ""),
     /**
      * Times for the dewar sensor measurements given as modified Julian dates. The MJDHDR keyword may be used for the
      * time at which the image header is created or the MJD-OBS keyword may be used for the time of observation.
@@ -3318,7 +3318,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWMJDn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWMJDn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Dewar position angle measurements in appropriate units.
      * <p>
@@ -3328,7 +3328,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWPAN(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWPAN(HDU.ANY, VALUE.REAL, ""),
     /**
      * Dewar position angle measurements in appropriate units.
      * <p>
@@ -3338,7 +3338,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWPANn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWPANn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Dewar linear position sensor measurements in appropriate units.
      * <p>
@@ -3348,7 +3348,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWPOS(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWPOS(HDU.ANY, VALUE.REAL, ""),
     /**
      * Dewar linear position sensor measurements in appropriate units.
      * <p>
@@ -3358,7 +3358,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWPOSn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWPOSn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Dewar pressure sensor measurements in appropriate units.
      * <p>
@@ -3371,7 +3371,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWPRE(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWPRE(HDU.ANY, VALUE.REAL, ""),
     /**
      * Dewar pressure sensor measurements in appropriate units.
      * <p>
@@ -3384,7 +3384,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWPREn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWPREn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Dewar status.
      * <p>
@@ -3394,7 +3394,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DEWSTAT(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Dewar status"),
+    DEWSTAT(HDU.ANY, VALUE.STRING, "Dewar status"),
     /**
      * Dewar software version.
      * <p>
@@ -3404,7 +3404,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DEWSWV(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Dewar software version"),
+    DEWSWV(HDU.ANY, VALUE.STRING, "Dewar software version"),
     /**
      * Dewar temperature sensor measurements in degrees Celsius.
      * <p>
@@ -3417,7 +3417,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWTEM(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Dewar temperature"),
+    DEWTEM(HDU.ANY, VALUE.REAL, "Dewar temperature"),
     /**
      * Dewar temperature sensor measurements in degrees Celsius.
      * <p>
@@ -3430,7 +3430,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWTEMn(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Dewar temperature"),
+    DEWTEMn(HDU.ANY, VALUE.REAL, "Dewar temperature"),
     /**
      * Dewar voltage sensor measurements in volts.
      * <p>
@@ -3443,7 +3443,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWVOL(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWVOL(HDU.ANY, VALUE.REAL, ""),
     /**
      * Dewar voltage sensor measurements in volts.
      * <p>
@@ -3456,7 +3456,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-999
      * </p>
      */
-    DEWVOLn(HDU.PRIMARY_EXTENSION, VALUE.REAL, ""),
+    DEWVOLn(HDU.ANY, VALUE.REAL, ""),
     /**
      * Times for the disperser sensor measurements given as modified Julian dates.
      * <p>
@@ -3601,7 +3601,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DISPUNIT(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Dispersion coordinate unit"),
+    DISPUNIT(HDU.ANY, VALUE.STRING, "Dispersion coordinate unit"),
     /**
      * Default dispersion coordinate value.
      * <p>
@@ -3614,7 +3614,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DISPVAL(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Dispersion coordinate"),
+    DISPVAL(HDU.ANY, VALUE.REAL, "Dispersion coordinate"),
     /**
      * Approximate central dispersion coordinate on the detector.
      * <p>
@@ -4276,7 +4276,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    EXPREQ(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Requested exposure time"),
+    EXPREQ(HDU.ANY, VALUE.REAL, "Requested exposure time"),
     /**
      * Fiber identification for the fiber(s). The string consists of a fiber number, an object type number (0=sky,
      * 1=object, etc.), the right ascension and declination, and the object name or title. This can replace OBJNAME,
@@ -5363,7 +5363,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    LST_OBS("LST-OBS", HDU.PRIMARY_EXTENSION, VALUE.STRING, "LST of exposure start"),
+    LST_OBS("LST-OBS", HDU.ANY, VALUE.STRING, "LST of exposure start"),
     /**
      * Local siderial time at the end of the exposure.
      * <p>
@@ -5376,7 +5376,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    LSTEND(HDU.PRIMARY_EXTENSION, VALUE.STRING, "LST at end of exposure"),
+    LSTEND(HDU.ANY, VALUE.STRING, "LST at end of exposure"),
     /**
      * Local siderial time of the header creation.
      * <p>
@@ -5389,7 +5389,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    LSTHDR(HDU.PRIMARY_EXTENSION, VALUE.STRING, "LST of header creation"),
+    LSTHDR(HDU.ANY, VALUE.STRING, "LST of header creation"),
     /**
      * Default local siderial time for the observation. This keyword is generally not used and is LST-OBS keyword for
      * the start of the exposure on the detector is used.
@@ -5403,7 +5403,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    LSTOBS(HDU.PRIMARY_EXTENSION, VALUE.STRING, "LST of observation"),
+    LSTOBS(HDU.ANY, VALUE.STRING, "LST of observation"),
     /**
      * Transformation matrix between CCD and image coordinates. If missing the default is an identify matrix.
      * <p>
@@ -5462,7 +5462,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    MJDHDR(HDU.PRIMARY_EXTENSION, VALUE.REAL, "MJD of header creation"),
+    MJDHDR(HDU.ANY, VALUE.REAL, "MJD of header creation"),
     /**
      * Default modified Julian date for the observation. The fractional part of the date is given to better than a
      * second of time. This keyword is generally not used and is MJD-OBS keyword for the start of the exposure on the
@@ -5477,7 +5477,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    MJDOBS(HDU.PRIMARY_EXTENSION, VALUE.REAL, "MJD of observation"),
+    MJDOBS(HDU.ANY, VALUE.REAL, "MJD of observation"),
     /**
      * The number of amplifiers in the detector. When there is only a single amplifier used it may be absent since the
      * default value is 1.
@@ -5718,7 +5718,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    NSUBEXPS(HDU.PRIMARY_EXTENSION, VALUE.INTEGER, "Number of subexposures"),
+    NSUBEXPS(HDU.ANY, VALUE.INTEGER, "Number of subexposures"),
     /**
      * Declination of the target astronomical object(s).
      * <p>
@@ -5904,7 +5904,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    OBSID(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Observation identification"),
+    OBSID(HDU.ANY, VALUE.STRING, "Observation identification"),
     /**
      * Right ascension of the observation. This may be distinct from the object coordinates and the telescope
      * coordinates. It may be used to indicate the requested observation coordinates.
@@ -5968,7 +5968,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    OBSTYPE(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Observation type"),
+    OBSTYPE(HDU.ANY, VALUE.STRING, "Observation type"),
     /**
      * Declination of the target astronomical object(s).
      * <p>
@@ -6062,7 +6062,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    PHOTCAL(HDU.PRIMARY_EXTENSION, VALUE.LOGICAL, "Data proportional to photons?"),
+    PHOTCAL(HDU.ANY, VALUE.LOGICAL, "Data proportional to photons?"),
     /**
      * Photometric conditions during the observation.
      * <p>
@@ -6082,7 +6082,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-99
      * </p>
      */
-    PIPEHW(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Processing hardware"),
+    PIPEHW(HDU.ANY, VALUE.STRING, "Processing hardware"),
     /**
      * Processing hardware used.
      * <p>
@@ -6092,7 +6092,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-99
      * </p>
      */
-    PIPEHWn(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Processing hardware"),
+    PIPEHWn(HDU.ANY, VALUE.STRING, "Processing hardware"),
     /**
      * Name of processing pipeline applied.
      * <p>
@@ -6102,7 +6102,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    PIPELINE(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Pipeline used"),
+    PIPELINE(HDU.ANY, VALUE.STRING, "Pipeline used"),
     /**
      * Processing software version.
      * <p>
@@ -6112,7 +6112,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-99
      * </p>
      */
-    PIPESW(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Processing software"),
+    PIPESW(HDU.ANY, VALUE.STRING, "Processing software"),
     /**
      * Processing software version.
      * <p>
@@ -6122,7 +6122,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-99
      * </p>
      */
-    PIPESWn(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Processing software"),
+    PIPESWn(HDU.ANY, VALUE.STRING, "Processing software"),
     /**
      * Projected pixel scale along axis n.
      * <p>
@@ -6149,7 +6149,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = 1-9
      * </p>
      */
-    PIXSIZEn(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Pixel size"),
+    PIXSIZEn(HDU.ANY, VALUE.REAL, "Pixel size"),
     /**
      * Pixel limit for region occupied by the spectrum.
      * <p>
@@ -6266,7 +6266,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    PREFLASH(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Preflash time"),
+    PREFLASH(HDU.ANY, VALUE.REAL, "Preflash time"),
     /**
      * Processing log information formatted as FITS comments.
      * <p>
@@ -6276,7 +6276,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = 1-9999
      * </p>
      */
-    PROCnnn(HDU.PRIMARY_EXTENSION, VALUE.STRING, ""),
+    PROCnnn(HDU.ANY, VALUE.STRING, ""),
     /**
      * Processing status.
      * <p>
@@ -6286,7 +6286,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    PROCSTAT(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Processing status"),
+    PROCSTAT(HDU.ANY, VALUE.STRING, "Processing status"),
     /**
      * The unique observatory proposal identification.
      * <p>
@@ -6340,7 +6340,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    RADECEQ(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Default coordinate equinox"),
+    RADECEQ(HDU.ANY, VALUE.REAL, "Default coordinate equinox"),
 
     /**
      * Projected position angle of the positive right ascension axis on the detector. The position angle is measured
@@ -6365,7 +6365,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    RAUNIT(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Right ascension unit"),
+    RAUNIT(HDU.ANY, VALUE.STRING, "Right ascension unit"),
     /**
      * CCD readout noise in rms electrons. This is the most current estimate.
      * <p>
@@ -6391,7 +6391,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none none
      * </p>
      */
-    READTIME(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Unbinned pixel read time"),
+    READTIME(HDU.ANY, VALUE.REAL, "Unbinned pixel read time"),
     /**
      * Archive identification. This may be the same as the observation identification.
      * <p>
@@ -6471,7 +6471,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    SEXP(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Subexposure time"),
+    SEXP(HDU.ANY, VALUE.REAL, "Subexposure time"),
     /**
      * Exposure time of the nth subexposure. If all subexposures are the same length then only the first keyword, SEXP,
      * is needed. For charge shuffling the subexposure time is the total time for each charge shuffled exposure. There
@@ -6487,7 +6487,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    SEXPnnn(HDU.PRIMARY_EXTENSION, VALUE.REAL, "Subexposure time"),
+    SEXPnnn(HDU.ANY, VALUE.REAL, "Subexposure time"),
     /**
      * Time for the shutter to close fully.
      * <p>
@@ -6594,7 +6594,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    SUT(HDU.PRIMARY_EXTENSION, VALUE.STRING, "UTC of subexposure start"),
+    SUT(HDU.ANY, VALUE.STRING, "UTC of subexposure start"),
     /**
      * UTC of the start of each subexposure.
      * <p>
@@ -6607,7 +6607,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    SUTn(HDU.PRIMARY_EXTENSION, VALUE.STRING, "UTC of subexposure start"),
+    SUTn(HDU.ANY, VALUE.STRING, "UTC of subexposure start"),
     /**
      * FWHM of the object spectrum profile on the detector. The width is in the units of the spatial world coordinate
      * system. This may be approximate. It is particularly useful for specifying the profile width of fiber fed spectra.
@@ -6980,7 +6980,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    TIMEEND(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Time of exposure end"),
+    TIMEEND(HDU.ANY, VALUE.STRING, "Time of exposure end"),
     /**
      * Time of header creation.
      * <p>
@@ -6993,7 +6993,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    TIMEHDR(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Time of header creation"),
+    TIMEHDR(HDU.ANY, VALUE.STRING, "Time of header creation"),
     /**
      * Default time system. All times which do not have a "timesys" element associated with them in this dictionary
      * default to this keyword. .
@@ -7025,7 +7025,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    TSYSEND(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Time system for TIMEEND"),
+    TSYSEND(HDU.ANY, VALUE.STRING, "Time system for TIMEEND"),
     /**
      * Time system for the header creation keywords.
      * <p>
@@ -7035,7 +7035,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    TSYSHDR(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Time system for header creation"),
+    TSYSHDR(HDU.ANY, VALUE.STRING, "Time system for header creation"),
     /**
      * Time system for the TIME-OBS keyword.
      * <p>
@@ -7045,7 +7045,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    TSYSOBS(HDU.PRIMARY_EXTENSION, VALUE.STRING, "Time system for TIME-OBS"),
+    TSYSOBS(HDU.ANY, VALUE.STRING, "Time system for TIME-OBS"),
     /**
      * TV name.
      * <p>
@@ -7766,7 +7766,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    UTC_OBS("UTC-OBS", HDU.PRIMARY_EXTENSION, VALUE.STRING, "UTC of exposure start"),
+    UTC_OBS("UTC-OBS", HDU.ANY, VALUE.STRING, "UTC of exposure start"),
     /**
      * UTC at the end of the exposure.
      * <p>
@@ -7779,7 +7779,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    UTCEND(HDU.PRIMARY_EXTENSION, VALUE.STRING, "UTC at end of exposure"),
+    UTCEND(HDU.ANY, VALUE.STRING, "UTC at end of exposure"),
     /**
      * UTC of header creation.
      * <p>
@@ -7792,7 +7792,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    UTCHDR(HDU.PRIMARY_EXTENSION, VALUE.STRING, "UTC of header creation"),
+    UTCHDR(HDU.ANY, VALUE.STRING, "UTC of header creation"),
     /**
      * Default UTC time for the observation. This keyword is generally not used and is UTC-OBS keyword for the start of
      * the exposure on the detector is used.
@@ -7806,7 +7806,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    UTCOBS(HDU.PRIMARY_EXTENSION, VALUE.STRING, "UTC of observation"),
+    UTCOBS(HDU.ANY, VALUE.STRING, "UTC of observation"),
     /**
      * IRAF WCS attribute strings for all axes. These are defined by the IRAF WCS system.
      * <p>
@@ -7816,7 +7816,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = 1-999
      * </p>
      */
-    WAT_nnn(HDU.PRIMARY_EXTENSION, VALUE.STRING, ""),
+    WAT_nnn(HDU.ANY, VALUE.STRING, ""),
     /**
      * IRAF WCS attribute strings. These are defined by the IRAF WCS system.
      * <p>
@@ -7826,7 +7826,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = 1-9,1-999
      * </p>
      */
-    WATn_nnn(HDU.PRIMARY_EXTENSION, VALUE.STRING, ""),
+    WATn_nnn(HDU.ANY, VALUE.STRING, ""),
     /**
      * Descriptive string identifying the source of the astrometry used to derive the WCS. One example is the exposure
      * used to derive a WCS apart from the reference coordinate.
@@ -7837,7 +7837,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    WCSAnnn(HDU.PRIMARY_EXTENSION, VALUE.STRING, "WCS Source"),
+    WCSAnnn(HDU.ANY, VALUE.STRING, "WCS Source"),
     /**
      * Descriptive string identifying the source of the astrometry used to derive the WCS. One example is the exposure
      * used to derive a WCS apart from the reference coordinate.
@@ -7848,7 +7848,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    WCSASTRM(HDU.PRIMARY_EXTENSION, VALUE.STRING, "WCS Source"),
+    WCSASTRM(HDU.ANY, VALUE.STRING, "WCS Source"),
     /**
      * Dimensionality of the WCS physical system. In IRAF a WCS can have a higher dimensionality than the image.
      * <p>
@@ -7858,7 +7858,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    WCSDIM(HDU.PRIMARY_EXTENSION, VALUE.INTEGER, "WCS dimensionality"),
+    WCSDIM(HDU.ANY, VALUE.INTEGER, "WCS dimensionality"),
     /**
      * Epoch of the coordinates used in the world coordinate system.
      * <p>
@@ -7871,7 +7871,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    WCSEnnn(HDU.PRIMARY_EXTENSION, VALUE.REAL, "WCS coordinate epoch"),
+    WCSEnnn(HDU.ANY, VALUE.REAL, "WCS coordinate epoch"),
     /**
      * Equinox when equatorial coordinates are used in the world coordinate system. A value before 1984 is Besselian
      * otherwise it is Julian.
@@ -7885,7 +7885,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    WCSEPOCH(HDU.PRIMARY_EXTENSION, VALUE.REAL, "WCS coordinate epoch"),
+    WCSEPOCH(HDU.ANY, VALUE.REAL, "WCS coordinate epoch"),
     /**
      * Coordinate system type when equatorial coordinates are used in the world coordinate system.
      * <p>
@@ -7895,7 +7895,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    WCSRADEC(HDU.PRIMARY_EXTENSION, VALUE.STRING, "WCS coordinate system"),
+    WCSRADEC(HDU.ANY, VALUE.STRING, "WCS coordinate system"),
     /**
      * Coordinate system type when equatorial coordinates are used in the world coordinate system.
      * <p>
@@ -7905,7 +7905,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    WCSRnnn(HDU.PRIMARY_EXTENSION, VALUE.STRING, "WCS coordinate system"),
+    WCSRnnn(HDU.ANY, VALUE.STRING, "WCS coordinate system"),
     /**
      * Weather condition description. Generally this would be either 'clear' or 'partly cloudy'.
      * <p>
@@ -7942,7 +7942,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    MJD_OBS("MJD-OBS", HDU.PRIMARY_EXTENSION, VALUE.REAL, "MJD of exposure start");
+    MJD_OBS("MJD-OBS", HDU.ANY, VALUE.REAL, "MJD of exposure start");
 
     private final IFitsHeader key;
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1118,7 +1118,7 @@ The `Header.KeywordCheck` enum defines the following policies that may be used:
 
 The standardized keywords that implement the `IFitsHeader` interface can also specify the type of acceptable values
 to use. As of __1.19__ we will throw an appropriate exception (`IllegalArgumentException` or 
-`MismatchedValueTypeException`, depending on the method) if the user attempt to set a value of unsupported type. For
+`ValueTypeException`, depending on the method) if the user attempt to set a value of unsupported type. For
 example trying to set the value of the `Standard.TELESCOP` keyword (which expects a string value) to a boolean will
 throw an exception. 
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1101,7 +1101,7 @@ them. If the keyword should not be used in the header belonging to a specific ty
 policy, the library will throw an `IllegalArgumentException`.
 
 You can use `Header.setKeywordChecking()` to adjust the type of checking to be applied on a per header instance basis,
-or use the static `Header.setDEfaultKeywordChecking()` to change the default policy for all newly created headers.
+or use the static `Header.setDefaultKeywordChecking()` to change the default policy for all newly created headers.
 
 The `Header.KeywordCheck` enum defines the following policies that may be used:
 
@@ -1121,6 +1121,17 @@ to use. As of __1.19__ we will throw an appropriate exception (`IllegalArgumentE
 `MismatchedValueTypeException`, depending on the method) if the user attempt to set a value of unsupported type. For
 example trying to set the value of the `Standard.TELESCOP` keyword (which expects a string value) to a boolean will
 throw an exception. 
+
+The keyword checking policy can be adjusted via the `HeaderCard.setValueCheckingPolicy()` method. 
+`HeaderCard.ValueCheck` defines the following policies:
+
+- `NONE` -- no value type checking will be performed. You can do whatever you want without consequences. This policy 
+  is the most backward compatible one, since we have not done checking before.
+- `LOGGING` -- Attempting to set values of the wrong type for `IFitsHeader` keywords will be allowed but a warning 
+  will be logged each time.
+- `EXCEPTION` --  Attempting to set values of the wrong type for `IFitsHeader` keywords will throw an appropriate 
+  exception, such as `ValueTypeException` or `IllegalArgumentException` depending on the method used. 
+
 
 
 <a name="hierarch-style-header-keywords"></a>

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -24,6 +24,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.Standard;
@@ -1731,6 +1732,13 @@ public class HeaderTest {
         Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.SIMPLE, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testKeywordCheckingIntegralException() throws Exception {
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
+        Header h = new BinaryTable().toHDU().getHeader();
+        h.addValue(Compression.ZIMAGE, true);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1750,14 +1750,14 @@ public class HeaderTest {
     @Test
     public void testKeywordCheckingPrimary() throws Exception {
         Header.setDefaultKeywordChecking(Header.KeywordCheck.DATA_TYPE);
-        Header h = new BinaryTable().toHDU().getHeader();
+        Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
         h.addValue(Standard.SIMPLE, true);
     }
 
     @Test
     public void testKeywordCheckingOptional() throws Exception {
         Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
-        Header h = new BinaryTable().toHDU().getHeader();
+        Header h = ImageData.from(new int[10][10]).toHDU().getHeader();
         h.addValue(NOAOExt.ADCMJD, 0.0);
     }
 

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1727,17 +1727,24 @@ public class HeaderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testKeywordCheckingPrimaryException() throws Exception {
+    public void testKeywordCheckingMandatoryException() throws Exception {
         Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
         Header h = new BinaryTable().toHDU().getHeader();
         h.addValue(Standard.SIMPLE, true);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testKeywordCheckingExtensionException() throws Exception {
-        Header.setDefaultKeywordChecking(Header.KeywordCheck.STRICT);
+    public void testKeywordCheckingPrimaryException() throws Exception {
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.DATA_TYPE);
         Header h = new BinaryTable().toHDU().getHeader();
-        h.addValue(Standard.XTENSION, Standard.XTENSION_BINTABLE);
+        h.addValue(Standard.SIMPLE, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testKeywordCheckingExtensionException() throws Exception {
+        Header.setDefaultKeywordChecking(Header.KeywordCheck.DATA_TYPE);
+        Header h = new RandomGroupsData(new Object[][] {{new int[4], new int[2]}}).toHDU().getHeader();
+        h.addValue(Standard.XTENSION, true);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1744,7 +1744,7 @@ public class HeaderTest {
     public void testKeywordCheckingExtensionException() throws Exception {
         Header.setDefaultKeywordChecking(Header.KeywordCheck.DATA_TYPE);
         Header h = new RandomGroupsData(new Object[][] {{new int[4], new int[2]}}).toHDU().getHeader();
-        h.addValue(Standard.XTENSION, true);
+        h.addValue(Standard.INHERIT, true);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/nom/tam/fits/ProtectedFitsTest.java
+++ b/src/test/java/nom/tam/fits/ProtectedFitsTest.java
@@ -99,9 +99,6 @@ public class ProtectedFitsTest {
         Assert.assertTrue(randomGroupsHDU.isHeader());
         randomGroupsHDU.setPrimaryHDU(true);
         Assert.assertTrue(randomGroupsHDU.getHeader().getBooleanValue(Standard.SIMPLE));
-        randomGroupsHDU.setPrimaryHDU(false);
-        Assert.assertFalse(randomGroupsHDU.getHeader().getBooleanValue(Standard.SIMPLE));
-        Assert.assertEquals(XTENSION_IMAGE, randomGroupsHDU.getHeader().getStringValue(Standard.XTENSION));
 
         randomGroupsHDU = new RandomGroupsHDU(null, RandomGroupsHDU.manufactureData(header));
         ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
 - Check that primary keywords (e.g. `SIMPLE`) are not used in extension only HDUs (such as tables).
 - Check that extension only keywords (e.g. `XTENSION`) are not used in primary only HDUs (such as random groups)
 - Fix log spamming when setting integer values to real-type keywords in PR #534
 - Deprecate `IFitsHeader.HDU.PRIMARY_EXTENSION` (meaning primary or extension) since it is the same as `.ANY`. Refactor `PRIMARY_EXTENSION` to `ANY` in `NOAOExt` 
 - `PCOUNT`, `GCOUNT` were marked as `HDU.EXTENSION`, but these are required keywords in __all__ HDUs, so change it `HDU.ANY`
 - Similarly `EXTNAME`, `EXTVER`, and `EXTLEVEL` are explicitly allowed in the primary by the FITS standard so correct their assignment to `HDU.ANY` also, and add to `Synonyms` with equivalent (non-standard) `HDU...` alternatives.
 - Change designation of `Compression` keywords. These all must appear in compressed (binary) table HDUs, and should be managed by the libtary (i.e. `SOURCE.INTEGRAL`)