### PR TITLE
More cleanup of standard and conventional keyword definitions etc.

### DIFF
--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -488,7 +488,6 @@ public class Header implements FitsElement {
             }
             break;
         case TABLE:
-            System.err.println("### keyword " + keyword.key() + ", hdu " + owner.getClass().getName());
             if (owner instanceof TableHDU) {
                 return;
             }

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
@@ -45,7 +45,7 @@ import static nom.tam.fits.header.Compression.ZVALn;
  * 
  * @param <OPTION> The generic type of the compression option for which this parameter is used.
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public abstract class CompressHeaderParameter<OPTION> extends CompressParameter<OPTION>
         implements ICompressHeaderParameter {
 

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
@@ -49,7 +49,6 @@ import static nom.tam.fits.header.Standard.TTYPEn;
  * 
  * @see CompressParameter
  */
-@SuppressWarnings("deprecation")
 public abstract class CompressParameters implements ICompressParameters, Cloneable {
 
     @Override

--- a/src/main/java/nom/tam/fits/header/Checksum.java
+++ b/src/main/java/nom/tam/fits/header/Checksum.java
@@ -70,14 +70,14 @@ public enum Checksum implements IFitsHeader {
      */
     DATASUM(HDU.ANY, VALUE.STRING, "checksum of the data records");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     Checksum(HDU hdu, VALUE valueType, String comment) {
         key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.CHECKSUM, hdu, valueType, comment);
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public FitsHeaderImpl impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/Checksum.java
+++ b/src/main/java/nom/tam/fits/header/Checksum.java
@@ -74,7 +74,7 @@ public enum Checksum implements IFitsHeader {
 
     Checksum(HDU hdu, VALUE valueType, String comment) {
         key = new FitsKey(name(), IFitsHeader.SOURCE.CHECKSUM, hdu, valueType, comment);
-        FitsKey.registerStandard(name(), this);
+        FitsKey.registerStandard(this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/Checksum.java
+++ b/src/main/java/nom/tam/fits/header/Checksum.java
@@ -74,6 +74,7 @@ public enum Checksum implements IFitsHeader {
 
     Checksum(HDU hdu, VALUE valueType, String comment) {
         key = new FitsKey(name(), IFitsHeader.SOURCE.CHECKSUM, hdu, valueType, comment);
+        FitsKey.registerStandard(name(), this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/Checksum.java
+++ b/src/main/java/nom/tam/fits/header/Checksum.java
@@ -70,14 +70,14 @@ public enum Checksum implements IFitsHeader {
      */
     DATASUM(HDU.ANY, VALUE.STRING, "checksum of the data records");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     Checksum(HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.CHECKSUM, hdu, valueType, comment);
+        key = new FitsKey(name(), IFitsHeader.SOURCE.CHECKSUM, hdu, valueType, comment);
     }
 
     @Override
-    public FitsHeaderImpl impl() {
+    public FitsKey impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/Compression.java
+++ b/src/main/java/nom/tam/fits/header/Compression.java
@@ -419,7 +419,7 @@ public enum Compression implements IFitsHeader {
     Compression(VALUE valueType, String comment, IFitsHeader uncompressedKey) {
         key = new FitsKey(name(), IFitsHeader.SOURCE.INTEGRAL, HDU.BINTABLE, valueType, comment);
         this.uncompressedKey = uncompressedKey;
-        FitsKey.registerStandard(name(), this);
+        FitsKey.registerStandard(this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/Compression.java
+++ b/src/main/java/nom/tam/fits/header/Compression.java
@@ -406,7 +406,7 @@ public enum Compression implements IFitsHeader {
      */
     public static final String SMOOTH = "SMOOTH";
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     private final IFitsHeader uncompressedKey;
 
@@ -415,12 +415,12 @@ public enum Compression implements IFitsHeader {
     }
 
     Compression(VALUE valueType, String comment, IFitsHeader uncompressedKey) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.INTEGRAL, HDU.BINTABLE, valueType, comment);
+        key = new FitsKey(name(), IFitsHeader.SOURCE.INTEGRAL, HDU.BINTABLE, valueType, comment);
         this.uncompressedKey = uncompressedKey;
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/Compression.java
+++ b/src/main/java/nom/tam/fits/header/Compression.java
@@ -60,7 +60,7 @@ public enum Compression implements IFitsHeader {
 
     /**
      * (required keyword) The value field of this keyword shall contain an integer that gives the value of the BITPIX
-     * keyword in the uncompressed FITS image. 1
+     * keyword in the uncompressed FITS image.
      */
     ZBITPIX(VALUE.INTEGER, "", Standard.BITPIX),
 
@@ -75,6 +75,7 @@ public enum Compression implements IFitsHeader {
      * the NAXISn keywords in the uncompressed FITS image.
      */
     ZNAXISn(VALUE.INTEGER, "", Standard.NAXISn),
+
     /**
      * (optional keywords) The value of these indexed keywords (where n ranges from 1 to ZNAXIS ) shall contain a
      * positive integer representing the number o f pixels along axis n of the compression tiles. Each tile of pixels is
@@ -97,6 +98,7 @@ public enum Compression implements IFitsHeader {
      * algorithm.
      */
     ZNAMEn(VALUE.STRING, ""),
+
     /**
      * (optional keywords) These pairs of optional array keywords (where n is an integer index number starting with 1)
      * supply the name and value, respectively, of any algorithm-specific parameters that are needed to compress o r
@@ -105,6 +107,7 @@ public enum Compression implements IFitsHeader {
      * algorithm.
      */
     ZVALn(VALUE.ANY, ""),
+
     /**
      * (optional keyword) Used to record the name of the image compression algorithm that was used to compress the
      * optional null pixel data mask. See the “Preserving undefined pixels with lossy compression” section for more
@@ -126,7 +129,6 @@ public enum Compression implements IFitsHeader {
      * identical copy o f the original FITS file when the image is uncompressed.preserves the original XTENSION
      * keyword.may only be used if the original uncompressed image was contained in in IMAGE extension.
      */
-
     ZTENSION(VALUE.STRING, "", Standard.XTENSION),
 
     /**
@@ -417,6 +419,7 @@ public enum Compression implements IFitsHeader {
     Compression(VALUE valueType, String comment, IFitsHeader uncompressedKey) {
         key = new FitsKey(name(), IFitsHeader.SOURCE.INTEGRAL, HDU.BINTABLE, valueType, comment);
         this.uncompressedKey = uncompressedKey;
+        FitsKey.registerStandard(name(), this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/Compression.java
+++ b/src/main/java/nom/tam/fits/header/Compression.java
@@ -406,7 +406,7 @@ public enum Compression implements IFitsHeader {
      */
     public static final String SMOOTH = "SMOOTH";
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     private final IFitsHeader uncompressedKey;
 
@@ -420,7 +420,7 @@ public enum Compression implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -193,14 +193,14 @@ public enum DataDescription implements IFitsHeader {
      */
     TSORTKEY(SOURCE.HEASARC, HDU.TABLE, VALUE.STRING, "defines the sort order of a table");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     DataDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -193,14 +193,14 @@ public enum DataDescription implements IFitsHeader {
      */
     TSORTKEY(SOURCE.HEASARC, HDU.TABLE, VALUE.STRING, "defines the sort order of a table");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     DataDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+        key = new FitsKey(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -436,7 +436,7 @@ public enum DateTime implements IFitsHeader {
      */
     public static final String TIMEUNIT_BESSELIAN_YEAR = "Ba";
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     DateTime(SOURCE status, HDU hdu, VALUE valueType, String comment) {
         this(null, status, hdu, valueType, comment);
@@ -447,7 +447,7 @@ public enum DateTime implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -32,7 +32,7 @@ package nom.tam.fits.header;
  */
 
 /**
- * Date-time related standard FITS keywords.
+ * Date-time related keywords defined by the FITS standard.
  * 
  * @author Attila Kovacs
  *
@@ -171,14 +171,14 @@ public enum DateTime implements IFitsHeader {
     JDREF(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[day] reference Julian Date"),
 
     /**
-     * The start time of the observation, in the format specified in the FITS Standard, in the format HH:MM:SS[.sss]'.
+     * The start time of the observation, in the format specified in the FITS Standard, in the format HH:MM:SS[.s...]'.
      * 
      * @since 1.19
      */
     TSTART(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "start time of observation"),
 
     /**
-     * The end time of the observation, in the format specified in the FITS Standard, in the format HH:MM:SS[.sss]'.
+     * The end time of the observation, in the format specified in the FITS Standard, in the format HH:MM:SS[.s...]'.
      * 
      * @since 1.19
      */
@@ -199,14 +199,14 @@ public enum DateTime implements IFitsHeader {
     JEPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[yr] Julian epoch of observation"),
 
     /**
-     * Net exposure duration
+     * Net exposure duration (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
     XPOSURE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Net exposure duration"),
 
     /**
-     * Wall clock exposure duration
+     * Wall clock exposure duration (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
@@ -262,28 +262,28 @@ public enum DateTime implements IFitsHeader {
     TIMEUNIT(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time unit"),
 
     /**
-     * Precision time offset
+     * Precision time offset (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
     TIMEOFFS(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Time offset"),
 
     /**
-     * Systematic time error
+     * Systematic time error (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
     TIMESYER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Systematic time error"),
 
     /**
-     * Random time error
+     * Random time error (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
     TIMERDER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Random time error"),
 
     /**
-     * Time resolution
+     * Time resolution (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
@@ -403,7 +403,7 @@ public enum DateTime implements IFitsHeader {
 
     /** Solar System ephemeris value for {@link #PLEPHEM} for Park, et al. (2021). */
     public static final String PLEPHEM_DE440 = "DE440";
-   
+
     /** Solar System ephemeris value for {@link #PLEPHEM} for Park, et al. (2021). */
     public static final String PLEPHEM_DE441 = "DE441";
 

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -444,7 +444,7 @@ public enum DateTime implements IFitsHeader {
 
     DateTime(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsKey(headerName == null ? name() : headerName, status, hdu, valueType, comment);
-        FitsKey.registerStandard(headerName, this);
+        FitsKey.registerStandard(this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -444,6 +444,7 @@ public enum DateTime implements IFitsHeader {
 
     DateTime(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsKey(headerName == null ? name() : headerName, status, hdu, valueType, comment);
+        FitsKey.registerStandard(headerName, this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -436,18 +436,18 @@ public enum DateTime implements IFitsHeader {
      */
     public static final String TIMEUNIT_BESSELIAN_YEAR = "Ba";
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     DateTime(SOURCE status, HDU hdu, VALUE valueType, String comment) {
         this(null, status, hdu, valueType, comment);
     }
 
     DateTime(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(headerName == null ? name() : headerName, status, hdu, valueType, comment);
+        key = new FitsKey(headerName == null ? name() : headerName, status, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -36,8 +36,8 @@ package nom.tam.fits.header;
  * unintuitive class name.
  * 
  * @author Attila Kovacs
- * @deprecated Use the more intuitively named {@link FitsKey} class instead. This
- *             class is provided for compatibility with prior releases.
+ * @deprecated Use the more intuitively named {@link FitsKey} class instead.
+ *             This class is provided for compatibility with prior releases.
  */
 public class FitsHeaderImpl extends FitsKey {
 

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -32,12 +32,12 @@ package nom.tam.fits.header;
  */
 
 /**
- * The old concrete implementation of standardized FITS keywords, with a very
- * unintuitive class name.
+ * The old concrete implementation of standardized FITS keywords, with a very unintuitive class name.
  * 
- * @author Attila Kovacs
- * @deprecated Use the more intuitively named {@link FitsKey} class instead.
- *             This class is provided for compatibility with prior releases.
+ * @author     ritchie
+ * 
+ * @deprecated Use the more intuitively named {@link FitsKey} class instead. This class is provided for compatibility
+ *                 with prior releases.
  */
 public class FitsHeaderImpl extends FitsKey {
 
@@ -47,24 +47,21 @@ public class FitsHeaderImpl extends FitsKey {
     private static final long serialVersionUID = 2393951402526656978L;
 
     /**
-     * Creates a new standardized FITS keyword with the specific usage
-     * constraints
+     * Creates a new standardized FITS keyword with the specific usage constraints
      * 
-     * @param headerName
-     *            The keyword as it will appear in the FITS headers, usually a
-     *            string with up to 8 characters, containing uppper case letters
-     *            (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
-     *            hyphen (<code>-</code>) characters for standard FITS keywords.
-     * @param status
-     *            The convention that defines this keyword
-     * @param hdu
-     *            the type of HDU this keyword may appear in
-     * @param valueType
-     *            the type of value that may be associated with this keyword
-     * @param comment
-     *            the standard comment to include with this keyword
+     * @param  headerName               The keyword as it will appear in the FITS headers, usually a string with up to 8
+     *                                      characters, containing uppper case letters (A-Z), digits (0-9), and/or
+     *                                      underscore (<code>_</code>) or hyphen (<code>-</code>) characters for
+     *                                      standard FITS keywords.
+     * @param  status                   The convention that defines this keyword
+     * @param  hdu                      the type of HDU this keyword may appear in
+     * @param  valueType                the type of value that may be associated with this keyword
+     * @param  comment                  the standard comment to include with this keyword
+     * 
+     * @throws IllegalArgumentException if the keyword name is invalid.
      */
-    public FitsHeaderImpl(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
+    public FitsHeaderImpl(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment)
+            throws IllegalArgumentException {
         super(headerName, status, hdu, valueType, comment);
         // TODO Auto-generated constructor stub
     }

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -81,7 +81,7 @@ public class FitsHeaderImpl implements IFitsHeader, Serializable {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return this;
     }
 

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -1,21 +1,18 @@
 package nom.tam.fits.header;
 
-import java.io.Serializable;
-import java.util.HashSet;
-
-/*
+/*-
  * #%L
- * nom.tam FITS library
+ * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
- *
+ * 
  * Anyone is free to copy, modify, publish, use, compile, sell, or
  * distribute this software, either in source code form or as a compiled
  * binary, for any purpose, commercial or non-commercial, and by any
  * means.
- *
+ * 
  * In jurisdictions that recognize copyright laws, the author or authors
  * of this software dedicate any and all copyright interest in the
  * software to the public domain. We make this dedication for the benefit
@@ -23,7 +20,7 @@ import java.util.HashSet;
  * successors. We intend this dedication to be an overt act of
  * relinquishment in perpetuity of all present and future rights to this
  * software under copyright law.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
@@ -35,98 +32,41 @@ import java.util.HashSet;
  */
 
 /**
- * A generic implementation of standardized FITS header keywords, which may be extended to provide arbitrary further
- * conventional keywords, beyond what is provided by this library. For example, users may extend this class to define
- * commonly used keywords for their applications, and benefit for the extra checks they afford, and to avoid typos when
- * using these.
+ * The old concrete implementation of standardized FITS keywords, with a very
+ * unintuitive class name.
+ * 
+ * @author Attila Kovacs
+ * @deprecated Use the more intuitively named {@link FitsKey} class instead. This
+ *             class is provided for compatibility with prior releases.
  */
-public class FitsHeaderImpl implements IFitsHeader, Serializable {
+public class FitsHeaderImpl extends FitsKey {
+
     /**
-     *
-     */
+    *
+    */
     private static final long serialVersionUID = 2393951402526656978L;
 
-    private final String comment;
-
-    private final HDU hdu;
-
-    private final String key;
-
-    private final SOURCE status;
-
-    private final VALUE valueType;
-
-    private static HashSet<String> commentStyleKeys = new HashSet<>();
-
     /**
-     * Creates a new conventional FITS keyword with the specific usage constraints
+     * Creates a new standardized FITS keyword with the specific usage
+     * constraints
      * 
-     * @param headerName The keyword as it will appear in the FITS headers, usually a string with up to 8 characters,
-     *                       containing uppper case letters (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
-     *                       hyphen (<code>-</code>) characters for standard FITS keywords.
-     * @param status     The convention that defines this keyword
-     * @param hdu        the type of HDU this keyword may appear in
-     * @param valueType  the type of value that may be associated with this keyword
-     * @param comment    the standard comment to include with this keyword
+     * @param headerName
+     *            The keyword as it will appear in the FITS headers, usually a
+     *            string with up to 8 characters, containing uppper case letters
+     *            (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
+     *            hyphen (<code>-</code>) characters for standard FITS keywords.
+     * @param status
+     *            The convention that defines this keyword
+     * @param hdu
+     *            the type of HDU this keyword may appear in
+     * @param valueType
+     *            the type of value that may be associated with this keyword
+     * @param comment
+     *            the standard comment to include with this keyword
      */
     public FitsHeaderImpl(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = headerName;
-        this.status = status;
-        this.hdu = hdu;
-        this.valueType = valueType;
-        this.comment = comment;
-        if (valueType == VALUE.NONE) {
-            commentStyleKeys.add(headerName);
-        }
+        super(headerName, status, hdu, valueType, comment);
+        // TODO Auto-generated constructor stub
     }
 
-    @Override
-    public final FitsHeaderImpl impl() {
-        return this;
-    }
-
-    @Override
-    public String comment() {
-        return comment;
-    }
-
-    @Override
-    public HDU hdu() {
-        return hdu;
-    }
-
-    @Override
-    public String key() {
-        if (key.endsWith("a")) {
-            return key.substring(0, key.length() - 1);
-        }
-        return key;
-    }
-
-    @Override
-    public SOURCE status() {
-        return status;
-    }
-
-    @Override
-    public VALUE valueType() {
-        return valueType;
-    }
-
-    /**
-     * (<i>for internal use</i>) Checks if a keywords is known to be a comment-style keyword. That is, it checks if the
-     * <code>key</code> argument matches any {@link IFitsHeader} constructed via this implementation with a
-     * <code>valueType</code> argument that was <code>null</code>, or if the key is empty.
-     *
-     * @param  key the keyword to check
-     *
-     * @return     <code>true</code> if the key is empty or if it matches any known {@link IFitsHeader} keywords
-     *                 implemented through this class that have valueType of <code>null</code>. Otherwise
-     *                 <code>false</code>.
-     *
-     * @since      1.17
-     */
-    public static boolean isCommentStyleKey(String key) {
-        return commentStyleKeys.contains(key) || key.trim().isEmpty();
-    }
 }

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -218,7 +218,8 @@ public class FitsKey implements IFitsHeader, Serializable {
     }
 
     /**
-     * cache of all standard keys, for reusing the standards.
+     * A registry of all standard keys, for reusing the standards. We keep the registry outside of the enums that define
+     * keys to avoid circular dependency issues.
      */
     private static final Map<String, IFitsHeader> STANDARD_KEYS = new HashMap<>();
 
@@ -278,5 +279,6 @@ public class FitsKey implements IFitsHeader, Serializable {
         return STANDARD_KEYS.get(pattern.toString());
     }
 
+    /** We define this here with package level visibility for IFitsHeader */
     static final int BASE_10 = 10;
 }

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -80,6 +80,39 @@ public class FitsKey implements IFitsHeader, Serializable {
         }
     }
 
+    /**
+     * Creates a new standardized user-defined FITS keyword. The keyword will have source set to
+     * {@link IFitsHeader.SOURCE#UNKNOWN}.
+     * 
+     * @param headerName The keyword as it will appear in the FITS headers, usually a string with up to 8 characters,
+     *                       containing uppper case letters (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
+     *                       hyphen (<code>-</code>) characters for standard FITS keywords.
+     * @param hdu        the type of HDU this keyword may appear in
+     * @param valueType  the type of value that may be associated with this keyword
+     * @param comment    the standard comment to include with this keyword
+     * 
+     * @since            1.19
+     */
+    public FitsKey(String headerName, HDU hdu, VALUE valueType, String comment) {
+        this(headerName, SOURCE.UNKNOWN, hdu, valueType, comment);
+    }
+
+    /**
+     * Creates a new standardized user-defined FITS keyword. The keyword will have source set to
+     * {@link IFitsHeader.SOURCE#UNKNOWN} and HDY type to {@link IFitsHeader.HDU#ANY}.
+     * 
+     * @param headerName The keyword as it will appear in the FITS headers, usually a string with up to 8 characters,
+     *                       containing uppper case letters (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
+     *                       hyphen (<code>-</code>) characters for standard FITS keywords.
+     * @param valueType  the type of value that may be associated with this keyword
+     * @param comment    the standard comment to include with this keyword
+     * 
+     * @since            1.19
+     */
+    public FitsKey(String headerName, VALUE valueType, String comment) {
+        this(headerName, HDU.ANY, valueType, comment);
+    }
+
     @Override
     public final FitsKey impl() {
         return this;

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -162,4 +162,6 @@ public class FitsKey implements IFitsHeader, Serializable {
     public static boolean isCommentStyleKey(String key) {
         return commentStyleKeys.contains(key) || key.trim().isEmpty();
     }
+
+    static final int BASE_10 = 10;
 }

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -1,0 +1,132 @@
+package nom.tam.fits.header;
+
+import java.io.Serializable;
+import java.util.HashSet;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2021 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+/**
+ * A concrete implementation of standardized FITS header keywords, which may be extended to provide arbitrary further
+ * conventional keywords, beyond what is provided by this library. Wsers may instantiate this class or extend it to
+ * define commonly used keywords for their applications, and benefit for the extra checks they afford, and to avoid
+ * typos when using these.
+ * 
+ * @since 1.19
+ */
+public class FitsKey implements IFitsHeader, Serializable {
+
+    private static final long serialVersionUID = -8312303744399173040L;
+
+    private final String comment;
+
+    private final HDU hdu;
+
+    private final String key;
+
+    private final SOURCE status;
+
+    private final VALUE valueType;
+
+    private static HashSet<String> commentStyleKeys = new HashSet<>();
+
+    /**
+     * Creates a new standardized FITS keyword with the specific usage constraints
+     * 
+     * @param headerName The keyword as it will appear in the FITS headers, usually a string with up to 8 characters,
+     *                       containing uppper case letters (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
+     *                       hyphen (<code>-</code>) characters for standard FITS keywords.
+     * @param status     The convention that defines this keyword
+     * @param hdu        the type of HDU this keyword may appear in
+     * @param valueType  the type of value that may be associated with this keyword
+     * @param comment    the standard comment to include with this keyword
+     */
+    public FitsKey(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
+        key = headerName;
+        this.status = status;
+        this.hdu = hdu;
+        this.valueType = valueType;
+        this.comment = comment;
+        if (valueType == VALUE.NONE) {
+            commentStyleKeys.add(headerName);
+        }
+    }
+
+    @Override
+    public final FitsKey impl() {
+        return this;
+    }
+
+    @Override
+    public String comment() {
+        return comment;
+    }
+
+    @Override
+    public HDU hdu() {
+        return hdu;
+    }
+
+    @Override
+    public String key() {
+        if (key.endsWith("a")) {
+            return key.substring(0, key.length() - 1);
+        }
+        return key;
+    }
+
+    @Override
+    public SOURCE status() {
+        return status;
+    }
+
+    @Override
+    public VALUE valueType() {
+        return valueType;
+    }
+
+    /**
+     * (<i>for internal use</i>) Checks if a keywords is known to be a comment-style keyword. That is, it checks if the
+     * <code>key</code> argument matches any {@link IFitsHeader} constructed via this implementation with a
+     * <code>valueType</code> argument that was <code>null</code>, or if the key is empty.
+     *
+     * @param  key the keyword to check
+     *
+     * @return     <code>true</code> if the key is empty or if it matches any known {@link IFitsHeader} keywords
+     *                 implemented through this class that have valueType of <code>null</code>. Otherwise
+     *                 <code>false</code>.
+     *
+     * @since      1.17
+     */
+    public static boolean isCommentStyleKey(String key) {
+        return commentStyleKeys.contains(key) || key.trim().isEmpty();
+    }
+}

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -222,8 +222,8 @@ public class FitsKey implements IFitsHeader, Serializable {
      */
     private static final Map<String, IFitsHeader> STANDARD_KEYS = new HashMap<>();
 
-    static void registerStandard(String name, IFitsHeader key) throws IllegalArgumentException {
-        STANDARD_KEYS.put(name, key);
+    static void registerStandard(IFitsHeader key) throws IllegalArgumentException {
+        STANDARD_KEYS.put(key.key(), key);
     }
 
     /**
@@ -275,7 +275,7 @@ public class FitsKey implements IFitsHeader, Serializable {
             }
         }
 
-        return FitsKey.STANDARD_KEYS.get(pattern.toString());
+        return STANDARD_KEYS.get(pattern.toString());
     }
 
     static final int BASE_10 = 10;

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -64,8 +64,8 @@ public class FitsKey implements IFitsHeader, Serializable {
      * Creates a new standardized FITS keyword with the specific usage constraints. The keyword must be composed of
      * uppper-case 'A'-'Z', digits, underscore ('_') and hyphen ('-') characters. Additionally, lower case 'n' may be
      * used as a place-holder for a numerical index, and the keyword name may end with a lower-case 'a' to indicate that
-     * it may be used for/with alternate WCS coordinate systems. (We also allow '/' because some STScI keywords use
-     * these even though they violate the FITS standard.
+     * it may be used for/with alternate WCS coordinate systems. (We also allow '/' because some STScI keywords use it
+     * even though it violates the FITS standard.)
      * 
      * @param  headerName               The keyword as it will appear in the FITS headers, usually a string with up to 8
      *                                      characters, containing uppper case letters (A-Z), digits (0-9), and/or
@@ -123,7 +123,8 @@ public class FitsKey implements IFitsHeader, Serializable {
      * {@link IFitsHeader.SOURCE#UNKNOWN}. The keyword must be composed of uppper-case 'A'-'Z', digits, underscore ('_')
      * and hyphen ('-') characters. Additionally, lower case 'n' may be used as a place-holder for a numerical index,
      * and the keyword name may end with a lower-case 'a' to indicate that it may be used for/with alternate WCS
-     * coordinate systems.
+     * coordinate systems. (We also allow '/' because some STScI keywords use it even though it violates the FITS
+     * standard.)
      * 
      * @param  headerName               The keyword as it will appear in the FITS headers, usually a string with up to 8
      *                                      characters, containing uppper case letters (A-Z), digits (0-9), and/or
@@ -146,7 +147,8 @@ public class FitsKey implements IFitsHeader, Serializable {
      * {@link IFitsHeader.SOURCE#UNKNOWN} and HDY type to {@link IFitsHeader.HDU#ANY}. The keyword must be composed of
      * uppper-case 'A'-'Z', digits, underscore ('_') and hyphen ('-') characters. Additionally, lower case 'n' may be
      * used as a place-holder for a numerical index, and the keyword name may end with a lower-case 'a' to indicate that
-     * it may be used for/with alternate WCS coordinate systems.
+     * it may be used for/with alternate WCS coordinate systems. (We also allow '/' because some STScI keywords use it
+     * even though it violates the FITS standard.)
      * 
      * @param  headerName               The keyword as it will appear in the FITS headers, usually a string with up to 8
      *                                      characters, containing uppper case letters (A-Z), digits (0-9), and/or

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -3,6 +3,8 @@ package nom.tam.fits.header;
 import java.io.Serializable;
 import java.util.HashSet;
 
+import nom.tam.fits.HeaderCard;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -59,22 +61,58 @@ public class FitsKey implements IFitsHeader, Serializable {
     private static HashSet<String> commentStyleKeys = new HashSet<>();
 
     /**
-     * Creates a new standardized FITS keyword with the specific usage constraints
+     * Creates a new standardized FITS keyword with the specific usage constraints. The keyword must be composed of
+     * uppper-case 'A'-'Z', digits, underscore ('_') and hyphen ('-') characters. Additionally, lower case 'n' may be
+     * used as a place-holder for a numerical index, and the keyword name may end with a lower-case 'a' to indicate that
+     * it may be used for/with alternate WCS coordinate systems. (We also allow '/' because some STScI keywords use
+     * these even though they violate the FITS standard.
      * 
-     * @param headerName The keyword as it will appear in the FITS headers, usually a string with up to 8 characters,
-     *                       containing uppper case letters (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
-     *                       hyphen (<code>-</code>) characters for standard FITS keywords.
-     * @param status     The convention that defines this keyword
-     * @param hdu        the type of HDU this keyword may appear in
-     * @param valueType  the type of value that may be associated with this keyword
-     * @param comment    the standard comment to include with this keyword
+     * @param  headerName               The keyword as it will appear in the FITS headers, usually a string with up to 8
+     *                                      characters, containing uppper case letters (A-Z), digits (0-9), and/or
+     *                                      underscore (<code>_</code>) or hyphen (<code>-</code>) characters for
+     *                                      standard FITS keywords.
+     * @param  status                   The convention that defines this keyword
+     * @param  hdu                      the type of HDU this keyword may appear in
+     * @param  valueType                the type of value that may be associated with this keyword
+     * @param  comment                  the standard comment to include with this keyword
+     * 
+     * @throws IllegalArgumentException if the keyword name is invalid.
      */
-    public FitsKey(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = headerName;
+    public FitsKey(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment)
+            throws IllegalArgumentException {
+        if (headerName.length() > HeaderCard.MAX_KEYWORD_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Keyword " + headerName + " exceeeds the FITS " + HeaderCard.MAX_KEYWORD_LENGTH + " character limit");
+        }
+
+        for (int i = 0; i < headerName.length(); i++) {
+            char c = headerName.charAt(i);
+
+            if (c >= 'A' && c <= 'Z') {
+                continue;
+            }
+            if (c >= '0' && c <= '9') {
+                continue;
+            }
+            if (c == '-' || c == '_' || c == '/') {
+                continue;
+            }
+            if (c == 'n') {
+                continue;
+            }
+            if (c == 'a' && (i + 1) == headerName.length()) {
+                continue;
+            }
+
+            throw new IllegalArgumentException("Invalid FITS keyword: " + headerName);
+        }
+
+        this.key = headerName;
         this.status = status;
         this.hdu = hdu;
         this.valueType = valueType;
         this.comment = comment;
+
         if (valueType == VALUE.NONE) {
             commentStyleKeys.add(headerName);
         }
@@ -82,34 +120,46 @@ public class FitsKey implements IFitsHeader, Serializable {
 
     /**
      * Creates a new standardized user-defined FITS keyword. The keyword will have source set to
-     * {@link IFitsHeader.SOURCE#UNKNOWN}.
+     * {@link IFitsHeader.SOURCE#UNKNOWN}. The keyword must be composed of uppper-case 'A'-'Z', digits, underscore ('_')
+     * and hyphen ('-') characters. Additionally, lower case 'n' may be used as a place-holder for a numerical index,
+     * and the keyword name may end with a lower-case 'a' to indicate that it may be used for/with alternate WCS
+     * coordinate systems.
      * 
-     * @param headerName The keyword as it will appear in the FITS headers, usually a string with up to 8 characters,
-     *                       containing uppper case letters (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
-     *                       hyphen (<code>-</code>) characters for standard FITS keywords.
-     * @param hdu        the type of HDU this keyword may appear in
-     * @param valueType  the type of value that may be associated with this keyword
-     * @param comment    the standard comment to include with this keyword
+     * @param  headerName               The keyword as it will appear in the FITS headers, usually a string with up to 8
+     *                                      characters, containing uppper case letters (A-Z), digits (0-9), and/or
+     *                                      underscore (<code>_</code>) or hyphen (<code>-</code>) characters for
+     *                                      standard FITS keywords.
+     * @param  hdu                      the type of HDU this keyword may appear in
+     * @param  valueType                the type of value that may be associated with this keyword
+     * @param  comment                  the standard comment to include with this keyword
      * 
-     * @since            1.19
+     * @throws IllegalArgumentException if the keyword name is invalid.
+     * 
+     * @since                           1.19
      */
-    public FitsKey(String headerName, HDU hdu, VALUE valueType, String comment) {
+    public FitsKey(String headerName, HDU hdu, VALUE valueType, String comment) throws IllegalArgumentException {
         this(headerName, SOURCE.UNKNOWN, hdu, valueType, comment);
     }
 
     /**
      * Creates a new standardized user-defined FITS keyword. The keyword will have source set to
-     * {@link IFitsHeader.SOURCE#UNKNOWN} and HDY type to {@link IFitsHeader.HDU#ANY}.
+     * {@link IFitsHeader.SOURCE#UNKNOWN} and HDY type to {@link IFitsHeader.HDU#ANY}. The keyword must be composed of
+     * uppper-case 'A'-'Z', digits, underscore ('_') and hyphen ('-') characters. Additionally, lower case 'n' may be
+     * used as a place-holder for a numerical index, and the keyword name may end with a lower-case 'a' to indicate that
+     * it may be used for/with alternate WCS coordinate systems.
      * 
-     * @param headerName The keyword as it will appear in the FITS headers, usually a string with up to 8 characters,
-     *                       containing uppper case letters (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
-     *                       hyphen (<code>-</code>) characters for standard FITS keywords.
-     * @param valueType  the type of value that may be associated with this keyword
-     * @param comment    the standard comment to include with this keyword
+     * @param  headerName               The keyword as it will appear in the FITS headers, usually a string with up to 8
+     *                                      characters, containing uppper case letters (A-Z), digits (0-9), and/or
+     *                                      underscore (<code>_</code>) or hyphen (<code>-</code>) characters for
+     *                                      standard FITS keywords.
+     * @param  valueType                the type of value that may be associated with this keyword
+     * @param  comment                  the standard comment to include with this keyword
      * 
-     * @since            1.19
+     * @throws IllegalArgumentException if the keyword name is invalid.
+     * 
+     * @since                           1.19
      */
-    public FitsKey(String headerName, VALUE valueType, String comment) {
+    public FitsKey(String headerName, VALUE valueType, String comment) throws IllegalArgumentException {
         this(headerName, HDU.ANY, valueType, comment);
     }
 

--- a/src/main/java/nom/tam/fits/header/GenericKey.java
+++ b/src/main/java/nom/tam/fits/header/GenericKey.java
@@ -89,7 +89,7 @@ public final class GenericKey {
     public static IFitsHeader create(String key) {
         IFitsHeader result = STANDARD_KEYS.get(key);
         if (result == null) {
-            result = new FitsHeaderImpl(key, SOURCE.UNKNOWN, HDU.ANY, VALUE.ANY, "");
+            result = new FitsKey(key, SOURCE.UNKNOWN, HDU.ANY, VALUE.ANY, "");
         }
         return result;
     }

--- a/src/main/java/nom/tam/fits/header/GenericKey.java
+++ b/src/main/java/nom/tam/fits/header/GenericKey.java
@@ -31,57 +31,29 @@ package nom.tam.fits.header;
  * #L%
  */
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import nom.tam.fits.header.IFitsHeader.HDU;
 import nom.tam.fits.header.IFitsHeader.SOURCE;
 import nom.tam.fits.header.IFitsHeader.VALUE;
 
 /**
  * generic key interface, create an IFitsHeader from a key.
- *
+ * 
  * @author ritchie
+ * @deprecated This class duplicates functionality that is available in
+ *             {@link FitsKey}, {@link Standard}, ans/or {@link IFitsHeader}.
  */
 public final class GenericKey {
 
     private static final int NUMBER_BASE = 10;
 
     /**
-     * cache of all standard keys, for reusing the standards.
-     */
-    private static final Map<String, IFitsHeader> STANDARD_KEYS;
-
-    static {
-        Map<String, IFitsHeader> headers = new HashMap<>();
-        for (IFitsHeader key : Standard.values()) {
-            headers.put(key.key(), key);
-        }
-        for (IFitsHeader key : DateTime.values()) {
-            headers.put(key.key(), key);
-        }
-        for (IFitsHeader key : WCS.values()) {
-            headers.put(key.key(), key);
-        }
-        for (IFitsHeader key : Checksum.values()) {
-            headers.put(key.key(), key);
-        }
-        for (IFitsHeader key : Compression.values()) {
-            headers.put(key.key(), key);
-        }
-        STANDARD_KEYS = Collections.unmodifiableMap(headers);
-    }
-
-    /**
-     * Creates a generic FITS header key that may be used in any HDU, with any type of value, and does not have a
-     * standard comment.
-     *
-     * @param      key the string to create the key for
-     *
-     * @return         the IFitsHeader implementation for the key.
+     * Creates a generic FITS header key that may be used in any HDU, with any
+     * type of value, and does not have a standard comment.
      * 
-     * @deprecated     Use {@link FitsKey#FitsKey(String, VALUE, String)} instead.
+     * @param key
+     *            the string to create the key for
+     * @return the IFitsHeader implementation for the key.
+     * @deprecated Use {@link FitsKey#FitsKey(String, VALUE, String)} instead.
      */
     public static IFitsHeader create(String key) {
         IFitsHeader result = lookup(key);
@@ -92,13 +64,14 @@ public final class GenericKey {
     }
 
     /**
-     * @deprecated      (<i>for internal use</i>) Creates a array of generic FITS header keys. The resulting keys have
-     *                      no HDU assignment or value type restrictions, not default comments. As such they may be used
-     *                      for accessing existing keys by the specified names, more so than for adding new values.
-     *
-     * @param      keys the array of string keys
-     *
-     * @return          the equivalent array of super-generic standarddized keys.
+     * @deprecated (<i>for internal use</i>) Creates a array of generic FITS
+     *             header keys. The resulting keys have no HDU assignment or
+     *             value type restrictions, not default comments. As such they
+     *             may be used for accessing existing keys by the specified
+     *             names, more so than for adding new values.
+     * @param keys
+     *            the array of string keys
+     * @return the equivalent array of super-generic standarddized keys.
      */
     public static IFitsHeader[] create(String[] keys) {
         IFitsHeader[] result = new IFitsHeader[keys.length];
@@ -109,16 +82,17 @@ public final class GenericKey {
     }
 
     /**
-     * Returns the number value that appear at the trailing end of a FITS keyword. For example for <code>NAXIS2</code>
-     * it will return 2, while for <code>TFORM17</code> it will return 17. If there keyword does not end with a number,
-     * 0 is returned (FITS keywords are always numbered from 1 and up).
+     * Returns the number value that appear at the trailing end of a FITS
+     * keyword. For example for <code>NAXIS2</code> it will return 2, while for
+     * <code>TFORM17</code> it will return 17. If there keyword does not end
+     * with a number, 0 is returned (FITS keywords are always numbered from 1
+     * and up).
      * 
-     * @param      key The FITS keyword from which to extract the trailing number.
-     * 
-     * @return         the number contained at the end of the keyword or else 0 if the keyword does not end with a
-     *                     number.
-     * 
-     * @deprecated     Use {@link IFitsHeader#extractIndices(String)} instead.
+     * @param key
+     *            The FITS keyword from which to extract the trailing number.
+     * @return the number contained at the end of the keyword or else 0 if the
+     *         keyword does not end with a number.
+     * @deprecated Use {@link IFitsHeader#extractIndices(String)} instead.
      */
     public static int getN(String key) {
         int index = key.length() - 1;
@@ -139,54 +113,17 @@ public final class GenericKey {
     }
 
     /**
-     * Lookup a string key in the standard key sets, resolving indexes and coordinate alternatives as appropriate for
-     * the set of standard FITS keywords. Same as {@link Standard#match(String)}, which is preferred.
-     *
-     * @param  key the fits key to search.
-     *
-     * @return     the found fits key or null
+     * Lookup a string key in the standard key sets, resolving indexes and
+     * coordinate alternatives as appropriate for the set of standard FITS
+     * keywords. Same as {@link Standard#match(String)}, which is preferred.
      * 
-     * @see        Standard#match(String)
+     * @param key
+     *            the fits key to search.
+     * @return the found fits key or null
+     * @deprecated Use {@link Standard#match(String)} instead.
      */
     public static IFitsHeader lookup(String key) {
-        int i = 0, l = key.length();
-        StringBuilder pattern = new StringBuilder();
-
-        // If ends with digit + letter, then it must alt coordinate if standard...
-        if (l > 1 && Character.isAlphabetic(key.charAt(l - 1)) && Character.isDigit(key.charAt(l - 2))) {
-            key = key.substring(0, --l);
-        }
-
-        // If the first digit is a number it may be a coordinate index
-        if (i < l && Character.isDigit(key.charAt(i))) {
-            pattern.append('n');
-            i++;
-
-            // If the second digit is a number it may be a coordinate index
-            if (i < l && Character.isDigit(key.charAt(i))) {
-                pattern.append('n');
-                i++;
-            }
-        }
-
-        // Replace sequence of digits with 'n'
-        while (i < l) {
-            char c = key.charAt(i);
-
-            if (Character.isDigit(c)) {
-                pattern.append('n');
-
-                // Skip successive digits.
-                while (i < l && Character.isDigit(key.charAt(i))) {
-                    i++;
-                }
-            } else {
-                pattern.append(c);
-                i++;
-            }
-        }
-
-        return STANDARD_KEYS.get(pattern.toString());
+        return Standard.match(key);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/header/GenericKey.java
+++ b/src/main/java/nom/tam/fits/header/GenericKey.java
@@ -84,7 +84,7 @@ public final class GenericKey {
      * @deprecated     Use {@link FitsKey#FitsKey(String, VALUE, String)} instead.
      */
     public static IFitsHeader create(String key) {
-        IFitsHeader result = STANDARD_KEYS.get(key);
+        IFitsHeader result = lookup(key);
         if (result == null) {
             result = new FitsKey(key, SOURCE.UNKNOWN, HDU.ANY, VALUE.ANY, "");
         }
@@ -113,9 +113,12 @@ public final class GenericKey {
      * it will return 2, while for <code>TFORM17</code> it will return 17. If there keyword does not end with a number,
      * 0 is returned (FITS keywords are always numbered from 1 and up).
      * 
-     * @param  key The FITS keyword from which to extract the trailing number.
+     * @param      key The FITS keyword from which to extract the trailing number.
      * 
-     * @return     the number contained at the end of the keyword or else 0 if the keyword does not end with a number.
+     * @return         the number contained at the end of the keyword or else 0 if the keyword does not end with a
+     *                     number.
+     * 
+     * @deprecated     Use {@link IFitsHeader#extractIndices(String)} instead.
      */
     public static int getN(String key) {
         int index = key.length() - 1;
@@ -136,11 +139,14 @@ public final class GenericKey {
     }
 
     /**
-     * Lookup a string key in the standard key sets.
+     * Lookup a string key in the standard key sets, resolving indexes and coordinate alternatives as appropriate for
+     * the set of standard FITS keywords. Same as {@link Standard#match(String)}, which is preferred.
      *
      * @param  key the fits key to search.
      *
      * @return     the found fits key or null
+     * 
+     * @see        Standard#match(String)
      */
     public static IFitsHeader lookup(String key) {
         int i = 0, l = key.length();

--- a/src/main/java/nom/tam/fits/header/GenericKey.java
+++ b/src/main/java/nom/tam/fits/header/GenericKey.java
@@ -186,8 +186,6 @@ public final class GenericKey {
             }
         }
 
-        System.err.println("### " + pattern.toString());
-
         return STANDARD_KEYS.get(pattern.toString());
     }
 

--- a/src/main/java/nom/tam/fits/header/HierarchicalGrouping.java
+++ b/src/main/java/nom/tam/fits/header/HierarchicalGrouping.java
@@ -57,14 +57,14 @@ public enum HierarchicalGrouping implements IFitsHeader {
      */
     GRPNAME(SOURCE.HEASARC, HDU.TABLE, VALUE.STRING, "the grouping table name");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     HierarchicalGrouping(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+        key = new FitsKey(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/HierarchicalGrouping.java
+++ b/src/main/java/nom/tam/fits/header/HierarchicalGrouping.java
@@ -57,14 +57,14 @@ public enum HierarchicalGrouping implements IFitsHeader {
      */
     GRPNAME(SOURCE.HEASARC, HDU.TABLE, VALUE.STRING, "the grouping table name");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     HierarchicalGrouping(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -180,7 +180,7 @@ public interface IFitsHeader {
      * 
      * @since  1.19
      */
-    default FitsHeaderImpl impl() {
+    default FitsKey impl() {
         return null;
     }
 
@@ -253,7 +253,7 @@ public interface IFitsHeader {
             throw new IllegalStateException("indexed keyword " + headerName.toString() + " is too long.");
         }
 
-        return new FitsHeaderImpl(headerName.toString(), status(), hdu(), valueType(), comment());
+        return new FitsKey(headerName.toString(), status(), hdu(), valueType(), comment());
     }
 
     /**

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -273,4 +273,56 @@ public interface IFitsHeader {
     default VALUE valueType() {
         return impl().valueType();
     }
+
+    /**
+     * Extracts the indices for this key from an actual keyword. The keyword realization must be for this key, or else
+     * an exception will be thrown.
+     * 
+     * @param  key                      The actual keyword as it appears in a FITS header
+     * 
+     * @return                          An array of indices that appear in the key, or <code>null</code> if the keyword
+     *                                      is not one that can be indexed.
+     * 
+     * @throws IllegalArgumentException if the keyword does not match the pattern of this standardized FITS key
+     * 
+     * @see                             Standard#match(String)
+     * 
+     * @since                           1.19
+     */
+    default int[] extractIndices(String key) throws IllegalArgumentException {
+        String pattern = key();
+        int i, j = 0, lp = pattern.length(), lk = key.length();
+        int n = 0;
+
+        for (i = 0; i < lp; i++) {
+            if (pattern.charAt(i) == 'n') {
+                n++;
+            }
+        }
+
+        if (n == 0) {
+            return null;
+        }
+
+        int[] idx = new int[n];
+
+        for (i = 0, n = 0; i < lp; i++) {
+            if (pattern.charAt(i) == 'n') {
+                if (i + 1 < lp && pattern.charAt(i + 1) == 'n') {
+                    idx[n++] = key.charAt(j++) - '0';
+                } else {
+                    int value = 0;
+                    while (j < lk && Character.isDigit(key.charAt(j))) {
+                        value = FitsKey.BASE_10 * value + key.charAt(j++) - '0';
+                    }
+                    idx[n++] = value;
+                }
+            } else if (key.charAt(j++) != pattern.charAt(i)) {
+                throw new IllegalArgumentException("Key " + key + " does no match pattern " + pattern);
+            }
+        }
+
+        return idx;
+    }
+
 }

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -37,6 +37,9 @@ import nom.tam.fits.HeaderCard;
  * Interface for standardized header keyword implementations. Standardized header keys help with proper usage, with
  * restricted use and value types as appropriate. Using keywords that implement this interface make it less likely for
  * one to end up with inproperly constructed FITS files. Therefore, their usage is highly encouranged when possible.
+ * 
+ * @see HeaderCard#setValueCheckingPolicy(nom.tam.fits.HeaderCard.ValueCheck)
+ * @see nom.tam.fits.Header#setKeywordChecking(nom.tam.fits.Header.KeywordCheck)
  */
 public interface IFitsHeader {
 
@@ -177,7 +180,7 @@ public interface IFitsHeader {
      * 
      * @since  1.19
      */
-    default IFitsHeader impl() {
+    default FitsHeaderImpl impl() {
         return null;
     }
 

--- a/src/main/java/nom/tam/fits/header/InstrumentDescription.java
+++ b/src/main/java/nom/tam/fits/header/InstrumentDescription.java
@@ -99,14 +99,14 @@ public enum InstrumentDescription implements IFitsHeader {
      */
     SATURATE(SOURCE.STScI, HDU.ANY, VALUE.INTEGER, "Data value at which saturation occurs");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     InstrumentDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/InstrumentDescription.java
+++ b/src/main/java/nom/tam/fits/header/InstrumentDescription.java
@@ -99,14 +99,14 @@ public enum InstrumentDescription implements IFitsHeader {
      */
     SATURATE(SOURCE.STScI, HDU.ANY, VALUE.INTEGER, "Data value at which saturation occurs");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     InstrumentDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+        key = new FitsKey(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/NonStandard.java
+++ b/src/main/java/nom/tam/fits/header/NonStandard.java
@@ -80,7 +80,7 @@ public enum NonStandard implements IFitsHeader {
      */
     INHERIT(SOURCE.STScI, HDU.EXTENSION, VALUE.LOGICAL, "denotes the INHERIT keyword convention");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     /**
      * An alternative older value of the XTENSION keword in case of an image.
@@ -97,7 +97,7 @@ public enum NonStandard implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/NonStandard.java
+++ b/src/main/java/nom/tam/fits/header/NonStandard.java
@@ -75,6 +75,8 @@ public enum NonStandard implements IFitsHeader {
      * The presence of this keyword with a value = T in an extension key indicates that the keywords contained in the
      * primary key (except the FITS Mandatory keywords, and any COMMENT, HISTORY or 'blank' keywords) are to be
      * inherited, or logically included in that extension key.
+     * 
+     * @deprecated Part of the FITS standard, use {@link Standard#INHERIT} instead.
      */
     INHERIT(SOURCE.STScI, HDU.EXTENSION, VALUE.LOGICAL, "denotes the INHERIT keyword convention");
 

--- a/src/main/java/nom/tam/fits/header/NonStandard.java
+++ b/src/main/java/nom/tam/fits/header/NonStandard.java
@@ -80,7 +80,7 @@ public enum NonStandard implements IFitsHeader {
      */
     INHERIT(SOURCE.STScI, HDU.EXTENSION, VALUE.LOGICAL, "denotes the INHERIT keyword convention");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     /**
      * An alternative older value of the XTENSION keword in case of an image.
@@ -93,11 +93,11 @@ public enum NonStandard implements IFitsHeader {
     public static final String XTENSION_A3DTABLE = "A3DTABLE";
 
     NonStandard(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+        key = new FitsKey(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/ObservationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDescription.java
@@ -183,14 +183,14 @@ public enum ObservationDescription implements IFitsHeader {
      */
     SUNANGLE(SOURCE.STScI, HDU.ANY, VALUE.REAL, "angle between the observation and the sun");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     ObservationDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/ObservationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDescription.java
@@ -183,14 +183,14 @@ public enum ObservationDescription implements IFitsHeader {
      */
     SUNANGLE(SOURCE.STScI, HDU.ANY, VALUE.REAL, "angle between the observation and the sun");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     ObservationDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(name(), status, hdu, valueType, comment);
+        key = new FitsKey(name(), status, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 }

--- a/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
@@ -124,7 +124,7 @@ public enum ObservationDurationDescription implements IFitsHeader {
      */
     TIME_OBS("TIME-OBS", SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "time at the start of the observation");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     ObservationDurationDescription(SOURCE status, HDU hdu, VALUE valueType, String comment) {
         this(null, status, hdu, valueType, comment);
@@ -135,7 +135,7 @@ public enum ObservationDurationDescription implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
@@ -54,12 +54,14 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * of the observation. These 2 keywords may give either the calendar date using the 'yyyy-mm-dd' format, or may give
      * the full date and time using the 'yyyy-mm-ddThh:mm:ss.sss' format.
      * 
-     * @see DateTime#DATE_END
+     * @deprecated Part of the FITS standard, use {@link DateTime#DATE_END} instead
      */
     DATE_END("DATE-END", SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "date of the end of observation"),
     /**
      * The value field shall contain a floating point number giving the difference between the stop and start times of
      * the observation in units of seconds. This keyword is synonymous with the TELAPSE keyword.
+     * 
+     * @see DateTime#TELAPSE
      */
     ELAPTIME(SOURCE.UCOLICK, HDU.ANY, VALUE.REAL, "elapsed time of the observation"),
     /**
@@ -76,6 +78,8 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * seconds. The exact definition of 'exposure time' is mission dependent and may, for example, include corrections
      * for shutter open and close duration, detector dead time, vignetting, or other effects. This keyword is synonymous
      * with the EXPOSURE keyword.
+     * 
+     * @see DateTime#XPOSURE
      */
     EXPTIME(SOURCE.NOAO, HDU.ANY, VALUE.REAL, "exposure time"),
     /**
@@ -88,13 +92,15 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * The value field shall contain a floating point number giving the total integrated exposure time of the
      * observation in units of seconds. ONTIME may be less than TELAPSE if there were intevals during the observation in
      * which the target was not observed (e.g., the shutter was closed, or the detector power was turned off).
+     * 
+     * @see DateTime#XPOSURE
      */
     ONTIME(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "integration time during the observation"),
     /**
      * The value field shall contain a floating point number giving the difference between the stop and start times of
      * the observation in units of seconds. This keyword is synonymous with the ELAPTIME keyword.
      * 
-     * @see DateTime#TELAPSE
+     * @deprecated Part of the FITS standard, use {@link DateTime#TELAPSE} instead.
      */
     TELAPSE(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "elapsed time of the observation"),
     /**
@@ -103,6 +109,8 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * gives the ending calendar date, with format 'yyyy-mm-dd', and TIME-END gives the time within that day using the
      * format 'hh:mm:ss.sss...'. This keyword should not be used if the time is included directly as part of the
      * DATE-END keyword value with the format 'yyyy-mm-ddThh:mm:ss.sss'.
+     * 
+     * @see DateTime#TSTOP
      */
     TIME_END("TIME-END", SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "time at the end of the observation"),
     /**
@@ -111,6 +119,8 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * the DATE-OBS keyword gives the starting calendar date, with format 'yyyy-mm-dd', and TIME-OBS gives the time
      * within that day using the format 'hh:mm:ss.sss...'. This keyword should not be used if the time is included
      * directly as part of the DATE-OBS keyword value with the format 'yyyy-mm-ddThh:mm:ss.sss'.
+     * 
+     * @see DateTime#TSTART
      */
     TIME_OBS("TIME-OBS", SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "time at the start of the observation");
 

--- a/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
@@ -124,18 +124,18 @@ public enum ObservationDurationDescription implements IFitsHeader {
      */
     TIME_OBS("TIME-OBS", SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "time at the start of the observation");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     ObservationDurationDescription(SOURCE status, HDU hdu, VALUE valueType, String comment) {
         this(null, status, hdu, valueType, comment);
     }
 
     ObservationDurationDescription(String key, SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        this.key = new FitsHeaderImpl(key == null ? name() : key, status, hdu, valueType, comment);
+        this.key = new FitsKey(key == null ? name() : key, status, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -651,7 +651,7 @@ public enum Standard implements IFitsHeader {
             StandardCommentReplacement... replacements) {
         key = new FitsKey(headerName == null ? name() : headerName, status, hdu, valueType, comment);
         commentReplacements = replacements;
-        FitsKey.registerStandard(headerName, this);
+        FitsKey.registerStandard(this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -641,7 +641,7 @@ public enum Standard implements IFitsHeader {
 
     private final StandardCommentReplacement[] commentReplacements;
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     Standard(SOURCE status, HDU hdu, VALUE valueType, String comment, StandardCommentReplacement... replacements) {
         this(null, status, hdu, valueType, comment, replacements);
@@ -649,12 +649,12 @@ public enum Standard implements IFitsHeader {
 
     Standard(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment,
             StandardCommentReplacement... replacements) {
-        key = new FitsHeaderImpl(headerName == null ? name() : headerName, status, hdu, valueType, comment);
+        key = new FitsKey(headerName == null ? name() : headerName, status, hdu, valueType, comment);
         commentReplacements = replacements;
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -641,7 +641,7 @@ public enum Standard implements IFitsHeader {
 
     private final StandardCommentReplacement[] commentReplacements;
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     Standard(SOURCE status, HDU hdu, VALUE valueType, String comment, StandardCommentReplacement... replacements) {
         this(null, status, hdu, valueType, comment, replacements);
@@ -654,7 +654,7 @@ public enum Standard implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -143,7 +143,7 @@ public enum Standard implements IFitsHeader {
      * string value may be continued on any number of consecutive CONTINUE keywords, thus effectively allowing
      * arbitrarily long strings to be written as keyword values.
      */
-    CONTINUE(SOURCE.HEASARC, HDU.ANY, VALUE.NONE, "denotes the CONTINUE long string keyword convention"),
+    CONTINUE(SOURCE.RESERVED, HDU.ANY, VALUE.NONE, "denotes the CONTINUE long string keyword convention"),
 
     /**
      * This keyword is used to indicate a rotation from a standard coordinate system described by the CTYPEn to a
@@ -562,7 +562,7 @@ public enum Standard implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TDMAXn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "maximum value in the column"),
+    TDMAXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "maximum value in the column"),
 
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the minimum valid
@@ -571,7 +571,7 @@ public enum Standard implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TDMINn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "minimum value in the column"),
+    TDMINn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "minimum value in the column"),
 
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the upper bound of the
@@ -582,7 +582,7 @@ public enum Standard implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TLMAXn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "maximum legal value in the column"),
+    TLMAXn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "maximum legal value in the column"),
 
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the lower bound of the
@@ -593,7 +593,7 @@ public enum Standard implements IFitsHeader {
      * 
      * @since 1.19
      */
-    TLMINn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "minimum legal value in the column"),
+    TLMINn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "minimum legal value in the column"),
 
     /**
      * The value field shall contain a character string giving the name of the extension type. This keyword is mandatory

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -725,4 +725,20 @@ public enum Standard implements IFitsHeader {
     private static StandardCommentReplacement replaceable(String string, Class<?> clazz, String comment) {
         return new StandardCommentReplacement(string, clazz, comment);
     }
+
+    /**
+     * Returns the standard FITS keyword that matches the specified actual key.
+     * 
+     * @param  key The key as it may appear in a FITS header, e.g. "CTYPE1"
+     * 
+     * @return     The standard FITS keyword/pattern that matches, e.g. {@link Standard#CTYPEn}.
+     * 
+     * @see        IFitsHeader#extractIndices(String)
+     * 
+     * @since      1.19
+     */
+    public static IFitsHeader match(String key) {
+        return GenericKey.lookup(key);
+    }
+
 }

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -1,5 +1,9 @@
 package nom.tam.fits.header;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import nom.tam.fits.AsciiTable;
 import nom.tam.fits.BasicHDU;
 import nom.tam.fits.BinaryTable;
@@ -610,6 +614,31 @@ public enum Standard implements IFitsHeader {
      */
     INHERIT(SOURCE.RESERVED, HDU.EXTENSION, VALUE.LOGICAL, "Inherit primary header entries");
 
+    /**
+     * cache of all standard keys, for reusing the standards.
+     */
+    private static final Map<String, IFitsHeader> STANDARD_KEYS;
+
+    static {
+        Map<String, IFitsHeader> headers = new HashMap<>();
+        for (IFitsHeader key : Standard.values()) {
+            headers.put(key.key(), key);
+        }
+        for (IFitsHeader key : DateTime.values()) {
+            headers.put(key.key(), key);
+        }
+        for (IFitsHeader key : WCS.values()) {
+            headers.put(key.key(), key);
+        }
+        for (IFitsHeader key : Checksum.values()) {
+            headers.put(key.key(), key);
+        }
+        for (IFitsHeader key : Compression.values()) {
+            headers.put(key.key(), key);
+        }
+        STANDARD_KEYS = Collections.unmodifiableMap(headers);
+    }
+
     private static final ThreadLocal<Class<?>> COMMENT_CONTEXT = new ThreadLocal<>();
 
     /**
@@ -738,7 +767,44 @@ public enum Standard implements IFitsHeader {
      * @since      1.19
      */
     public static IFitsHeader match(String key) {
-        return GenericKey.lookup(key);
+        int i = 0, l = key.length();
+        StringBuilder pattern = new StringBuilder();
+
+        // If ends with digit + letter, then it must alt coordinate if standard...
+        if (l > 1 && Character.isAlphabetic(key.charAt(l - 1)) && Character.isDigit(key.charAt(l - 2))) {
+            key = key.substring(0, --l);
+        }
+
+        // If the first digit is a number it may be a coordinate index
+        if (i < l && Character.isDigit(key.charAt(i))) {
+            pattern.append('n');
+            i++;
+
+            // If the second digit is a number it may be a coordinate index
+            if (i < l && Character.isDigit(key.charAt(i))) {
+                pattern.append('n');
+                i++;
+            }
+        }
+
+        // Replace sequence of digits with 'n'
+        while (i < l) {
+            char c = key.charAt(i);
+
+            if (Character.isDigit(c)) {
+                pattern.append('n');
+
+                // Skip successive digits.
+                while (i < l && Character.isDigit(key.charAt(i))) {
+                    i++;
+                }
+            } else {
+                pattern.append(c);
+                i++;
+            }
+        }
+
+        return STANDARD_KEYS.get(pattern.toString());
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -76,7 +76,7 @@ public enum Standard implements IFitsHeader {
      * Columns 1-8 contain ASCII blanks. This keyword has no associated value. Columns 9-80 may contain any ASCII text.
      * Any number of card images with blank keyword fields may appear in a key.
      */
-    BLANKS("        ", SOURCE.RESERVED, HDU.ANY, VALUE.NONE, null),
+    BLANKS("", SOURCE.RESERVED, HDU.ANY, VALUE.NONE, null),
 
     /**
      * This keyword may be used only in the primary key. It shall appear within the first 36 card images of the FITS

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -129,6 +129,24 @@ public enum Synonyms {
      */
     EXTLEVEL(Standard.EXTLEVEL, DataDescription.HDULEVEL),
 
+    /**
+     * [s] Non-standard exposure time conventions.
+     * 
+     * @see DateTime#XPOSURE
+     */
+    EXPOSURE(ObservationDurationDescription.EXPOSURE, ObservationDurationDescription.EXPTIME,
+            ObservationDurationDescription.ONTIME),
+
+    /**
+     * Variants for recording the start time of observation in HH:MM:SS[.s...] format
+     */
+    TSTART(DateTime.TSTART, ObservationDurationDescription.TIME_OBS),
+
+    /**
+     * Variants for recording the ending time of observation in HH:MM:SS[.s...] format
+     */
+    TSTOP(DateTime.TSTOP, ObservationDurationDescription.TIME_END),
+
     /** DARKTIME appears in multiple conventions */
     DARKTIME(NOAOExt.DARKTIME, SBFitsExt.DARKTIME);
 

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -181,22 +181,22 @@ public enum Synonyms {
      * Returns the primary or preferred FITS header keyword to prefer for the given header entry to provide this
      * information in a FITS header.
      * 
-     * @param  header the standard or conventional header keyword.
+     * @param  key the standard or conventional header keyword.
      * 
      * @return        the primary (or preferred) FITS header keyword form to use
      * 
      * @see           #primaryKeyword(String)
      * @see           #primaryKeyword()
      */
-    public static IFitsHeader primaryKeyword(IFitsHeader header) {
+    public static IFitsHeader primaryKeyword(IFitsHeader key) {
         for (Synonyms synonym : values()) {
             for (IFitsHeader synHeader : synonym.synonyms) {
-                if (synHeader.equals(header)) {
+                if (synHeader.equals(key)) {
                     return synonym.primaryKeyword();
                 }
             }
         }
-        return header;
+        return key;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -938,18 +938,18 @@ public enum WCS implements IFitsHeader {
      */
     public static final String SPECTRAL_ALGO_A2V = "A2V";
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     WCS(SOURCE status, HDU hdu, VALUE valueType, String comment) {
         this(null, status, hdu, valueType, comment);
     }
 
     WCS(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
-        key = new FitsHeaderImpl(headerName == null ? name() : headerName, status, hdu, valueType, comment);
+        key = new FitsKey(headerName == null ? name() : headerName, status, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 
@@ -980,7 +980,7 @@ public enum WCS implements IFitsHeader {
             throw new IllegalArgumentException("Expected 'A' through 'Z': Got '%c'");
         }
 
-        return new FitsHeaderImpl(key() + Character.toUpperCase(c), status(), hdu(), valueType(), comment());
+        return new FitsKey(key() + Character.toUpperCase(c), status(), hdu(), valueType(), comment());
     }
 
 }

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -949,7 +949,7 @@ public enum WCS implements IFitsHeader {
 
     WCS(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsKey(headerName == null ? name() : headerName, status, hdu, valueType, comment);
-        FitsKey.registerStandard(headerName, this);
+        FitsKey.registerStandard(this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -949,6 +949,7 @@ public enum WCS implements IFitsHeader {
 
     WCS(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) {
         key = new FitsKey(headerName == null ? name() : headerName, status, hdu, valueType, comment);
+        FitsKey.registerStandard(headerName, this);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -938,7 +938,7 @@ public enum WCS implements IFitsHeader {
      */
     public static final String SPECTRAL_ALGO_A2V = "A2V";
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     WCS(SOURCE status, HDU hdu, VALUE valueType, String comment) {
         this(null, status, hdu, valueType, comment);
@@ -949,7 +949,7 @@ public enum WCS implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -844,6 +844,9 @@ public enum WCS implements IFitsHeader {
     TVn_na(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column pixel axis parameter value");
 
     /** ICRS coordinate reference frame */
+    public static final int WCSAXES_MAX_VALUE = 9;
+
+    /** ICRS coordinate reference frame */
     public static final String RADESYS_ICRS = "ICRS";
 
     /** IAU 1984 FK5 coordinate reference frame */

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -31,7 +31,7 @@ package nom.tam.fits.header.extra;
  * #L%
  */
 
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
@@ -174,14 +174,14 @@ public enum CXCExt implements IFitsHeader {
      */
     TSTOP("add TIMEZERO and MJDREF for absolute TT");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     CXCExt(String comment) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
+        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -174,14 +174,14 @@ public enum CXCExt implements IFitsHeader {
      */
     TSTOP("add TIMEZERO and MJDREF for absolute TT");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     CXCExt(String comment) {
         key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -87,14 +87,14 @@ public enum CXCStclSharedExt implements IFitsHeader {
      */
     TSTOP("add TIMEZERO and MJDREF for absolute TT");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     CXCStclSharedExt(String comment) {
         key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -31,7 +31,7 @@ package nom.tam.fits.header.extra;
  * #L%
  */
 
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
@@ -87,14 +87,14 @@ public enum CXCStclSharedExt implements IFitsHeader {
      */
     TSTOP("add TIMEZERO and MJDREF for absolute TT");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     CXCStclSharedExt(String comment) {
-        key = new FitsHeaderImpl(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
+        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -219,7 +219,7 @@ public enum MaxImDLExt implements IFitsHeader {
      */
     YBAYROFF(VALUE.REAL, "Y offset of Bayer array");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     MaxImDLExt(String key, VALUE valueType, String comment) {
         this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType,
@@ -231,7 +231,7 @@ public enum MaxImDLExt implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -31,7 +31,7 @@ package nom.tam.fits.header.extra;
  * #L%
  */
 
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
@@ -219,10 +219,10 @@ public enum MaxImDLExt implements IFitsHeader {
      */
     YBAYROFF(VALUE.REAL, "Y offset of Bayer array");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     MaxImDLExt(String key, VALUE valueType, String comment) {
-        this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType,
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType,
                 comment);
     }
 
@@ -231,7 +231,7 @@ public enum MaxImDLExt implements IFitsHeader {
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
@@ -7944,7 +7944,7 @@ public enum NOAOExt implements IFitsHeader {
      */
     MJD_OBS("MJD-OBS", HDU.ANY, VALUE.REAL, "MJD of exposure start");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     NOAOExt(HDU hdu, VALUE valueType, String comment) {
         this(null, hdu, valueType, comment);
@@ -7955,7 +7955,7 @@ public enum NOAOExt implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
@@ -31,7 +31,7 @@ package nom.tam.fits.header.extra;
  * #L%
  */
 
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
@@ -7944,18 +7944,18 @@ public enum NOAOExt implements IFitsHeader {
      */
     MJD_OBS("MJD-OBS", HDU.ANY, VALUE.REAL, "MJD of exposure start");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     NOAOExt(HDU hdu, VALUE valueType, String comment) {
         this(null, hdu, valueType, comment);
     }
 
     NOAOExt(String key, HDU hdu, VALUE valueType, String comment) {
-        this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.NOAO, hdu, valueType, comment);
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.NOAO, hdu, valueType, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -31,7 +31,7 @@ package nom.tam.fits.header.extra;
  * #L%
  */
 
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
@@ -193,10 +193,10 @@ public enum SBFitsExt implements IFitsHeader {
      */
     YPIXSZ(VALUE.REAL, "Pixel height in microns");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     SBFitsExt(String key, VALUE valueType, String comment) {
-        this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.SBIG, HDU.IMAGE, valueType, comment);
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.SBIG, HDU.IMAGE, valueType, comment);
     }
 
     SBFitsExt(VALUE valueType, String comment) {
@@ -204,7 +204,7 @@ public enum SBFitsExt implements IFitsHeader {
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -193,7 +193,7 @@ public enum SBFitsExt implements IFitsHeader {
      */
     YPIXSZ(VALUE.REAL, "Pixel height in microns");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     SBFitsExt(String key, VALUE valueType, String comment) {
         this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.SBIG, HDU.IMAGE, valueType, comment);
@@ -204,7 +204,7 @@ public enum SBFitsExt implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -214,7 +214,7 @@ public enum STScIExt implements IFitsHeader {
      */
     MJD_OBS("MJD-OBS", "MJD of exposure start");
 
-    private final IFitsHeader key;
+    private final FitsHeaderImpl key;
 
     STScIExt(String comment) {
         this(null, comment);
@@ -225,7 +225,7 @@ public enum STScIExt implements IFitsHeader {
     }
 
     @Override
-    public final IFitsHeader impl() {
+    public final FitsHeaderImpl impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -31,7 +31,7 @@ package nom.tam.fits.header.extra;
  * #L%
  */
 
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
@@ -214,18 +214,18 @@ public enum STScIExt implements IFitsHeader {
      */
     MJD_OBS("MJD-OBS", "MJD of exposure start");
 
-    private final FitsHeaderImpl key;
+    private final FitsKey key;
 
     STScIExt(String comment) {
         this(null, comment);
     }
 
     STScIExt(String key, String comment) {
-        this.key = new FitsHeaderImpl(key == null ? name() : key, IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
     }
 
     @Override
-    public final FitsHeaderImpl impl() {
+    public final FitsKey impl() {
         return key;
     }
 

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -75,7 +75,9 @@ public enum STScIExt implements IFitsHeader {
      */
     FOV_Y_MM("Detector Y field of view (mm)"),
     /**
-     * BITS/PIXEL OF IPPS RASTER.
+     * BITS/PIXEL OF IPPS RASTER. In truth this is an illegal FITS keyword, as the character '/' should not be allowed
+     * in standard FITS keywords. If possible, avoid using it since it may result in FITS that is not readable by some
+     * software.
      */
     IPPS_B_P("IPPS-B/P", "BITS/PIXEL OF IPPS RASTER."),
     /**

--- a/src/main/java/nom/tam/fits/header/package-info.java
+++ b/src/main/java/nom/tam/fits/header/package-info.java
@@ -49,7 +49,7 @@
  *   source: [http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html](http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html)  |
  * </pre>
  * <p>
- * There are synonymous keywords within these dictionaries, These we also started to collect in the {@link Synonyms}
+ * There are synonymous keywords within these dictionaries, These we also started to collect in the {@link nom.tam.fits.header.Synonyms}
  * class in the header package.
  * </p>
  * <p>

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -420,7 +420,7 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
             int zBitPix = header.getIntValue(ZBITPIX);
             ElementType<Buffer> elementType = ElementType.forNearestBitpix(zBitPix);
             if (elementType == ElementType.UNKNOWN) {
-                throw new IllegalArgumentException("illegal value for ZBITPIX " + zBitPix);
+                throw new IllegalArgumentException("Illegal value for ZBITPIX: " + zBitPix);
             }
             setBaseType(elementType);
         }

--- a/src/main/java/nom/tam/image/compression/tile/mask/ImageNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/ImageNullPixelMask.java
@@ -65,6 +65,7 @@ public class ImageNullPixelMask {
         return add(new NullPixelMaskRestorer(tileBuffer, tileIndex, nullValue, compressorControl));
     }
 
+    @SuppressWarnings("deprecation")
     public byte[][] getColumn() {
         byte[][] column = new byte[nullPixelMasks.length][];
         for (AbstractNullPixelMask tileMask : nullPixelMasks) {

--- a/src/main/java/nom/tam/util/HashedList.java
+++ b/src/main/java/nom/tam/util/HashedList.java
@@ -57,7 +57,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 
 /**
  * An ordered hash map implementation.
@@ -194,7 +194,7 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
      */
     private void add(int pos, VALUE entry) {
         String key = entry.getKey();
-        if (keyed.containsKey(key) && !FitsHeaderImpl.isCommentStyleKey(key)) {
+        if (keyed.containsKey(key) && !FitsKey.isCommentStyleKey(key)) {
             int oldPos = indexOf(entry);
             internalRemove(oldPos, entry);
             if (oldPos < pos) {
@@ -239,7 +239,7 @@ public class HashedList<VALUE extends CursorValue<String>> implements Collection
      * @param entry The element to add to the list.
      */
     public void update(String key, VALUE entry) {
-        if (keyed.containsKey(key) && !FitsHeaderImpl.isCommentStyleKey(key)) {
+        if (keyed.containsKey(key) && !FitsKey.isCommentStyleKey(key)) {
             int index = indexOf(get(key));
             remove(index);
             add(index, entry);

--- a/src/main/java/nom/tam/util/array/MultiArrayCopyFactory.java
+++ b/src/main/java/nom/tam/util/array/MultiArrayCopyFactory.java
@@ -481,7 +481,7 @@ public class MultiArrayCopyFactory<Source, Destination> {
         Map<Class<?>, Map<Class<?>, MultiArrayCopyFactory<?, ?>>> factories = new HashMap<>();
 
         Map<Class<?>, MultiArrayCopyFactory<byte[], ?>> byteMap = new HashMap<>();
-        byteMap.put(byte.class, new MultiArrayCopyFactory<byte[], byte[]>());
+        byteMap.put(byte.class, new MultiArrayCopyFactory<>());
         byteMap.put(char.class, new ByteToChar());
         byteMap.put(short.class, new ByteToShort());
         byteMap.put(int.class, new ByteToInt());
@@ -492,7 +492,7 @@ public class MultiArrayCopyFactory<Source, Destination> {
 
         Map<Class<?>, MultiArrayCopyFactory<char[], ?>> charMap = new HashMap<>();
         charMap.put(byte.class, new CharToByte());
-        charMap.put(char.class, new MultiArrayCopyFactory<char[], char[]>());
+        charMap.put(char.class, new MultiArrayCopyFactory<>());
         charMap.put(short.class, new CharToShort());
         charMap.put(int.class, new CharToInt());
         charMap.put(long.class, new CharToLong());
@@ -503,7 +503,7 @@ public class MultiArrayCopyFactory<Source, Destination> {
         Map<Class<?>, MultiArrayCopyFactory<short[], ?>> shortMap = new HashMap<>();
         shortMap.put(byte.class, new ShortToByte());
         shortMap.put(char.class, new ShortToChar());
-        shortMap.put(short.class, new MultiArrayCopyFactory<short[], short[]>());
+        shortMap.put(short.class, new MultiArrayCopyFactory<>());
         shortMap.put(int.class, new ShortToInt());
         shortMap.put(long.class, new ShortToLong());
         shortMap.put(float.class, new ShortToFloat());
@@ -514,7 +514,7 @@ public class MultiArrayCopyFactory<Source, Destination> {
         intMap.put(byte.class, new IntToByte());
         intMap.put(char.class, new IntToChar());
         intMap.put(short.class, new IntToShort());
-        intMap.put(int.class, new MultiArrayCopyFactory<int[], int[]>());
+        intMap.put(int.class, new MultiArrayCopyFactory<>());
         intMap.put(long.class, new IntToLong());
         intMap.put(float.class, new IntToFloat());
         intMap.put(double.class, new IntToDouble());
@@ -525,7 +525,7 @@ public class MultiArrayCopyFactory<Source, Destination> {
         longMap.put(char.class, new LongToChar());
         longMap.put(short.class, new LongToShort());
         longMap.put(int.class, new LongToInt());
-        longMap.put(long.class, new MultiArrayCopyFactory<long[], long[]>());
+        longMap.put(long.class, new MultiArrayCopyFactory<>());
         longMap.put(float.class, new LongToFloat());
         longMap.put(double.class, new LongToDouble());
         factories.put(long.class, Collections.unmodifiableMap(longMap));
@@ -536,7 +536,7 @@ public class MultiArrayCopyFactory<Source, Destination> {
         floatMap.put(short.class, new FloatToShort());
         floatMap.put(int.class, new FloatToInt());
         floatMap.put(long.class, new FloatToLong());
-        floatMap.put(float.class, new MultiArrayCopyFactory<float[], float[]>());
+        floatMap.put(float.class, new MultiArrayCopyFactory<>());
         floatMap.put(double.class, new FloatToDouble());
         factories.put(float.class, Collections.unmodifiableMap(floatMap));
 
@@ -547,7 +547,7 @@ public class MultiArrayCopyFactory<Source, Destination> {
         doubleMap.put(int.class, new DoubleToInt());
         doubleMap.put(long.class, new DoubleToLong());
         doubleMap.put(float.class, new DoubleToFloat());
-        doubleMap.put(double.class, new MultiArrayCopyFactory<double[], double[]>());
+        doubleMap.put(double.class, new MultiArrayCopyFactory<>());
         factories.put(double.class, Collections.unmodifiableMap(doubleMap));
 
         FACTORIES = Collections.unmodifiableMap(factories);

--- a/src/test/java/nom/tam/fits/DeprecatedTest.java
+++ b/src/test/java/nom/tam/fits/DeprecatedTest.java
@@ -33,6 +33,11 @@ package nom.tam.fits;
 
 import org.junit.Test;
 
+import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.IFitsHeader.HDU;
+import nom.tam.fits.header.IFitsHeader.SOURCE;
+import nom.tam.fits.header.IFitsHeader.VALUE;
+
 @SuppressWarnings("deprecation")
 public class DeprecatedTest {
 
@@ -41,5 +46,10 @@ public class DeprecatedTest {
         FitsFactory.setAllowHeaderRepairs(false);
         Header h = new Header();
         h.setBitpix(20);
+    }
+
+    @Test
+    public void testFitsHeaderImpl() throws Exception {
+        new FitsHeaderImpl("BLAH", SOURCE.UNKNOWN, HDU.ANY, VALUE.ANY, "blah");
     }
 }

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -6,7 +6,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import nom.tam.fits.header.DateTime;
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.IFitsHeader.HDU;
@@ -175,7 +175,7 @@ public class HeaderProtectedTest {
 
     @Test
     public void testIFitsHeaderSelfImpl() {
-        IFitsHeader key = new FitsHeaderImpl("BLAH", SOURCE.UNKNOWN, HDU.ANY, VALUE.ANY, "for testing only");
+        IFitsHeader key = new FitsKey("BLAH", SOURCE.UNKNOWN, HDU.ANY, VALUE.ANY, "for testing only");
         Assert.assertNotNull(key.impl());
     }
 

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1776,4 +1776,11 @@ public class HeaderTest {
         h.addValue(NOAOExt.ADCMJD, 0.0);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testReplaceCommentKeyException() throws Exception {
+        Header h = new Header();
+        h.insertComment("blah");
+        h.replaceKey(Standard.COMMENT, Standard.BLANKS);
+    }
+
 }

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -235,6 +235,8 @@ public class EnumHeaderTest {
         assertEquals(WCS.nCDEna, Standard.match("1CDE100"));
         assertEquals(WCS.nSn_na, Standard.match("1S100_1"));
         assertEquals(WCS.nnCDna, Standard.match("12CD100"));
+
+        assertEquals(Standard.SIMPLE, GenericKey.lookup("SIMPLE"));
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -213,16 +213,49 @@ public class EnumHeaderTest {
 
     @Test
     public void testLookups() {
-        assertEquals(WCS.nCDEna, GenericKey.lookup("1CDE100A"));
-        assertEquals(WCS.nSn_na, GenericKey.lookup("1S100_1A"));
-        assertEquals(WCS.nnCDna, GenericKey.lookup("12CD100A"));
+        Assert.assertNull(Standard.match("BLAH"));
 
-        assertEquals(WCS.nCDEna, GenericKey.lookup("1CDE100Z"));
-        assertEquals(WCS.nSn_na, GenericKey.lookup("1S100_1Z"));
-        assertEquals(WCS.nnCDna, GenericKey.lookup("12CD100Z"));
+        assertEquals(Standard.SIMPLE, Standard.match("SIMPLE"));
 
-        assertEquals(WCS.nCDEna, GenericKey.lookup("1CDE100"));
-        assertEquals(WCS.nSn_na, GenericKey.lookup("1S100_1"));
-        assertEquals(WCS.nnCDna, GenericKey.lookup("12CD100"));
+        assertEquals(WCS.CTYPEna, Standard.match("CTYPE1"));
+        assertEquals(WCS.CTYPEna, Standard.match("CTYPE1A"));
+        assertEquals(WCS.CTYPEna, Standard.match("CTYPE1Z"));
+
+        assertEquals(WCS.nCDEna, Standard.match("1CDE100A"));
+        assertEquals(WCS.nSn_na, Standard.match("1S100_1A"));
+        assertEquals(WCS.nnCDna, Standard.match("12CD100A"));
+
+        assertEquals(WCS.nCDEna, Standard.match("1CDE100Z"));
+        assertEquals(WCS.nSn_na, Standard.match("1S100_1Z"));
+        assertEquals(WCS.nnCDna, Standard.match("12CD100Z"));
+
+        assertEquals(WCS.nCDEna, Standard.match("1CDE100"));
+        assertEquals(WCS.nSn_na, Standard.match("1S100_1"));
+        assertEquals(WCS.nnCDna, Standard.match("12CD100"));
+    }
+
+    @Test
+    public void testResolveIndices() {
+        Assert.assertNull(Standard.SIMPLE.extractIndices("SIMPLE"));
+
+        Assert.assertArrayEquals(new int[] {1}, WCS.CTYPEna.extractIndices("CTYPE1"));
+        Assert.assertArrayEquals(new int[] {1}, WCS.CTYPEna.extractIndices("CTYPE1A"));
+
+        Assert.assertArrayEquals(new int[] {1, 100}, WCS.nCDEna.extractIndices("1CDE100A"));
+        Assert.assertArrayEquals(new int[] {1, 100, 1}, WCS.nSn_na.extractIndices("1S100_1A"));
+        Assert.assertArrayEquals(new int[] {1, 2, 100}, WCS.nnCDna.extractIndices("12CD100A"));
+
+        Assert.assertArrayEquals(new int[] {1, 100}, WCS.nCDEna.extractIndices("1CDE100Z"));
+        Assert.assertArrayEquals(new int[] {1, 100, 1}, WCS.nSn_na.extractIndices("1S100_1Z"));
+        Assert.assertArrayEquals(new int[] {1, 2, 100}, WCS.nnCDna.extractIndices("12CD100Z"));
+
+        Assert.assertArrayEquals(new int[] {1, 100}, WCS.nCDEna.extractIndices("1CDE100"));
+        Assert.assertArrayEquals(new int[] {1, 100, 1}, WCS.nSn_na.extractIndices("1S100_1"));
+        Assert.assertArrayEquals(new int[] {1, 2, 100}, WCS.nnCDna.extractIndices("12CD100"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveIndicesException() throws Exception {
+        WCS.CTYPEna.extractIndices("CRPIX1");
     }
 }

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -257,6 +257,21 @@ public class EnumHeaderTest {
         Assert.assertArrayEquals(new int[] {1, 2, 100}, WCS.nnCDna.extractIndices("12CD100"));
     }
 
+    @Test
+    public void testGetN() {
+        assertEquals(1, GenericKey.getN("1"));
+        assertEquals(1, GenericKey.getN("A1"));
+
+        assertEquals(11, GenericKey.getN("11"));
+        assertEquals(11, GenericKey.getN("A11"));
+
+        assertEquals(1, GenericKey.getN("1A"));
+        assertEquals(1, GenericKey.getN("A1A"));
+
+        assertEquals(0, GenericKey.getN("1AA"));
+        assertEquals(0, GenericKey.getN("A1AA"));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testResolveIndicesException() throws Exception {
         WCS.CTYPEna.extractIndices("CRPIX1");

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -29,6 +29,7 @@ import nom.tam.fits.header.ObservationDescription;
 import nom.tam.fits.header.ObservationDurationDescription;
 import nom.tam.fits.header.Standard;
 import nom.tam.fits.header.Synonyms;
+import nom.tam.fits.header.WCS;
 import nom.tam.fits.header.extra.CXCExt;
 import nom.tam.fits.header.extra.CXCStclSharedExt;
 import nom.tam.fits.header.extra.MaxImDLExt;
@@ -208,5 +209,20 @@ public class EnumHeaderTest {
         assertSame(IFitsHeader.SOURCE.UNKNOWN, IFitsHeader.SOURCE.valueOf(IFitsHeader.SOURCE.UNKNOWN.name()));
         assertEquals(7, IFitsHeader.VALUE.values().length);
         assertSame(IFitsHeader.VALUE.ANY, IFitsHeader.VALUE.valueOf(IFitsHeader.VALUE.ANY.name()));
+    }
+
+    @Test
+    public void testLookups() {
+        assertEquals(WCS.nCDEna, GenericKey.lookup("1CDE100A"));
+        assertEquals(WCS.nSn_na, GenericKey.lookup("1S100_1A"));
+        assertEquals(WCS.nnCDna, GenericKey.lookup("12CD100A"));
+
+        assertEquals(WCS.nCDEna, GenericKey.lookup("1CDE100Z"));
+        assertEquals(WCS.nSn_na, GenericKey.lookup("1S100_1Z"));
+        assertEquals(WCS.nnCDna, GenericKey.lookup("12CD100Z"));
+
+        assertEquals(WCS.nCDEna, GenericKey.lookup("1CDE100"));
+        assertEquals(WCS.nSn_na, GenericKey.lookup("1S100_1"));
+        assertEquals(WCS.nnCDna, GenericKey.lookup("12CD100"));
     }
 }

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -23,6 +23,8 @@ import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.HierarchicalGrouping;
 import nom.tam.fits.header.IFitsHeader;
+import nom.tam.fits.header.IFitsHeader.HDU;
+import nom.tam.fits.header.IFitsHeader.VALUE;
 import nom.tam.fits.header.InstrumentDescription;
 import nom.tam.fits.header.NonStandard;
 import nom.tam.fits.header.ObservationDescription;
@@ -214,6 +216,7 @@ public class EnumHeaderTest {
     @Test
     public void testLookups() {
         Assert.assertNull(Standard.match("BLAH"));
+        Assert.assertNull(Standard.match("1"));
 
         assertEquals(Standard.SIMPLE, Standard.match("SIMPLE"));
 
@@ -258,4 +261,26 @@ public class EnumHeaderTest {
     public void testResolveIndicesException() throws Exception {
         WCS.CTYPEna.extractIndices("CRPIX1");
     }
+
+    @Test
+    public void testFitsKeyConstructors() {
+        assertEquals("AZ_1-3n", new FitsKey("AZ_1-3na", HDU.ANY, VALUE.ANY, "blah").key());
+        assertEquals("AZ_1-3n", new FitsKey("AZ_1-3na", VALUE.ANY, "blah").key());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFitsKeyConstructorLongException() {
+        new FitsKey("AZ_100-300na", VALUE.ANY, "blah");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFitsKeyConstructorIllegalAltException() {
+        new FitsKey("AZ_1-3an", VALUE.ANY, "blah");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFitsKeyConstructorIllegalCharacterException() {
+        new FitsKey("AZ_1-3nb", VALUE.ANY, "blah");
+    }
+
 }

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -19,7 +19,7 @@ import nom.tam.fits.Header;
 import nom.tam.fits.header.Checksum;
 import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.DataDescription;
-import nom.tam.fits.header.FitsHeaderImpl;
+import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.HierarchicalGrouping;
 import nom.tam.fits.header.IFitsHeader;
@@ -190,7 +190,7 @@ public class EnumHeaderTest {
         IFitsHeader[] result = GenericKey.create(new String[] {"BITPIX", "SIMPLE", "UNKOWN"});
         assertSame(Standard.BITPIX, result[0]);
         assertSame(Standard.SIMPLE, result[1]);
-        assertTrue(result[2] instanceof FitsHeaderImpl);
+        assertTrue(result[2] instanceof FitsKey);
     }
 
     @Test


### PR DESCRIPTION
- Corrections to keyword sources, deprecations, synonyms, and javadoc updates.
- New `FitsKey` class to replace poorly named `FitsHeaderImpl`. (The latter continues to be available also for compatibility).
- Change `IFitsHeader.impl()` return `FitsKey` type.
- `FitsKey.extractIndices(String)` to extract all the expected indices from an actual keyword according to the pattern of the keyword definition.
- `FitsKey(...)` constructors to validate keywords and throw an `IllegalArgumentException` if the keyword does not conform to the FITS naming standard (with some further allowances for our template naming conventions).
- New `Standard.match(String)` for more intuitive matching of keyword forms to keyword definitions of the FITS standard.
- Also clean up various warnings across the library
