### PR TITLE
1.19.0 release composition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
             <exclude>**/FitsReader.java</exclude>
             <exclude>**/Main.java</exclude>
             <exclude>**/FitsLineAppender.java</exclude>
-            <exclude>**/FitsSubsctring.java</exclude>
+            <exclude>**/FitsSubstring.java</exclude>
             <exclude>**/AsciiTableData.java</exclude>
             <exclude>**/HeaderCommentsMap.java</exclude>
             <exclude>**/HeaderCardCountingArrayDataInput</exclude>
@@ -786,65 +786,12 @@
               <failOnError>false</failOnError>
               <aggregate>false</aggregate>
               <doctitle>
-                ${project.name} ${project.version} Public User API
+                ${project.name} ${project.version} Complete User API
               </doctitle>
               <windowtitle>
-                ${project.name} ${project.version} Public User API
+                ${project.name} ${project.version} Complete User API
               </windowtitle>
               <show>public</show>
-              <excludePackageNames>
-                nom.tam.fits.compress:
-                nom.tam.fits.compression.algorithm.gzip:
-                nom.tam.fits.compression.algorithm.gzip2:
-                nom.tam.fits.compression.algorithm.plio:
-                nom.tam.fits.compression.algorithm.uncompressed:
-                nom.tam.fits.compression.provider:
-                nom.tam.fits.compression.provider.param.*:
-                nom.tam.image.compression.bintable:
-                nom.tam.image.compression.tile:
-                nom.tam.image.compression.tile.mask:
-                nom.tam.image.tile.*
-              </excludePackageNames>
-              <sourceFileExcludes>
-                <exclude>**/CompressionLibLoaderProtection.java</exclude>
-                <exclude>**/CloseIS.java</exclude>
-                <exclude>**/ICompressor*.java</exclude>
-                <exclude>**/HCompress.java</exclude>
-                <exclude>**/HDecompress.java</exclude>
-                <exclude>**/HCompressor.java</exclude>
-                <exclude>**/RiceCompressor.java</exclude>
-                <exclude>**/BitBuffer.java</exclude>
-                <exclude>**/BitBuffer.java</exclude>
-                <exclude>**/Quantize.java</exclude>
-                <exclude>**/QuantizeProcessor.java</exclude>
-                <exclude>**/FitsCopy.java</exclude>
-                <exclude>**/FitsReader.java</exclude>
-                <exclude>**/Main.java</exclude>
-                <exclude>**/FitsLineAppender.java</exclude>
-                <exclude>**/FitsSubsctring.java</exclude>
-                <exclude>**/AsciiTableData.java</exclude>
-                <exclude>**/HeaderCommentsMap.java</exclude>
-                <exclude>**/HeaderCardCountingArrayDataInput</exclude>
-                <exclude>**/HeaderOrder.java</exclude>
-                <exclude>**/FitsHeaderImpl.java</exclude>
-                <exclude>**/GenericKey.java</exclude>
-                <exclude>**/StandardCommentReplacement.java</exclude>
-                <exclude>**/BlanksDotHierarchKeyFormatter.java</exclude>
-                <exclude>**/BufferDecoder.java</exclude>
-                <exclude>**/BufferEncoder.java</exclude>
-                <exclude>**/BufferPointer.java</exclude>
-                <exclude>**/BufferedData*putStream.java</exclude>
-                <exclude>**/BufferedFile.java</exclude>
-                <exclude>**/ByteFormatter.java</exclude>
-                <exclude>**/ByteParser.java</exclude>
-                <exclude>**/SafeClose.java</exclude>
-                <exclude>**/MultiArrayCopyFactory.java</exclude>
-                <exclude>**/MultiArrayPointer.java</exclude>
-                <exclude>**/PrimitiveType*.java</exclude>
-                <exclude>**/CXCStclSharedExt.java</exclude>
-                <exclude>**/HCompressorQuantizeOption.java</exclude>
-                <exclude>**/RiceQuantizeCompressOption.java</exclude>
-              </sourceFileExcludes>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -565,6 +565,30 @@
             <exclude>**/FitsCopy.java</exclude>
             <exclude>**/FitsReader.java</exclude>
             <exclude>**/Main.java</exclude>
+            <exclude>**/FitsLineAppender.java</exclude>
+            <exclude>**/FitsSubsctring.java</exclude>
+            <exclude>**/AsciiTableData.java</exclude>
+            <exclude>**/HeaderCommentsMap.java</exclude>
+            <exclude>**/HeaderCardCountingArrayDataInput</exclude>
+            <exclude>**/HeaderOrder.java</exclude>
+            <exclude>**/FitsHeaderImpl.java</exclude>
+            <exclude>**/GenericKey.java</exclude>
+            <exclude>**/StandardCommentReplacement.java</exclude>
+            <exclude>**/BlanksDotHierarchKeyFormatter.java</exclude>
+            <exclude>**/BufferDecoder.java</exclude>
+            <exclude>**/BufferEncoder.java</exclude>
+            <exclude>**/BufferPointer.java</exclude>
+            <exclude>**/BufferedData*putStream.java</exclude>
+            <exclude>**/BufferedFile.java</exclude>
+            <exclude>**/ByteFormatter.java</exclude>
+            <exclude>**/ByteParser.java</exclude>
+            <exclude>**/SafeClose.java</exclude>
+            <exclude>**/MultiArrayCopyFactory.java</exclude>
+            <exclude>**/MultiArrayPointer.java</exclude>
+            <exclude>**/PrimitiveType*.java</exclude>
+            <exclude>**/CXCStclSharedExt.java</exclude>
+            <exclude>**/HCompressorQuantizeOption.java</exclude>
+            <exclude>**/RiceQuantizeCompressOption.java</exclude>
           </sourceFileExcludes>
         </configuration>
         <reportSets>
@@ -796,6 +820,30 @@
                 <exclude>**/FitsCopy.java</exclude>
                 <exclude>**/FitsReader.java</exclude>
                 <exclude>**/Main.java</exclude>
+                <exclude>**/FitsLineAppender.java</exclude>
+                <exclude>**/FitsSubsctring.java</exclude>
+                <exclude>**/AsciiTableData.java</exclude>
+                <exclude>**/HeaderCommentsMap.java</exclude>
+                <exclude>**/HeaderCardCountingArrayDataInput</exclude>
+                <exclude>**/HeaderOrder.java</exclude>
+                <exclude>**/FitsHeaderImpl.java</exclude>
+                <exclude>**/GenericKey.java</exclude>
+                <exclude>**/StandardCommentReplacement.java</exclude>
+                <exclude>**/BlanksDotHierarchKeyFormatter.java</exclude>
+                <exclude>**/BufferDecoder.java</exclude>
+                <exclude>**/BufferEncoder.java</exclude>
+                <exclude>**/BufferPointer.java</exclude>
+                <exclude>**/BufferedData*putStream.java</exclude>
+                <exclude>**/BufferedFile.java</exclude>
+                <exclude>**/ByteFormatter.java</exclude>
+                <exclude>**/ByteParser.java</exclude>
+                <exclude>**/SafeClose.java</exclude>
+                <exclude>**/MultiArrayCopyFactory.java</exclude>
+                <exclude>**/MultiArrayPointer.java</exclude>
+                <exclude>**/PrimitiveType*.java</exclude>
+                <exclude>**/CXCStclSharedExt.java</exclude>
+                <exclude>**/HCompressorQuantizeOption.java</exclude>
+                <exclude>**/RiceQuantizeCompressOption.java</exclude>
               </sourceFileExcludes>
             </configuration>
           </plugin>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -1,14 +1,14 @@
 <document xmlns="http://maven.apache.org/changes/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/xsd/changes-1.0.0.xsd">
 <body>
 
-   <release version="1.19.0-SNAPSHOT" date="2024-01-15" description="Feature release with bug fixes.">
+   <release version="1.19.0" date="2024-01-21" description="Feature release with bug fixes.">
       <action type="fix" dev="cek" issue="496">
           Workaround for read-only FITS files on Windows network shares.
       </action>
-      <action type="fix" dev="attipaci" issue="532">
+      <action type="fix" dev="attipaci" issue="531">
           Keywords with hyphens in STScIExt had the wrong form previously.
       </action>
-      <action type="fix" dev="attipaci" issue="531">
+      <action type="fix" dev="attipaci" issue="532">
           Small fixes to HashedList handling iterator access corner cases.
       </action>
       <action type="add" dev="attipaci" issue="488">
@@ -17,43 +17,44 @@
           [...]HDU.encapsulate(Object) methods.
       </action>
       <action type="add" dev="attipaci" issue="489">
-          New Header.mergeDistinct(Header) method to allow copying non-conflicting header 
-          keywords from one FITS header to another.
+          New Header.mergeDistinct(Header) method to allow copying non-conflicting header keywords 
+          from one FITS header to another.
       </action>
       <action type="add" dev="attipaci" issue="490">
-          New inspection methods to UndefinedData class, to easily retrieve XTENSION type, 
-          BITPIX, and data size/shape information from HDUs containing unsupported data types.
+          New inspection methods to UndefinedData class, to easily retrieve XTENSION type, BITPIX, 
+          and data size/shape information from HDUs containing unsupported data types.
       </action>
-            <action type="add" dev="attipaci" issue="492">
-          New access methods to parameters stored in RandomGroupsHDU types, in line with
-          the FITS specification.
+      <action type="add" dev="attipaci" issue="492">
+          New access methods for parameters stored in RandomGroupsHDU types, according to the 
+          FITS specification.
       </action>
       <action type="add" dev="attipaci" issue="494">
           A better way to control how FITS I10 type columns are treated in ASCII tables, via
           static AsciiTable.setI10PreferInt(boolean) and .isI10PreferInt() methods.
       </action>
       <action type="add" dev="attipaci" issue="520">
-          New methods to make the decompression of selected CompressedTableHDU tiles 
-          even easier (and safer) to use.
+          New methods to make the decompression of selected CompressedTableHDU tiles even easier 
+          (and safer) to use.
       </action>
       <action type="add" dev="attipaci" issue="531">
-          Support for INHERIT keyword via Fits.getCompleteHeader(...) methods. These methods
-          will populate the mandatory FITS header keywords in the the selected HDU, and return 
-          either the updated header or else an independent composite header made up of both the 
-          explicitly defined keywords in the selected HDU and the inherited (non-conflicting) 
-          keywords from the primary HDU.
+          New WCS and DateTime enums with an enumeration of all standard FITS WCS and date-time 
+          related keywords, and recognized values (constants). The WCS enums support alternate 
+          coordinate systems via the WCS.alt(char) method. For example to generate the "CTYPE1A" 
+          standard keyword you may call WCS.CTYPEna.alt('A').n(1). 
       </action>
       <action type="add" dev="attipaci" issue="532">
-          New WCS and DateTime enums with an enumeration of all standard FITS WCS and 
-          date-time related keywords, and recognized values (constants). The WCS enums support
-          alternate coordinate systems via the WCS.alt(char) method. For example to generate
-          the "CTYPE1A" standard keywords you may call WCS.CTYPEna.alt('A').n(1). 
+          Support for INHERIT keyword via Fits.getCompleteHeader(...) methods. These methods will 
+          populate the mandatory FITS header keywords in the the selected HDU, and return either 
+          the updated header or else a new header composed up of both the explicitly defined 
+          keywords in the selected HDU and the inherited (non-conflicting) entries from the 
+          primary HDU.
       </action>
       <action type="add" dev="attipaci" issue="534">
-	  Adding standardized (IFitsHeader) keywords to HDU headers will now check that the keyword
-	  can be used with the associated HDU type (if any), and may throw an IllegalArgumentException
-	  if the usage is inappropriate. The type of checks (if any) can be adjusted via the new
-	  Header.setKeywordChecking() and/or the static Header.setDefaultKeywordChecking() methods.
+	  Adding standardized (IFitsHeader) keywords to HDU headers will now check that the 
+	  keyword can be used with the associated HDU type (if any), and may throw an 
+	  IllegalArgumentException if the usage is inappropriate. The type of checks (if any) can 
+	  be adjusted via the new Header.setKeywordChecking() and/or the static 
+	  Header.setDefaultKeywordChecking() methods.
       </action>
       <action type="add" dev="attipaci" issue="534">
 	  Setting values for HeaderCards with standardized (IFitsHeader) keywords now checks that
@@ -63,16 +64,16 @@
 	  static HeaderCard.setValueCheckPolicy() method.	  
       </action>
       <action type="add" dev="attipaci" issue="538">
-	  New FitsKey class to replace the poorly named FitsHeaderImpl. (The latter class
+	  New FitsKey class to replace the poorly named FitsHeaderImpl class. (The latter
 	  continues to exist in deprecated form for compatibility). Added new functionality.
       </action>
       <action type="add" dev="attipaci" issue="538">
-	  New Standard.match(String) method to match one of the reserved keyword templates of 
-	  the FITS standard to a keyword instance, such as "CTYPE1A" to WCS.CTYPEna.
+	  New Standard.match(String) method to match one of the reserved keyword templates of the 
+	  FITS standard to a keyword instance, such as "CTYPE1A" to WCS.CTYPEna.
       </action>
       <action type="update" dev="attipaci" issue="519">
-          Demoted FitsException to be a soft exception, extending IllegalStateException. As
-          a result, users are no longer required to catch these, or its derivatives such as
+          Demoted FitsException to be a soft exception, extending IllegalStateException. As a 
+          result, users are no longer required to catch these, or its derivatives such as
           HeaderCardException. Some methods that have previously thrown IllegalStateException may 
           now throw a FitsException, in a fully backwards compatible way. 
       </action>
@@ -84,40 +85,37 @@
       </action>
       <action type="update" dev="attipaci" issue="518">
           The constructor of PaddingException does not throw a FitsException, and 
-          FitsCheckSum.Checksum also does not throw an IllegalArgumentException -- so they 
-          are now declared as such. Some related javadoc updates.
+          FitsCheckSum.Checksum also does not throw an IllegalArgumentException -- so they are now 
+          declared as such. Some related javadoc updates.
       </action>
       <action type="update" dev="attipaci" issue="525">
           Improvements to AsciiTable with addColumn() argument checking and more specific
           documentation.
       </action>
-      <action type="update" dev="attipaci" issue="532">
+      <action type="update" dev="attipaci" issue="531">
           Synonyms has been extended to enumerate all synonymous WCS keys and a few other
           keywords with equivalent definitions.
       </action>
-      <action type="update" dev="attipaci" issue="532">
-          Added impl() method to IFitsHeader interface with a default implementation to 
-          eliminate code that was duplicated many times over across enums.
+      <action type="update" dev="attipaci" issue="531">
+          Added impl() method to IFitsHeader interface with a default implementation to eliminate 
+          code that was duplicated many times over across enums.
       </action>
-      <action type="update" dev="attipaci" issue="532">
-          IFitsHeader.n(int...) now checks that the supplied indices are in the 0-999 range 
-          (we'll accept 0, even though it's not really proper FITS, but appears to be used 
-          nevertheless), and throw an IllegalArgumentException if any of the indices are out 
-          of bounds. The method now also checks that the resulting indexed keyword does not 
-          exceed the 8-byte limit of standard FITS keywords, or else will throw an 
-          IllegalStateException.
+      <action type="update" dev="attipaci" issue="531">
+          IFitsHeader.n(int...) now checks that the supplied indices are in the 0-999 range, or 
+          else throw an IndexOutOfBoundsException. If too many indices are supplied it will throw 
+          a NoSuchElementException. And, if the resulting indexed keyword exceeds the 8-byte limit 
+          of standard FITS keywords it will throw an IllegalStateException.
       </action>
-      <action type="update" dev="attipaci" issue="532">
-          Attempting to create a HeaderCard with a standard keyword that has unfilled 
-          indices will throw an IllegalArgumentException, while specifying more indices than can 
-          be filled for an IFitsHeader will throw an IndexOutOfBoundsException.
+      <action type="update" dev="attipaci" issue="531">
+          Attempting to create a HeaderCard with a standard keyword that has unfilled indices will 
+          throw an IllegalArgumentException.
       </action>
       <action type="update" dev="attipaci">
-          CompressedImageHDU.getTileHDU() now updates CRPIXna keywords also in the 
-          alternate coordinate systems (if present) for the selected cutout image.
+          CompressedImageHDU.getTileHDU() now updates CRPIXna keywords also in the alternate 
+          coordinate systems (if present) for the selected cutout image.
       </action>
       <action type="update" dev="attipaci" issue="538">
-          Corrections to standard keyword sources, deprecations, synonyms, and associated 
+          Corrections to standard keyword sources, deprecations, synonyms, comments and associated 
           javadoc.
       </action>
       <action type="update" dev="attipaci">

--- a/src/main/java/nom/tam/fits/AbstractTableData.java
+++ b/src/main/java/nom/tam/fits/AbstractTableData.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -11,7 +11,7 @@ import nom.tam.util.Cursor;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/BasicHDU.java
+++ b/src/main/java/nom/tam/fits/BasicHDU.java
@@ -20,7 +20,7 @@ import nom.tam.util.RandomAccess;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -13,7 +13,7 @@ import nom.tam.util.Cursor;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/Data.java
+++ b/src/main/java/nom/tam/fits/Data.java
@@ -6,7 +6,7 @@ import java.io.EOFException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/FitsElement.java
+++ b/src/main/java/nom/tam/fits/FitsElement.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/FitsException.java
+++ b/src/main/java/nom/tam/fits/FitsException.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/FitsFactory.java
+++ b/src/main/java/nom/tam/fits/FitsFactory.java
@@ -16,7 +16,7 @@ import nom.tam.image.compression.hdu.CompressedTableHDU;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/FitsHeap.java
+++ b/src/main/java/nom/tam/fits/FitsHeap.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/FitsIntegrityException.java
+++ b/src/main/java/nom/tam/fits/FitsIntegrityException.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/FitsUtil.java
+++ b/src/main/java/nom/tam/fits/FitsUtil.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/Header.java
+++ b/src/main/java/nom/tam/fits/Header.java
@@ -34,7 +34,7 @@ import nom.tam.util.RandomAccess;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HeaderCardBuilder.java
+++ b/src/main/java/nom/tam/fits/HeaderCardBuilder.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HeaderCardCountingArrayDataInput.java
+++ b/src/main/java/nom/tam/fits/HeaderCardCountingArrayDataInput.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HeaderCardException.java
+++ b/src/main/java/nom/tam/fits/HeaderCardException.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HeaderCardFormatter.java
+++ b/src/main/java/nom/tam/fits/HeaderCardFormatter.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HeaderCardParser.java
+++ b/src/main/java/nom/tam/fits/HeaderCardParser.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HeaderCommentsMap.java
+++ b/src/main/java/nom/tam/fits/HeaderCommentsMap.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HeaderOrder.java
+++ b/src/main/java/nom/tam/fits/HeaderOrder.java
@@ -19,7 +19,7 @@ import static nom.tam.fits.header.Standard.XTENSION;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
+++ b/src/main/java/nom/tam/fits/HierarchNotEnabledException.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/ImageHDU.java
+++ b/src/main/java/nom/tam/fits/ImageHDU.java
@@ -12,7 +12,7 @@ import nom.tam.util.ArrayFuncs;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/LongStringsNotEnabledException.java
+++ b/src/main/java/nom/tam/fits/LongStringsNotEnabledException.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/LongValueException.java
+++ b/src/main/java/nom/tam/fits/LongValueException.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/NullData.java
+++ b/src/main/java/nom/tam/fits/NullData.java
@@ -6,7 +6,7 @@ import java.nio.Buffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/NullDataHDU.java
+++ b/src/main/java/nom/tam/fits/NullDataHDU.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/PaddingException.java
+++ b/src/main/java/nom/tam/fits/PaddingException.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/RandomGroupsData.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsData.java
@@ -158,6 +158,7 @@ public class RandomGroupsData extends Data {
         return sampleRow == null ? null : ArrayFuncs.getDimensions(sampleRow[1]);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void fillHeader(Header h) throws FitsException {
         if (groups <= 0) {

--- a/src/main/java/nom/tam/fits/RandomGroupsHDU.java
+++ b/src/main/java/nom/tam/fits/RandomGroupsHDU.java
@@ -16,7 +16,7 @@ import nom.tam.util.FitsOutput;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/TableData.java
+++ b/src/main/java/nom/tam/fits/TableData.java
@@ -6,7 +6,7 @@ import nom.tam.util.ComplexValue;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -12,7 +12,7 @@ import static nom.tam.fits.header.Standard.TTYPEn;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/TruncatedFileException.java
+++ b/src/main/java/nom/tam/fits/TruncatedFileException.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/UnclosedQuoteException.java
+++ b/src/main/java/nom/tam/fits/UnclosedQuoteException.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/UndefinedData.java
+++ b/src/main/java/nom/tam/fits/UndefinedData.java
@@ -117,6 +117,7 @@ public class UndefinedData extends Data {
         ArrayFuncs.copyInto(x, data);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void fillHeader(Header head) {
         // We'll assume it's a primary image, until we know better...
@@ -124,7 +125,7 @@ public class UndefinedData extends Data {
         head.deleteKey(Standard.SIMPLE);
         head.deleteKey(Standard.EXTEND);
 
-        Standard.context(null);
+        Standard.context(UndefinedData.class);
 
         Cursor<String, HeaderCard> c = head.iterator();
         c.add(HeaderCard.create(Standard.XTENSION, extensionType));
@@ -138,6 +139,8 @@ public class UndefinedData extends Data {
 
         c.add(HeaderCard.create(Standard.PCOUNT, pCount));
         c.add(HeaderCard.create(Standard.GCOUNT, gCount));
+
+        Standard.context(null);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/UndefinedHDU.java
+++ b/src/main/java/nom/tam/fits/UndefinedHDU.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compress/BZip2CompressionProvider.java
+++ b/src/main/java/nom/tam/fits/compress/BZip2CompressionProvider.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/BasicCompressProvider.java
+++ b/src/main/java/nom/tam/fits/compress/BasicCompressProvider.java
@@ -11,7 +11,7 @@ import nom.tam.fits.FitsException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/CloseIS.java
+++ b/src/main/java/nom/tam/fits/compress/CloseIS.java
@@ -14,7 +14,7 @@ import java.util.logging.Logger;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/CompressionLibLoaderProtection.java
+++ b/src/main/java/nom/tam/fits/compress/CompressionLibLoaderProtection.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/CompressionManager.java
+++ b/src/main/java/nom/tam/fits/compress/CompressionManager.java
@@ -15,7 +15,7 @@ import nom.tam.fits.FitsException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/ExternalBZip2CompressionProvider.java
+++ b/src/main/java/nom/tam/fits/compress/ExternalBZip2CompressionProvider.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/GZipCompressionProvider.java
+++ b/src/main/java/nom/tam/fits/compress/GZipCompressionProvider.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/ICompressProvider.java
+++ b/src/main/java/nom/tam/fits/compress/ICompressProvider.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/ZCompressionProvider.java
+++ b/src/main/java/nom/tam/fits/compress/ZCompressionProvider.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compress/package-info.java
+++ b/src/main/java/nom/tam/fits/compress/package-info.java
@@ -12,7 +12,7 @@ package nom.tam.fits.compress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/api/ICompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/api/ICompressOption.java
@@ -6,7 +6,7 @@ import nom.tam.fits.compression.provider.param.api.ICompressParameters;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/api/ICompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/api/ICompressor.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.api;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/api/ICompressorControl.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/api/ICompressorControl.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.api;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/api/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/api/package-info.java
@@ -12,7 +12,7 @@ package nom.tam.fits.compression.algorithm.api;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressor.java
@@ -23,7 +23,7 @@ import nom.tam.util.type.ElementType;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip/package-info.java
@@ -10,7 +10,7 @@ package nom.tam.fits.compression.algorithm.gzip;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip2/GZip2Compressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip2/GZip2Compressor.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.gzip2;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip2/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip2/package-info.java
@@ -10,7 +10,7 @@ package nom.tam.fits.compression.algorithm.gzip2;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompress.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompress.java
@@ -7,7 +7,7 @@ import java.nio.LongBuffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressor.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.hcompress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorOption.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.hcompress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorQuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HCompressorQuantizeOption.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.hcompress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HDecompress.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/HDecompress.java
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/hcompress/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/hcompress/package-info.java
@@ -20,7 +20,7 @@ package nom.tam.fits.compression.algorithm.hcompress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/plio/PLIOCompress.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/plio/PLIOCompress.java
@@ -10,7 +10,7 @@ import nom.tam.fits.compression.algorithm.api.ICompressor;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/plio/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/plio/package-info.java
@@ -14,7 +14,7 @@ package nom.tam.fits.compression.algorithm.plio;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -9,7 +9,7 @@ import nom.tam.fits.compression.provider.param.quant.QuantizeParameters;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeProcessor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeProcessor.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/RandomSequence.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/RandomSequence.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/package-info.java
@@ -25,7 +25,7 @@ package nom.tam.fits.compression.algorithm.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/BitBuffer.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/BitBuffer.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.rice;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressOption.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.rice;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceCompressor.java
@@ -16,7 +16,7 @@ import nom.tam.util.type.ElementType;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceQuantizeCompressOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/RiceQuantizeCompressOption.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.rice;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/rice/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/rice/package-info.java
@@ -21,7 +21,7 @@ package nom.tam.fits.compression.algorithm.rice;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/uncompressed/NoCompressCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/uncompressed/NoCompressCompressor.java
@@ -15,7 +15,7 @@ import nom.tam.util.type.ElementType;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/algorithm/uncompressed/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/uncompressed/package-info.java
@@ -9,7 +9,7 @@ package nom.tam.fits.compression.algorithm.uncompressed;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/provider/CompressorControlNameComputer.java
+++ b/src/main/java/nom/tam/fits/compression/provider/CompressorControlNameComputer.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
+++ b/src/main/java/nom/tam/fits/compression/provider/CompressorProvider.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/api/ICompressorProvider.java
+++ b/src/main/java/nom/tam/fits/compression/provider/api/ICompressorProvider.java
@@ -6,7 +6,7 @@ import nom.tam.fits.compression.algorithm.api.ICompressorControl;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/api/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/provider/api/package-info.java
@@ -9,7 +9,7 @@ package nom.tam.fits.compression.provider.api;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/provider/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/provider/package-info.java
@@ -9,7 +9,7 @@ package nom.tam.fits.compression.provider;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderAccess.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.api;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderCardAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/HeaderCardAccess.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressColumnParameter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.api;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressHeaderParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressHeaderParameter.java
@@ -7,7 +7,7 @@ import nom.tam.fits.HeaderCardException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.api;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressParameters.java
@@ -12,7 +12,7 @@ import nom.tam.fits.compression.provider.param.base.CompressParameters;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/IHeaderAccess.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/IHeaderAccess.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/package-info.java
@@ -10,7 +10,7 @@ package nom.tam.fits.compression.provider.param.api;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/BundledParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/BundledParameters.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.base;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.base;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
@@ -10,7 +10,7 @@ import nom.tam.fits.compression.provider.param.api.IHeaderAccess;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.base;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
@@ -14,7 +14,7 @@ import nom.tam.fits.compression.provider.param.api.ICompressParameters;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/package-info.java
@@ -10,7 +10,7 @@ package nom.tam.fits.compression.provider.param.base;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressParameters.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.hcompress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressScaleParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressScaleParameter.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressSmoothParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/hcompress/HCompressSmoothParameter.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/hcompress/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/hcompress/package-info.java
@@ -10,7 +10,7 @@ package nom.tam.fits.compression.provider.param.hcompress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
@@ -6,7 +6,7 @@ import nom.tam.fits.compression.algorithm.api.ICompressOption;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankParameter.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZQuantizeParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZQuantizeParameter.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZScaleColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZScaleColumnParameter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZZeroColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZZeroColumnParameter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/package-info.java
@@ -11,7 +11,7 @@ package nom.tam.fits.compression.provider.param.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBlockSizeParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBlockSizeParameter.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBytePixParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceBytePixParameter.java
@@ -6,7 +6,7 @@ import nom.tam.fits.Header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceCompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/rice/RiceCompressParameters.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider.param.rice;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/compression/provider/param/rice/package-info.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/rice/package-info.java
@@ -10,7 +10,7 @@ package nom.tam.fits.compression.provider.param.rice;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/header/Bitpix.java
+++ b/src/main/java/nom/tam/fits/header/Bitpix.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/Checksum.java
+++ b/src/main/java/nom/tam/fits/header/Checksum.java
@@ -52,7 +52,7 @@ public enum Checksum implements IFitsHeader {
      * value of the CHECKSUM keyword shall be set to the string '0000000000000000' (ASCII 0's, hex 30) before the
      * checksum is computed.
      */
-    CHECKSUM(HDU.ANY, VALUE.STRING, "checksum for the current HDU"),
+    CHECKSUM(HDU.ANY, VALUE.STRING, "complement checksum for the current HDU"),
     /**
      * The value field of the CHECKVER keyword shall contain a string, unique in the first 8 characters, which
      * distinguishes between any future alternative checksum algorithms which may be defined. The default value for a

--- a/src/main/java/nom/tam/fits/header/Checksum.java
+++ b/src/main/java/nom/tam/fits/header/Checksum.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/Compression.java
+++ b/src/main/java/nom/tam/fits/header/Compression.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -57,7 +57,7 @@ public enum DataDescription implements IFitsHeader {
      * originally created the current FITS HDU. This keyword is synonymous with the PROGRAM keyword. Example: 'TASKNAME
      * V1.2.3'
      */
-    CREATOR(SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "the name of the software task that created the file"),
+    CREATOR(SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "name of the software task that created the file"),
 
     /**
      * The value field shall contain a character string giving the the host file name used to record the original data.

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -112,7 +112,7 @@ public enum DateTime implements IFitsHeader {
      * 
      * @since 1.19
      */
-    DATEREF(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Reference date"),
+    DATEREF(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "reference date"),
 
     /**
      * [day] Modified Julian Date of observation
@@ -203,98 +203,98 @@ public enum DateTime implements IFitsHeader {
      * 
      * @since 1.19
      */
-    XPOSURE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Net exposure duration"),
+    XPOSURE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "net exposure duration"),
 
     /**
      * Wall clock exposure duration (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
-    TELAPSE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Wall-clock exposure duration"),
+    TELAPSE(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "wall-clock exposure duration"),
 
     /**
      * Time reference system name
      * 
      * @since 1.19
      */
-    TIMESYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time scale"),
+    TIMESYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "time reference system"),
 
     /**
-     * Time reference position
+     * Time reference location
      * 
      * @since 1.19
      */
-    TREFPOS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time reference position"),
+    TREFPOS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "time reference location"),
 
     /**
-     * Time reference position for given column index.
+     * Time reference location for given column index.
      * 
      * @since 1.19
      */
-    TRPOSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "Time reference position in column"),
+    TRPOSn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "time reference location in column"),
 
     /**
      * Pointer to time reference direction
      * 
      * @since 1.19
      */
-    TREFDIR(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time reference direction"),
+    TREFDIR(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "time reference direction"),
 
     /**
      * Time reference direction for given column index, e.g. 'TOPOCENT'
      * 
      * @since 1.19
      */
-    TRDIRn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "Time reference direction in column"),
+    TRDIRn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "time reference direction in column"),
 
     /**
      * Solar system ephemeris used, e.g. 'DE-405'.
      * 
      * @since 1.19
      */
-    PLEPHEM(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Solar system ephemeris"),
+    PLEPHEM(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "solar-system ephemeris ID"),
 
     /**
      * Time unit name
      * 
      * @since 1.19
      */
-    TIMEUNIT(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Time unit"),
+    TIMEUNIT(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "time unit"),
 
     /**
      * Precision time offset (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
-    TIMEOFFS(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Time offset"),
+    TIMEOFFS(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "time offset"),
 
     /**
      * Systematic time error (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
-    TIMESYER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Systematic time error"),
+    TIMESYER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "systematic time error"),
 
     /**
      * Random time error (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
-    TIMERDER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Random time error"),
+    TIMERDER(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "random time error"),
 
     /**
      * Time resolution (in specified time units, or else seconds)
      * 
      * @since 1.19
      */
-    TIMEDEL(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Time resolution"),
+    TIMEDEL(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "time resolution"),
 
     /**
      * Time location within pixel, between 0.0 and 1.0 (default 0.5).
      * 
      * @since 1.19
      */
-    TIMEPIXR(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "Time location in pixel");
+    TIMEPIXR(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "time location within pixel");
 
     /** International Atomic Time (TAI) timescale value. */
     public static final String TIMESYS_TAI = "TAI";

--- a/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
+++ b/src/main/java/nom/tam/fits/header/FitsHeaderImpl.java
@@ -32,12 +32,12 @@ package nom.tam.fits.header;
  */
 
 /**
- * The old concrete implementation of standardized FITS keywords, with a very unintuitive class name.
+ * The old concrete implementation of standardized FITS keywords, with a very
+ * unintuitive class name.
  * 
- * @author     ritchie
- * 
- * @deprecated Use the more intuitively named {@link FitsKey} class instead. This class is provided for compatibility
- *                 with prior releases.
+ * @author ritchie
+ * @deprecated Use the more intuitively named {@link FitsKey} class instead.
+ *             This class is provided for compatibility with prior releases.
  */
 public class FitsHeaderImpl extends FitsKey {
 
@@ -47,21 +47,26 @@ public class FitsHeaderImpl extends FitsKey {
     private static final long serialVersionUID = 2393951402526656978L;
 
     /**
-     * Creates a new standardized FITS keyword with the specific usage constraints
+     * Creates a new standardized FITS keyword with the specific usage
+     * constraints
      * 
-     * @param  headerName               The keyword as it will appear in the FITS headers, usually a string with up to 8
-     *                                      characters, containing uppper case letters (A-Z), digits (0-9), and/or
-     *                                      underscore (<code>_</code>) or hyphen (<code>-</code>) characters for
-     *                                      standard FITS keywords.
-     * @param  status                   The convention that defines this keyword
-     * @param  hdu                      the type of HDU this keyword may appear in
-     * @param  valueType                the type of value that may be associated with this keyword
-     * @param  comment                  the standard comment to include with this keyword
-     * 
-     * @throws IllegalArgumentException if the keyword name is invalid.
+     * @param headerName
+     *            The keyword as it will appear in the FITS headers, usually a
+     *            string with up to 8 characters, containing uppper case letters
+     *            (A-Z), digits (0-9), and/or underscore (<code>_</code>) or
+     *            hyphen (<code>-</code>) characters for standard FITS keywords.
+     * @param status
+     *            The convention that defines this keyword
+     * @param hdu
+     *            the type of HDU this keyword may appear in
+     * @param valueType
+     *            the type of value that may be associated with this keyword
+     * @param comment
+     *            the standard comment to include with this keyword
+     * @throws IllegalArgumentException
+     *             if the keyword name is invalid.
      */
-    public FitsHeaderImpl(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment)
-            throws IllegalArgumentException {
+    public FitsHeaderImpl(String headerName, SOURCE status, HDU hdu, VALUE valueType, String comment) throws IllegalArgumentException {
         super(headerName, status, hdu, valueType, comment);
         // TODO Auto-generated constructor stub
     }

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -39,10 +39,17 @@ import nom.tam.fits.HeaderCard;
  */
 
 /**
- * A concrete implementation of standardized FITS header keywords, which may be extended to provide arbitrary further
- * conventional keywords, beyond what is provided by this library. Wsers may instantiate this class or extend it to
+ * <p>
+ * A concrete implementation of standardized FITS header keywords. Users may instantiate this class or extend it to
  * define commonly used keywords for their applications, and benefit for the extra checks they afford, and to avoid
  * typos when using these.
+ * </p>
+ * <p>
+ * FITS keywords must be composed of uppper-case 'A'-'Z', digits, underscore ('_') and hyphen ('-') characters.
+ * Additionally, lower case 'n' may be used as a place-holder for a numerical index, and the keyword name may end with a
+ * lower-case 'a' to indicate that it may be used for/with alternate WCS coordinate systems. (We also allow '/' because
+ * some STScI keywords use it even though it violates the FITS standard.)
+ * </p>
  * 
  * @since 1.19
  */

--- a/src/main/java/nom/tam/fits/header/FitsKey.java
+++ b/src/main/java/nom/tam/fits/header/FitsKey.java
@@ -11,7 +11,7 @@ import nom.tam.fits.HeaderCard;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/GenericKey.java
+++ b/src/main/java/nom/tam/fits/header/GenericKey.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/HierarchicalGrouping.java
+++ b/src/main/java/nom/tam/fits/header/HierarchicalGrouping.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/InstrumentDescription.java
+++ b/src/main/java/nom/tam/fits/header/InstrumentDescription.java
@@ -97,7 +97,7 @@ public enum InstrumentDescription implements IFitsHeader {
      * keyword value may differ from the maximum value implied by the BITPIX in that more bits may be allocated in the
      * FITS pixel values than the detector can accommodate.
      */
-    SATURATE(SOURCE.STScI, HDU.ANY, VALUE.INTEGER, "Data value at which saturation occurs");
+    SATURATE(SOURCE.STScI, HDU.ANY, VALUE.INTEGER, "data value at which saturation occurs");
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/InstrumentDescription.java
+++ b/src/main/java/nom/tam/fits/header/InstrumentDescription.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/NonStandard.java
+++ b/src/main/java/nom/tam/fits/header/NonStandard.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/NonStandard.java
+++ b/src/main/java/nom/tam/fits/header/NonStandard.java
@@ -69,7 +69,7 @@ public enum NonStandard implements IFitsHeader {
      * that the slash character be preceeded and followed by a space character. Example: "HIERARCH Filter Wheel = 12 /
      * filter position". In this example the logical name of the keyword is 'Filter Wheel' and the value is 12.
      */
-    HIERARCH(SOURCE.ESO, HDU.ANY, VALUE.NONE, "denotes the HIERARCH keyword convention"),
+    HIERARCH(SOURCE.ESO, HDU.ANY, VALUE.NONE, null),
 
     /**
      * The presence of this keyword with a value = T in an extension key indicates that the keywords contained in the
@@ -78,7 +78,7 @@ public enum NonStandard implements IFitsHeader {
      * 
      * @deprecated Part of the FITS standard, use {@link Standard#INHERIT} instead.
      */
-    INHERIT(SOURCE.STScI, HDU.EXTENSION, VALUE.LOGICAL, "denotes the INHERIT keyword convention");
+    INHERIT(SOURCE.STScI, HDU.EXTENSION, VALUE.LOGICAL, "inherit header description of primary HDU");
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/ObservationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDescription.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
@@ -63,7 +63,7 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * 
      * @see DateTime#TELAPSE
      */
-    ELAPTIME(SOURCE.UCOLICK, HDU.ANY, VALUE.REAL, "elapsed time of the observation"),
+    ELAPTIME(SOURCE.UCOLICK, HDU.ANY, VALUE.REAL, "[s] elapsed time of the observation"),
     /**
      * The value field shall contain a floating point number giving the exposure time of the observation in units of
      * seconds. The exact definition of 'exposure time' is mission dependent and may, for example, include corrections
@@ -72,7 +72,7 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * 
      * @see DateTime#XPOSURE
      */
-    EXPOSURE(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "exposure time"),
+    EXPOSURE(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "[s] exposure time"),
     /**
      * The value field shall contain a floating point number giving the exposure time of the observation in units of
      * seconds. The exact definition of 'exposure time' is mission dependent and may, for example, include corrections
@@ -81,13 +81,13 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * 
      * @see DateTime#XPOSURE
      */
-    EXPTIME(SOURCE.NOAO, HDU.ANY, VALUE.REAL, "exposure time"),
+    EXPTIME(SOURCE.NOAO, HDU.ANY, VALUE.REAL, "[s] exposure time"),
     /**
      * The value field shall contain a floating point number giving the total integrated exposure time in units of
      * seconds corrected for detector 'dead time' effects which reduce the net efficiency of the detector. The ratio of
      * LIVETIME/ONTIME gives the mean dead time correction during the observation, which lies in the range 0.0 to 1.0.
      */
-    LIVETIME(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "exposure time after deadtime correction"),
+    LIVETIME(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "[s] exposure time after deadtime correction"),
     /**
      * The value field shall contain a floating point number giving the total integrated exposure time of the
      * observation in units of seconds. ONTIME may be less than TELAPSE if there were intevals during the observation in
@@ -95,14 +95,14 @@ public enum ObservationDurationDescription implements IFitsHeader {
      * 
      * @see DateTime#XPOSURE
      */
-    ONTIME(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "integration time during the observation"),
+    ONTIME(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "[s] integration time during the observation"),
     /**
      * The value field shall contain a floating point number giving the difference between the stop and start times of
      * the observation in units of seconds. This keyword is synonymous with the ELAPTIME keyword.
      * 
      * @deprecated Part of the FITS standard, use {@link DateTime#TELAPSE} instead.
      */
-    TELAPSE(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "elapsed time of the observation"),
+    TELAPSE(SOURCE.HEASARC, HDU.ANY, VALUE.REAL, "[s] elapsed time of the observation"),
     /**
      * The value field shall contain a character string that gives the time at which the observation ended. This keyword
      * is used in conjunction with the DATE-END keyword to give the ending time of the observation; the DATE-END keyword

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -1,7 +1,6 @@
 package nom.tam.fits.header;
 
 import nom.tam.fits.AsciiTable;
-import nom.tam.fits.BasicHDU;
 import nom.tam.fits.BinaryTable;
 import nom.tam.fits.ImageData;
 import nom.tam.fits.RandomGroupsData;
@@ -50,20 +49,23 @@ import nom.tam.fits.UndefinedData;
  *
  * @author Richard van Nieuwenhoven
  */
+@SuppressWarnings("deprecation")
 public enum Standard implements IFitsHeader {
     /**
      * The value field shall contain a character string identifying who compiled the information in the data associated
      * with the key. This keyword is appropriate when the data originate in a published paper or are compiled from many
      * sources.
      */
-    AUTHOR(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "author of the data"),
+    AUTHOR(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "author name(s)"),
     /**
      * The value field shall contain an integer. The absolute value is used in computing the sizes of data structures.
      * It shall specify the number of bits that represent a data value. RANGE: -64,-32,8,16,32
+     * 
+     * @see {@link Bitpix}
      */
-    BITPIX(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "bits per data value", //
-            replaceable("header:bitpix", Object.class) //
+    BITPIX(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "bits per data element", replaceable("header:bitpix", Object.class) //
     ),
+
     /**
      * This keyword shall be used only in primary array headers or IMAGE extension headers with positive values of
      * BITPIX (i.e., in arrays with integer data). Columns 1-8 contain the string, `BLANK ' (ASCII blanks in columns
@@ -90,7 +92,7 @@ public enum Standard implements IFitsHeader {
      * @deprecated no blocksize other that 2880 may be used.
      */
     @Deprecated
-    BLOCKED(SOURCE.RESERVED, HDU.PRIMARY, VALUE.LOGICAL, "is physical blocksize a multiple of 2880?"),
+    BLOCKED(SOURCE.RESERVED, HDU.PRIMARY, VALUE.LOGICAL, "Non-standard FITS block size"),
 
     /**
      * This keyword shall be used, along with the BZERO keyword, when the array pixel values are not the true physical
@@ -99,7 +101,7 @@ public enum Standard implements IFitsHeader {
      * representing the coefficient of the linear term in the scaling equation, the ratio of physical value to array
      * value at zero offset. The default value for this keyword is 1.0.
      */
-    BSCALE(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "linear factor in scaling equation"),
+    BSCALE(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "data quantization scaling"),
 
     /**
      * The value field shall contain a character string, describing the physical units in which the quantities in the
@@ -108,7 +110,7 @@ public enum Standard implements IFitsHeader {
      * measurements given as floating point values and specified with reserved keywords, degrees are the recommended
      * units (with the units, if specified, given as 'deg').
      */
-    BUNIT(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "physical units of the array values"),
+    BUNIT(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "data physical unit"),
 
     /**
      * This keyword shall be used, along with the BSCALE keyword, when the array pixel values are not the true physical
@@ -116,7 +118,7 @@ public enum Standard implements IFitsHeader {
      * + BSCALE * array_value. The value field shall contain a floating point number representing the physical value
      * corresponding to an array value of zero. The default value for this keyword is 0.0.
      */
-    BZERO(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "zero point in scaling equation"),
+    BZERO(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "data quantization offset"),
 
     /**
      * The value field shall contain a floating point number giving the partial derivative of the coordinate specified
@@ -126,7 +128,7 @@ public enum Standard implements IFitsHeader {
      *
      * @see WCS#CDELTna
      */
-    CDELTn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate increment along axis"),
+    CDELTn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate spacing along axis"),
 
     /**
      * This keyword shall have no associated value; columns 9-80 may contain any ASCII text. Any number of COMMENT card
@@ -143,7 +145,7 @@ public enum Standard implements IFitsHeader {
      * string value may be continued on any number of consecutive CONTINUE keywords, thus effectively allowing
      * arbitrarily long strings to be written as keyword values.
      */
-    CONTINUE(SOURCE.RESERVED, HDU.ANY, VALUE.NONE, "denotes the CONTINUE long string keyword convention"),
+    CONTINUE(SOURCE.RESERVED, HDU.ANY, VALUE.NONE, null),
 
     /**
      * This keyword is used to indicate a rotation from a standard coordinate system described by the CTYPEn to a
@@ -152,7 +154,7 @@ public enum Standard implements IFitsHeader {
      * contain a floating point number giving the rotation angle in degrees between axis n and the direction implied by
      * the coordinate system defined by CTYPEn. In unit degrees.
      */
-    CROTAn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate system rotation angle"),
+    CROTAn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] coordinate axis rotation angle"),
 
     /**
      * The value field shall contain a floating point number, identifying the location of a reference point along axis
@@ -162,7 +164,7 @@ public enum Standard implements IFitsHeader {
      * 
      * @see WCS#CRPIXna
      */
-    CRPIXn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate system reference pixel"),
+    CRPIXn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate axis reference pixel"),
 
     /**
      * The value field shall contain a floating point number, giving the value of the coordinate specified by the CTYPEn
@@ -170,14 +172,14 @@ public enum Standard implements IFitsHeader {
      *
      * @see WCS#CRVALna
      */
-    CRVALn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate system value at reference pixel"),
+    CRVALn(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate axis value at reference pixel"),
 
     /**
      * The value field shall contain a character string, giving the name of the coordinate represented by axis n.
      *
      * @see WCS#CTYPEna
      */
-    CTYPEn(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "name of the coordinate axis"),
+    CTYPEn(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "coordinate axis type / name"),
 
     /**
      * The value field shall always contain a floating point number, regardless of the value of BITPIX. This number
@@ -220,18 +222,18 @@ public enum Standard implements IFitsHeader {
      * EPOCH keyword and thus it shall not be used in FITS files created after the adoption of the standard; rather, the
      * EQUINOX keyword shall be used.
      *
-     * @deprecated use {@link #EQUINOX} instead
+     * @deprecated Deprecated by the FITS standard in favor of {@link #EQUINOX}.
      */
-    EPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "equinox of celestial coordinate system"),
+    EPOCH(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[yr] equinox of celestial coordinate system"),
 
     /**
      * The value field shall contain a floating point number giving the equinox in years for the celestial coordinate
      * system in which positions are expressed. This version of the keyword does not support alternative coordinate
-     * systems
+     * systems.
      * 
      * @see WCS#EQUINOXa
      */
-    EQUINOX(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "equinox of celestial coordinate system"),
+    EQUINOX(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[yr] equinox of celestial coordinate system"),
 
     /**
      * If the FITS file may contain extensions, a card image with the keyword EXTEND and the value field containing the
@@ -239,13 +241,7 @@ public enum Standard implements IFitsHeader {
      * NAXIS card image. The presence of this keyword with the value T in the primary key does not require that
      * extensions be present.
      */
-    EXTEND(SOURCE.INTEGRAL, HDU.PRIMARY, VALUE.LOGICAL, "may the FITS file contain extensions?", //
-            replaceable("basichdu:extend", BasicHDU.class, "Allow extensions"), //
-            replaceable("header:extend", Object.class, "Extensions are permitted"), //
-            replaceable("imagedata:extend", ImageData.class, "Extension permitted"), //
-            replaceable("undefineddata:extend", UndefinedData.class, "Extensions are permitted")
-
-    ),
+    EXTEND(SOURCE.INTEGRAL, HDU.PRIMARY, VALUE.LOGICAL, "allow extensions"),
 
     /**
      * The value field shall contain an integer, specifying the level in a hierarchy of extension levels of the
@@ -261,7 +257,7 @@ public enum Standard implements IFitsHeader {
      * same type, i.e., with the same value of XTENSION, in a FITS file. This keyword is used to describe an extension
      * and but may appear in the primary header also.
      */
-    EXTNAME(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "name of the extension"),
+    EXTNAME(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "HDU name"),
 
     /**
      * The value field shall contain an integer, to be used to distinguish among different extensions in a FITS file
@@ -270,28 +266,24 @@ public enum Standard implements IFitsHeader {
      * EXTVER keyword is absent, the file should be treated as if the value were 1. This keyword is used to describe an
      * extension and should not appear in the primary key.RANGE: [1:] DEFAULT: 1
      */
-    EXTVER(SOURCE.RESERVED, HDU.ANY, VALUE.INTEGER, "version of the extension"),
+    EXTVER(SOURCE.RESERVED, HDU.ANY, VALUE.INTEGER, "HDU version"),
 
     /**
      * The value field shall contain an integer that shall be used in any way appropriate to define the data structure,
      * consistent with Eq. 5.2 in the FITS Standard. This keyword originated for use in FITS Random Groups where it
      * specifies the number of random groups present. In most other cases this keyword will have the value 1.
      */
-    GCOUNT(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "group count", //
-            replaceable("randomgroupsdata:gcount", RandomGroupsData.class), //
-            replaceable("asciitable:gcount", AsciiTable.class), //
-            replaceable("basichdu:gcount", Object.class, "Required value"), //
-            replaceable("binarytable:gcount", BinaryTable.class), //
-            replaceable("imagedata:gcount", ImageData.class, "No extra parameters"), //
-            replaceable("undefineddata:gcount", UndefinedData.class)
-
+    GCOUNT(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "group count",
+            replaceable("randomgroupsdata:groups", RandomGroupsData.class), //
+            replaceable("undefineddata:groups", UndefinedData.class), //
+            replaceable("header:groups", RandomGroupsData.class) //
     ),
 
     /**
      * The value field shall contain the logical constant T. The value T associated with this keyword implies that
      * random groups records are present.
      */
-    GROUPS(SOURCE.MANDATORY, HDU.GROUPS, VALUE.LOGICAL, "indicates random groups structure", //
+    GROUPS(SOURCE.MANDATORY, HDU.GROUPS, VALUE.LOGICAL, "random groups data", //
             replaceable("randomgroupsdata:groups", RandomGroupsData.class) //
     ),
 
@@ -313,9 +305,7 @@ public enum Standard implements IFitsHeader {
      * associated data array. A value of zero signifies that no data follow the key in the HDU. In the context of FITS
      * 'TABLE' or 'BINTABLE' extensions, the value of NAXIS is always 2.RANGE: [0:999]
      */
-    NAXIS(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "number of axes", //
-            replaceable("header:naxis", Object.class) //
-    ),
+    NAXIS(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "dimensionality of data"),
 
     /**
      * The value field of this indexed keyword shall contain a non-negative integer, representing the number of elements
@@ -323,15 +313,10 @@ public enum Standard implements IFitsHeader {
      * of n. A value of zero for any of the NAXISn signifies that no data follow the key in the HDU. If NAXIS is equal
      * to 0, there should not be any NAXISn keywords.RANGE: [0:]
      */
-    NAXISn(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "size of the n'th axis", //
-            replaceable("asciitable:naxis1", AsciiTable.class, "Size of row in bytes"), //
-            replaceable("binarytable:naxis1", BinaryTable.class, "Bytes per row"), //
-            replaceable("randomgroupsdata:naxis1", RandomGroupsData.class), //
-            replaceable("randomgroupsdata:naxisN", RandomGroupsData.class), //
-            replaceable("tablehdu:naxis2", TableData.class), //
-            replaceable("header:naxisN", Object.class), //
-            replaceable("undefineddata:naxis1", UndefinedData.class, "Number of Bytes") //
-    ),
+    NAXISn(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "n'th data dimension", //
+            replaceable("tablehdu:naxis1", TableData.class, "Size of table row in bytes"), //
+            replaceable("tablehdu:naxis2", TableData.class, "Number of table rows"),
+            replaceable("header:naxis2", Object.class)),
 
     /**
      * The value field shall contain a character string giving a name for the object observed.
@@ -341,7 +326,7 @@ public enum Standard implements IFitsHeader {
     /**
      * The value field shall contain a character string identifying who acquired the data associated with the key.
      */
-    OBSERVER(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "observer who acquired the data"),
+    OBSERVER(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "observer(s) who acquired the data"),
 
     /**
      * The value field shall contain a character string identifying the organization or institution responsible for
@@ -355,16 +340,10 @@ public enum Standard implements IFitsHeader {
      * represented the number of parameters preceding each group. It has since been used in 'BINTABLE' extensions to
      * represent the size of the data heap following the main data table. In most other cases its value will be zero.
      */
-    PCOUNT(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "parameter count", //
-            replaceable("asciitable:pcount", AsciiTable.class, "No group data"), //
-            replaceable("basichdu:pcount", Object.class, "Required value"), //
-            replaceable("binarytablehdu:pcount", BinaryTable.class, "Includes heap"), //
-            replaceable("binarytable:pcount", BinaryTable.class), //
-            replaceable("imagedata:pcount", ImageData.class, "One group"), //
-            replaceable("randomgroupsdata:pcount", RandomGroupsData.class), //
-            replaceable("undefineddata:pcount", UndefinedData.class) //
-
-    ),
+    PCOUNT(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "associated parameter count", //
+            replaceable("binarytable:pcount", TableData.class, "heap size in bytes"),
+            replaceable("randomgroups:pcount", RandomGroupsData.class, "parameter values per group"),
+            replaceable("undefineddata:pcount", UndefinedData.class), replaceable("header:pcount", Object.class)),
 
     /**
      * This keyword is reserved for use within the FITS Random Groups structure. This keyword shall be used, along with
@@ -374,7 +353,7 @@ public enum Standard implements IFitsHeader {
      * coefficient of the linear term, the scaling factor between true values and group parameter values at zero offset.
      * The default value for this keyword is 1.0.
      */
-    PSCALn(SOURCE.INTEGRAL, HDU.GROUPS, VALUE.REAL, "parameter scaling factor"),
+    PSCALn(SOURCE.INTEGRAL, HDU.GROUPS, VALUE.REAL, "parameter quantization scaling"),
 
     /**
      * This keyword is reserved for use within the FITS Random Groups structure. The value field shall contain a
@@ -393,7 +372,7 @@ public enum Standard implements IFitsHeader {
      * the true value corresponding to a group parameter value of zero. The default value for this keyword is 0.0. The
      * transformation equation is as follows: physical_value = PZEROn + PSCALn * group_parameter_value.DEFAULT: 0.0
      */
-    PZEROn(SOURCE.INTEGRAL, HDU.GROUPS, VALUE.REAL, "parameter scaling zero point"),
+    PZEROn(SOURCE.INTEGRAL, HDU.GROUPS, VALUE.REAL, "parameter quantization offset"),
 
     /**
      * Coordinate reference frame of major/minor axes.If absent the default value is 'FK5'. This version of the keyword
@@ -401,14 +380,14 @@ public enum Standard implements IFitsHeader {
      * 
      * @see WCS#RADESYSa
      */
-    RADESYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
+    RADESYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "celestial coordinate reference frame"),
 
     /**
      * Coordinate reference frame of major/minor axes (generic).
      *
      * @deprecated Deprecated in the current FITS satndard, use {@link #RADESYS} instead.
      */
-    RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
+    RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "celestial coordinate reference frame"),
 
     /**
      * [Hz] Rest frequency of observed spectral line.
@@ -417,14 +396,14 @@ public enum Standard implements IFitsHeader {
      * 
      * @see   WCS#RESTFRQa
      */
-    RESTFRQ(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[Hz] Line rest frequency"),
+    RESTFRQ(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[Hz] line rest frequency"),
 
     /**
      * [Hz] Rest frequeny of observed spectral line (generic).
      *
      * @deprecated Deprecated in the current FITS standard, use {@link #RESTFRQ} instead.
      */
-    RESTFREQ(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[Hz] Observed line rest frequency"),
+    RESTFREQ(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[Hz] observed line rest frequency"),
 
     /**
      * The value field shall contain a character string citing a reference where the data associated with the key are
@@ -438,7 +417,7 @@ public enum Standard implements IFitsHeader {
      * for the primary key and is not permitted in extension headers. A value of F signifies that the file does not
      * conform to this standard.
      */
-    SIMPLE(SOURCE.MANDATORY, HDU.PRIMARY, VALUE.LOGICAL, "does file conform to the Standard?", //
+    SIMPLE(SOURCE.MANDATORY, HDU.PRIMARY, VALUE.LOGICAL, "primary HDU", //
             replaceable("header:simple", Object.class, "Java FITS: " + new java.util.Date()) //
     ),
 
@@ -446,8 +425,8 @@ public enum Standard implements IFitsHeader {
      * The value field of this indexed keyword shall contain an integer specifying the column in which field n starts in
      * an ASCII TABLE extension. The first column of a row is numbered 1.RANGE: [1:]
      */
-    TBCOLn(SOURCE.MANDATORY, HDU.ASCII_TABLE, VALUE.INTEGER, "begining column number", //
-            replaceable("asciitable:tbcolN", AsciiTable.class, "Column offset") //
+    TBCOLn(SOURCE.MANDATORY, HDU.ASCII_TABLE, VALUE.INTEGER, "column byte offset", //
+            replaceable("asciitable:tbcolN", AsciiTable.class) //
     ),
 
     /**
@@ -457,9 +436,8 @@ public enum Standard implements IFitsHeader {
      * the FITS Standard in which the value string has the format '(l,m,n...)' where l, m, n,... are the dimensions of
      * the array.
      */
-    TDIMn(SOURCE.RESERVED, HDU.BINTABLE, VALUE.STRING, "dimensionality of the array ", //
-            replaceable("binarytablehdu:tdimN", BinaryTable.class), //
-            replaceable("headercard:tdimN", Object.class) //
+    TDIMn(SOURCE.RESERVED, HDU.BINTABLE, VALUE.STRING, "dimensionality of column array elements", //
+            replaceable("binarytable:tdimN", BinaryTable.class) //
     ),
 
     /**
@@ -473,24 +451,20 @@ public enum Standard implements IFitsHeader {
      * formats are not available, Ew.d may be used. The meaning of this keyword is not defined for fields of type P in
      * the Standard but may be defined in conventions using such fields.
      */
-    TDISPn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "display format"),
+    TDISPn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column display format"),
 
     /**
      * The value field shall contain a character string identifying the telescope used to acquire the data associated
      * with the key.
      */
-    TELESCOP(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "name of telescope"),
+    TELESCOP(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "name of telescope / observatory"),
 
     /**
      * The value field shall contain a non-negative integer representing the number of fields in each row of a 'TABLE'
      * or 'BINTABLE' extension. The maximum permissible value is 999. RANGE: [0:999]
      */
-    TFIELDS(SOURCE.MANDATORY, HDU.TABLE, VALUE.INTEGER, "number of columns in the table", //
-            replaceable("asciitablehdu:tfields", AsciiTable.class), //
-            replaceable("binarytable:tfields", BinaryTable.class), //
-            replaceable("tablehdu:tfields", TableData.class, "Number of table fields"), //
-            replaceable("asciitable:tfields", AsciiTable.class, "Number of fields in table") //
-    ),
+    TFIELDS(SOURCE.MANDATORY, HDU.TABLE, VALUE.INTEGER, "number of columns in the table"),
+
     /**
      * The value field of this indexed keyword shall contain a character string describing the format in which field n
      * is encoded in a 'TABLE' or 'BINTABLE' extension.
@@ -506,8 +480,8 @@ public enum Standard implements IFitsHeader {
      * product of the values of NAXIS1 and NAXIS2. This keyword shall not be used if the value of PCOUNT is zero. A
      * proposed application of this keyword is presented in Appendix B.1 of the FITS Standard.
      */
-    THEAP(SOURCE.INTEGRAL, HDU.BINTABLE, VALUE.INTEGER, "offset to starting data heap address", //
-            replaceable("binarytablehdu:theap", BinaryTable.class) //
+    THEAP(SOURCE.INTEGRAL, HDU.BINTABLE, VALUE.INTEGER, "heap byte offset", //
+            replaceable("binarytable:theap", BinaryTable.class) //
     ),
 
     /**
@@ -517,7 +491,7 @@ public enum Standard implements IFitsHeader {
      * represents an undefined value for field n of data type B, I, or J. The keyword may not be used in 'BINTABLE'
      * extensions if field n is of any other data type.
      */
-    TNULLn(SOURCE.INTEGRAL, HDU.TABLE, VALUE.STRING, "value used to indicate undefined table element"),
+    TNULLn(SOURCE.INTEGRAL, HDU.TABLE, VALUE.STRING, "column value for undefined elements"),
 
     /**
      * This indexed keyword shall be used, along with the TZEROn keyword, when the quantity in field n does not
@@ -527,7 +501,7 @@ public enum Standard implements IFitsHeader {
      * real part of the field with the imaginary part of the scaling factor set to zero. The default value for this
      * keyword is 1.0. This keyword may not be used if the format of field n is A, L, or X.DEFAULT: 1.0
      */
-    TSCALn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "linear data scaling factor"),
+    TSCALn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column quantization scaling"),
 
     /**
      * The value field for this indexed keyword shall contain a character string, giving the name of field n. It is
@@ -544,7 +518,7 @@ public enum Standard implements IFitsHeader {
      * measurements given as floating point values and specified with reserved keywords, degrees are the recommended
      * units (with the units, if specified, given as 'deg').
      */
-    TUNITn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column units"),
+    TUNITn(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column physical unit"),
 
     /**
      * This indexed keyword shall be used, along with the TSCALn keyword, when the quantity in field n does not
@@ -553,7 +527,7 @@ public enum Standard implements IFitsHeader {
      * types C and M, in the real part of the field, with the imaginary part set to zero. The default value for this
      * keyword is 0.0. This keyword may not be used if the format of field n is A, L, or X.DEFAULT: 0.0
      */
-    TZEROn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column scaling zero point"),
+    TZEROn(SOURCE.RESERVED, HDU.TABLE, VALUE.REAL, "column quantization offset"),
 
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the maximum valid
@@ -600,7 +574,13 @@ public enum Standard implements IFitsHeader {
      * for an extension key and must not appear in the primary key. For an extension that is not a standard extension,
      * the type name must not be the same as that of a standard extension.
      */
-    XTENSION(SOURCE.MANDATORY, HDU.EXTENSION, VALUE.STRING, "marks beginning of new HDU"),
+    XTENSION(SOURCE.MANDATORY, HDU.EXTENSION, VALUE.STRING, "marks beginning of new HDU",
+            replaceable("imagedata:xtension", ImageData.class, "image HDU"), //
+            replaceable("binarytable:xtension", BinaryTable.class, "binary table HDU"), //
+            replaceable("asciitable:xtension", AsciiTable.class, "ASCII table HDU"), //
+            replaceable("undefineddata:xtension", UndefinedData.class), //
+            replaceable("header:xtension", Object.class) //
+    ),
 
     /**
      * If set to <code>true</code>, it indicates that the HDU should inherit all non-confliucting keywords from the
@@ -608,7 +588,7 @@ public enum Standard implements IFitsHeader {
      * 
      * @since 1.19
      */
-    INHERIT(SOURCE.RESERVED, HDU.EXTENSION, VALUE.LOGICAL, "Inherit primary header entries");
+    INHERIT(SOURCE.RESERVED, HDU.EXTENSION, VALUE.LOGICAL, "inherit primary header entries");
 
     private static final ThreadLocal<Class<?>> COMMENT_CONTEXT = new ThreadLocal<>();
 
@@ -676,7 +656,7 @@ public enum Standard implements IFitsHeader {
     }
 
     /**
-     * Set the Data class in whose context the keyword is being used.
+     * (<i>for internal use</i>) Set the {#link nom.tam.fits.Data} subclass in whose context the keyword is being used.
      * 
      * @param clazz Usually a subclass of <code>nom.tam.fits.Data</code>.
      */
@@ -687,9 +667,11 @@ public enum Standard implements IFitsHeader {
     /**
      * scan for a comment with the specified reference key.
      *
-     * @param  commentKey the reference key
+     * @param      commentKey the reference key
      *
-     * @return            the comment for the reference key
+     * @return                the comment for the reference key
+     * 
+     * @deprecated            (<i>)for internal use</i>)
      */
     public String getCommentByKey(String commentKey) {
         for (StandardCommentReplacement commentReplacement : commentReplacements) {
@@ -707,8 +689,10 @@ public enum Standard implements IFitsHeader {
     /**
      * set the comment for the specified reference key.
      *
-     * @param commentKey the reference key
-     * @param value      the comment to set when the fits key is used.
+     * @param      commentKey the reference key
+     * @param      value      the comment to set when the fits key is used.
+     * 
+     * @deprecated            (<i>)for internal use</i>)
      */
     public void setCommentByKey(String commentKey, String value) {
         for (StandardCommentReplacement commentReplacement : commentReplacements) {

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -61,9 +61,10 @@ public enum Standard implements IFitsHeader {
      * The value field shall contain an integer. The absolute value is used in computing the sizes of data structures.
      * It shall specify the number of bits that represent a data value. RANGE: -64,-32,8,16,32
      * 
-     * @see {@link Bitpix}
+     * @see Bitpix
      */
-    BITPIX(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "bits per data element", replaceable("header:bitpix", Object.class) //
+    BITPIX(SOURCE.MANDATORY, HDU.ANY, VALUE.INTEGER, "bits per data element", //
+            replaceable("header:bitpix", Object.class) //
     ),
 
     /**
@@ -658,7 +659,8 @@ public enum Standard implements IFitsHeader {
     /**
      * @deprecated       (<i>for internal use</i>) Using {@link nom.tam.fits.HeaderCard#setComment(String)} after
      *                       creating a header card with this keyword provides a more transparent way of setting
-     *                       context-specific comments. This convoluted approach will be removed in the future.
+     *                       context-specific comments. This convoluted approach is no longer supported and will be
+     *                       removed in the future.
      * 
      * @param      clazz Usually a subclass of <code>nom.tam.fits.Data</code>.
      * 

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -11,7 +11,7 @@ import nom.tam.fits.UndefinedData;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/Standard.java
+++ b/src/main/java/nom/tam/fits/header/Standard.java
@@ -656,9 +656,13 @@ public enum Standard implements IFitsHeader {
     }
 
     /**
-     * (<i>for internal use</i>) Set the {#link nom.tam.fits.Data} subclass in whose context the keyword is being used.
+     * @deprecated       (<i>for internal use</i>) Using {@link nom.tam.fits.HeaderCard#setComment(String)} after
+     *                       creating a header card with this keyword provides a more transparent way of setting
+     *                       context-specific comments. This convoluted approach will be removed in the future.
      * 
-     * @param clazz Usually a subclass of <code>nom.tam.fits.Data</code>.
+     * @param      clazz Usually a subclass of <code>nom.tam.fits.Data</code>.
+     * 
+     * @see              nom.tam.fits.HeaderCard#setComment(String)
      */
     public static void context(Class<?> clazz) {
         COMMENT_CONTEXT.set(clazz);

--- a/src/main/java/nom/tam/fits/header/StandardCommentReplacement.java
+++ b/src/main/java/nom/tam/fits/header/StandardCommentReplacement.java
@@ -34,7 +34,9 @@ package nom.tam.fits.header;
 /**
  * Specify user defined comments for standard keywords.
  *
- * @author ritchie
+ * @author     ritchie
+ * 
+ * @deprecated (<i>for internal use</i>) Visibility may be reduced to package level in the future.
  */
 class StandardCommentReplacement {
 

--- a/src/main/java/nom/tam/fits/header/StandardCommentReplacement.java
+++ b/src/main/java/nom/tam/fits/header/StandardCommentReplacement.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -10,7 +10,7 @@ import nom.tam.fits.header.extra.STScIExt;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/WCS.java
+++ b/src/main/java/nom/tam/fits/header/WCS.java
@@ -49,42 +49,42 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    WCSNAMEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Coordinate system name"),
+    WCSNAMEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "coordinate system name"),
 
     /**
      * Dimensionality of image coordinate system
      * 
      * @since 1.19
      */
-    WCSAXESa(SOURCE.RESERVED, HDU.IMAGE, VALUE.INTEGER, "Coordinate system dimensions"),
+    WCSAXESa(SOURCE.RESERVED, HDU.IMAGE, VALUE.INTEGER, "coordinate dimensions"),
 
     /**
      * Coordinate reference frame of major/minor axes.If absent the default value is 'FK5'.
      * 
      * @since 1.19
      */
-    RADESYSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
+    RADESYSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "celestial coordinate reference frame."),
 
     /**
      * Coordinate reference frame of major/minor axes (generic).
      *
      * @deprecated Deprecated in the current FITS standard, use {@link #RADESYSa} instead.
      */
-    RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "Coordinate reference frame of major/minor axes."),
+    RADECSYS(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "celestial coordinate reference frame."),
 
     /**
      * [deg] The longitude of the celestial pole (for spherical coordinates).
      * 
      * @since 1.19
      */
-    LONPOLEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] Celestial pole longitude"),
+    LONPOLEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] celestial pole longitude"),
 
     /**
      * [deg] The latitude of the celestial pole (for spherical coordinates).
      * 
      * @since 1.19
      */
-    LATPOLEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] Celestial pole latitude"),
+    LATPOLEa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] celestial pole latitude"),
 
     /**
      * The value field shall contain a floating point number giving the equinox in years for the celestial coordinate
@@ -120,7 +120,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    CRPIXna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate system reference pixel"),
+    CRPIXna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate axis reference pixel"),
 
     /**
      * The value field shall contain a floating point number, giving the value of the coordinate specified by the CTYPEn
@@ -128,7 +128,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    CRVALna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate system value at reference pixel"),
+    CRVALna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate axis value at reference pixel"),
 
     /**
      * The value field shall contain a character string, giving the name of the coordinate represented by axis n.
@@ -145,7 +145,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    CDELTna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate increment along axis"),
+    CDELTna(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "coordinate spacing along axis"),
 
     /**
      * Random coordinate error on axis <i>n</i> in the physical coordinate unit (if defined).
@@ -178,42 +178,42 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    RESTFRQa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[Hz] Line rest frequency"),
+    RESTFRQa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[Hz] line rest frequency"),
 
     /**
      * [Hz] Rest frequeny of observed spectral line (generic).
      *
      * @deprecated Deprecated in the current FITS standard, use {@link #RESTFRQa} instead.
      */
-    RESTFREQ(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[Hz] Observed line rest frequency"),
+    RESTFREQ(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[Hz] observed line rest frequency"),
 
     /**
      * [m] Rest wavelength of observed spectral line in image.
      * 
      * @since 1.19
      */
-    RESTWAVa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[m] Line rest wavelength"),
+    RESTWAVa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[m] line rest wavelength"),
 
     /**
      * Image spectral reference system name.
      * 
      * @since 1.19
      */
-    SPECSYSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Spectral reference frame"),
+    SPECSYSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "spectral reference frame"),
 
     /**
      * Image spectral reference system name of observer.
      * 
      * @since 1.19
      */
-    SSYSOBSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Spectral reference frame of observer"),
+    SSYSOBSa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "spectral reference frame of observer"),
 
     /**
      * Spectral reference system name of source.
      * 
      * @since 1.19
      */
-    SSYSSRCa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "Spectral reference frame of source"),
+    SSYSSRCa(SOURCE.RESERVED, HDU.IMAGE, VALUE.STRING, "spectral reference frame of source"),
 
     /**
      * [m/s] Radial velocity of source in the spectral reference frame.
@@ -234,35 +234,35 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    VELANGLa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] True velocity angle"),
+    VELANGLa(SOURCE.RESERVED, HDU.IMAGE, VALUE.REAL, "[deg] true velocity angle"),
 
     /**
      * [m] Geodetic location of observer (<i>x</i> coordinate).
      * 
      * @since 1.19
      */
-    OBSGEO_X("OBSGEO-X", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] Geodetic location x of observer"),
+    OBSGEO_X("OBSGEO-X", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] geodetic location x of observer"),
 
     /**
      * [m] Geodetic location of observer (<i>y</i> coordinate).
      * 
      * @since 1.19
      */
-    OBSGEO_Y("OBSGEO-Y", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] Geodetic location y of observer"),
+    OBSGEO_Y("OBSGEO-Y", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] geodetic location y of observer"),
 
     /**
      * [m] Geodetic location of observer (<i>z</i> coordinate).
      * 
      * @since 1.19
      */
-    OBSGEO_Z("OBSGEO-Z", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] Geodetic location z of observer"),
+    OBSGEO_Z("OBSGEO-Z", SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[m] geodetic location z of observer"),
 
     /**
      * WCS name for the array entries in the given column index.
      * 
      * @since 1.19
      */
-    WCSNna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column WCS name"),
+    WCSNna(SOURCE.RESERVED, HDU.TABLE, VALUE.STRING, "column coordinate syste name"),
 
     /**
      * [deg] The longitude of the celestial pole for the entries in the given column index (for spherical coordinates).
@@ -619,7 +619,7 @@ public enum WCS implements IFitsHeader {
      * 
      * @since 1.19
      */
-    WCAXna(SOURCE.RESERVED, HDU.TABLE, VALUE.INTEGER, "Coordinate dimensions"),
+    WCAXna(SOURCE.RESERVED, HDU.TABLE, VALUE.INTEGER, "column coordinate dimensions"),
 
     /**
      * The coordinate axis type for (1D) pixel lists in this column (trailing index). This version does not support
@@ -958,8 +958,8 @@ public enum WCS implements IFitsHeader {
     }
 
     /**
-     * Use for specifying an alternative coordinate system. Alterntive systems are labelled 'A' through 'Z'. This call
-     * is available only for the enums, which have a lower-case 'a' at the end of their Java names (such as
+     * Specifying an alternative coordinate system. Alternative systems are labelled 'A' through 'Z'. This call is
+     * available only for the enums, which have a lower-case 'a' at the end of their Java names (such as
      * {@link #WCSNAMEa}). Attempting to call this on WCS keywords that do not end with lower-case 'a' in their Java
      * names (such as {@link #OBSGEO_X} will throw and {@link UnsupportedOperationException}. You will want to call this
      * before chaining other calls to {@link IFitsHeader}.
@@ -973,6 +973,8 @@ public enum WCS implements IFitsHeader {
      * @throws IllegalArgumentException      if the marker is outside of the legal range of 'A' through 'Z' (case
      *                                           insensitive).
      * @throws UnsupportedOperationException if the keyword does not support alternative coordinate systems
+     * 
+     * @since                                1.19
      */
     public IFitsHeader alt(char c) throws IllegalArgumentException, UnsupportedOperationException {
         if (!name().endsWith("a")) {

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header.extra;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -39,8 +39,8 @@ import nom.tam.fits.header.IFitsHeader;
  *
  * @author     Richard van Nieuwenhoven
  * 
- * @deprecated Will be removed in the future. This enum is duplicated by both {@link CXCExt} and {@link STScIExt}, and
- *                 users would (should) typically use one or the other.
+ * @deprecated This enum is duplicated by both {@link CXCExt} and {@link STScIExt}, and users would (should) typically
+ *                 use one or the other.
  */
 public enum CXCStclSharedExt implements IFitsHeader {
     /**

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header.extra;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header.extra;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header.extra;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header.extra;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -75,8 +75,8 @@ public enum STScIExt implements IFitsHeader {
      */
     FOV_Y_MM("Detector Y field of view (mm)"),
     /**
-     * BITS/PIXEL OF IPPS RASTER. In truth this is an illegal FITS keyword, as the character '/' should not be allowed
-     * in standard FITS keywords. If possible, avoid using it since it may result in FITS that is not readable by some
+     * BITS/PIXEL OF IPPS RASTER. In truth this is an illegal FITS keyword, as the character '/' is not allowed in
+     * standard FITS keywords. If possible, avoid using it since it may result in FITS that is not readable by some
      * software.
      */
     IPPS_B_P("IPPS-B/P", "BITS/PIXEL OF IPPS RASTER."),

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header.extra;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/extra/package-info.java
+++ b/src/main/java/nom/tam/fits/header/extra/package-info.java
@@ -10,7 +10,7 @@ package nom.tam.fits.header.extra;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/header/extra/package-info.java
+++ b/src/main/java/nom/tam/fits/header/extra/package-info.java
@@ -1,6 +1,6 @@
 /**
  * <p>
- * Various registered conventions for FITS header keywords.
+ * Various commonly used conventions for FITS header keywords, listed by organization.
  * </p>
  */
 

--- a/src/main/java/nom/tam/fits/header/hierarch/BlanksDotHierarchKeyFormatter.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/BlanksDotHierarchKeyFormatter.java
@@ -8,7 +8,7 @@ import nom.tam.fits.utilities.FitsLineAppender;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/Hierarch.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header.hierarch;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/header/hierarch/IHierarchKeyFormatter.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/IHierarchKeyFormatter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.header.hierarch;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/hierarch/StandardIHierarchKeyFormatter.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/StandardIHierarchKeyFormatter.java
@@ -8,7 +8,7 @@ import nom.tam.fits.utilities.FitsLineAppender;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/header/hierarch/package-info.java
+++ b/src/main/java/nom/tam/fits/header/hierarch/package-info.java
@@ -11,7 +11,7 @@ package nom.tam.fits.header.hierarch;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/header/package-info.java
+++ b/src/main/java/nom/tam/fits/header/package-info.java
@@ -24,7 +24,7 @@ package nom.tam.fits.header;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/header/package-info.java
+++ b/src/main/java/nom/tam/fits/header/package-info.java
@@ -1,62 +1,21 @@
 /**
  * <p>
- * Standardized FITS header keywords, as per FITS specification.
+ * Standardized FITS header keywords. In addition to the reserved keywords defined by the FITS standard, there are
+ * conventions and commonly adopted usage patterns. Many organisations have defined their own sets of keywords also. To
+ * help users conform to the standards and conventions, the library offers a collection the standard and commonly used
+ * FITS keywords.
  * </p>
  * <p>
- * There many many sources of FITS keywords. In addition to the standards documents many organisations (or groups of
- * organisations) have defined their own sets of keywords. This results in many different dictionaries with partly
- * overlapping definitions. To help the "normal" user of FITS files with these we started to collect the standards and
- * will try to include them in this library to ease the use of the "right" keyword.
+ * Using these 'standardized' keywords can now make compiler checked references to keywords (No more pruney String
+ * references), and prevents improper usage by restricting the types of HDUs keywords may appear in, as well as what
+ * type of values they may be associated with. See
+ * {@link nom.tam.fits.Header#setKeywordChecking(nom.tam.fits.Header.KeywordCheck)} and
+ * {@link nom.tam.fits.HeaderCard#setValueCheckingPolicy(nom.tam.fits.HeaderCard.ValueCheck)} on controlling what
+ * checking is done on keyword usage and how violations are dealt with.
  * </p>
  * <p>
- * These dictionaries are organized in a hierarchical form, that means every dictionary extends the list of keywords of
- * another dictionary. The root of this tree of dictionaries is the dictionary used in the standard text itself. Under
- * that is a dictionary that resulted from different libraries that used the same keywords, these are collected in a
- * dictionary with commonly used keywords.
- * </p>
- * <p>
- * These enumerations of keywords (dictionaries) can be found in and under the packages: {@link nom.tam.fits.header}
- * {@link nom.tam.fits.header.extra} Currently we include:
- * </p>
- *
- * <pre>
- * Standard
- *   The core mandatory and reserved keywords of the FITS standard  
- *   source: [http://heasarc.gsfc.nasa.gov/docs/fcg/standard_dict.html](http://heasarc.gsfc.nasa.gov/docs/fcg/standard_dict.html) |
- * WCS
- *   World Coordinate Systems (WCS) standard keywords, with support for alternate coordinate systems
- * DateTime
- *   FITS standard date-time related keywords
- * NonStandard
- *   A set of commonly used keyword conventions outside of the FITS standard
- * DataDescription
- *   Commonly used keywords to further describe the data
- * InstrumentDescription
- *   Commonly used keywords to describe the instrument used to obtain the data
- * ObservationDescription
- *   Commonly used keywords that describe the observation
- * ObservationDurationDescription
- *   Commonly used keywords that describe the length of observation.
- * NOAO
- *   source: [http://iraf.noao.edu/iraf/web/projects/ccdmosaic/imagedef/fitsdic.html](http://iraf.noao.edu/iraf/web/projects/ccdmosaic/imagedef/fitsdic.html)
- * SBFits
- *   source: [http://archive.sbig.com/pdffiles/SBFITSEXT_1r0.pdf](http://archive.sbig.com/pdffiles/SBFITSEXT_1r0.pdf)
- * MaxImDL
- *   source: [http://www.cyanogen.com/help/maximdl/FITS_File_Header_Definitions.htm](http://www.cyanogen.com/help/maximdl/FITS_File_Header_Definitions.htm)
- * CXC
- *   source: [http://cxc.harvard.edu/contrib/arots/fits/content.txt](http://cxc.harvard.edu/contrib/arots/fits/content.txt)
- * STScI
- *   source: [http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html](http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html)  |
- * </pre>
- * <p>
- * There are synonymous keywords within these dictionaries, These we also started to collect in the {@link nom.tam.fits.header.Synonyms}
- * class in the header package.
- * </p>
- * <p>
- * All these enums have no real effect for now in the library apart from the fact that you can now make compiler checked
- * references to keywords (No more pruney String references). Future versions of the library will try to validate
- * against them and warn you if you appear to be using a keyword inapprpopriately (in the wrong HDU, wrong type, etc)
- * deprecated keyword.
+ * Some of these dictionaries contain keywords that have equivalent usage. These are listed in
+ * {@link nom.tam.fits.header.Synonyms}.
  * </p>
  */
 package nom.tam.fits.header;

--- a/src/main/java/nom/tam/fits/package-info.java
+++ b/src/main/java/nom/tam/fits/package-info.java
@@ -15,7 +15,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
@@ -4,7 +4,7 @@ package nom.tam.fits.utilities;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/utilities/FitsCopy.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCopy.java
@@ -4,7 +4,7 @@ package nom.tam.fits.utilities;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/utilities/FitsLineAppender.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsLineAppender.java
@@ -6,7 +6,7 @@ import nom.tam.fits.HeaderCard;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/utilities/FitsReader.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsReader.java
@@ -4,7 +4,7 @@ package nom.tam.fits.utilities;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/utilities/FitsSubString.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsSubString.java
@@ -4,7 +4,7 @@ package nom.tam.fits.utilities;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/utilities/Main.java
+++ b/src/main/java/nom/tam/fits/utilities/Main.java
@@ -4,7 +4,7 @@ package nom.tam.fits.utilities;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/fits/utilities/package-info.java
+++ b/src/main/java/nom/tam/fits/utilities/package-info.java
@@ -11,7 +11,7 @@ package nom.tam.fits.utilities;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/ImageTiler.java
+++ b/src/main/java/nom/tam/image/ImageTiler.java
@@ -8,7 +8,7 @@ package nom.tam.image;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/StandardImageTiler.java
+++ b/src/main/java/nom/tam/image/StandardImageTiler.java
@@ -6,7 +6,7 @@ import java.io.EOFException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/StreamingTileImageData.java
+++ b/src/main/java/nom/tam/image/StreamingTileImageData.java
@@ -4,7 +4,7 @@ package nom.tam.image;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/compression/CompressedImageTiler.java
+++ b/src/main/java/nom/tam/image/compression/CompressedImageTiler.java
@@ -12,7 +12,7 @@ import java.util.logging.Logger;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2022 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTile.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTile.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.bintable;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileCompressor.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileCompressor.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.bintable;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDecompressor.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDecompressor.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.bintable;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDescription.java
+++ b/src/main/java/nom/tam/image/compression/bintable/BinaryTableTileDescription.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.bintable;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/bintable/package-info.java
+++ b/src/main/java/nom/tam/image/compression/bintable/package-info.java
@@ -14,7 +14,7 @@ package nom.tam.image.compression.bintable;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedCard.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedCard.java
@@ -14,7 +14,7 @@ import nom.tam.util.Cursor;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedCard.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedCard.java
@@ -81,6 +81,7 @@ import static nom.tam.fits.header.Standard.XTENSION;
  * uncompressed HDU is remapped to ZNAXIS1 in the compressed HDU so it does not interfere with the different layout of
  * the compressed HDU vs the layout of the original one.
  */
+@SuppressWarnings("deprecation")
 enum CompressedCard {
     MAP_ANY(null) {
 
@@ -105,9 +106,7 @@ enum CompressedCard {
             }
         }
     },
-    MAP_GCOUNT(GCOUNT), MAP_NAXIS(NAXIS), MAP_NAXISn(NAXISn), MAP_PCOUNT(PCOUNT),
-    // MAP_TFIELDS(TFIELDS),
-    MAP_ZFORMn(ZFORMn) {
+    MAP_GCOUNT(GCOUNT), MAP_NAXIS(NAXIS), MAP_NAXISn(NAXISn), MAP_PCOUNT(PCOUNT), MAP_ZFORMn(ZFORMn) {
 
         @Override
         protected void backupCard(HeaderCard card, Cursor<String, HeaderCard> headerIterator) throws HeaderCardException {
@@ -122,22 +121,22 @@ enum CompressedCard {
         }
 
     },
-    MAP_TFORMn(TFORMn), MAP_XTENSION(XTENSION), MAP_ZBITPIX(ZBITPIX), MAP_ZBLANK(ZBLANK), MAP_ZTILELEN(
-            ZTILELEN), MAP_ZCTYPn(ZCTYPn), @SuppressWarnings("deprecation")
-    MAP_ZBLOCKED(ZBLOCKED), MAP_ZCMPTYPE(ZCMPTYPE), MAP_ZDATASUM(ZDATASUM), MAP_ZDITHER0(ZDITHER0), MAP_ZEXTEND(
-            ZEXTEND), MAP_ZGCOUNT(ZGCOUNT), MAP_ZHECKSUM(ZHECKSUM), MAP_ZIMAGE(
-                    ZIMAGE), MAP_ZTABLE(ZTABLE), MAP_ZNAMEn(ZNAMEn), MAP_ZNAXIS(ZNAXIS), MAP_THEAP(THEAP) {
 
-                        @Override
-                        protected void backupCard(HeaderCard card, Cursor<String, HeaderCard> headerIterator)
-                                throws HeaderCardException {
-                        }
+    MAP_TFORMn(TFORMn), MAP_XTENSION(XTENSION), MAP_ZBITPIX(ZBITPIX), MAP_ZBLANK(ZBLANK), //
+    MAP_ZTILELEN(ZTILELEN), MAP_ZCTYPn(ZCTYPn), MAP_ZBLOCKED(ZBLOCKED), MAP_ZCMPTYPE(ZCMPTYPE), //
+    MAP_ZDATASUM(ZDATASUM), MAP_ZDITHER0(ZDITHER0), MAP_ZEXTEND(ZEXTEND), MAP_ZGCOUNT(ZGCOUNT), //
+    MAP_ZHECKSUM(ZHECKSUM), MAP_ZIMAGE(ZIMAGE), MAP_ZTABLE(ZTABLE), MAP_ZNAMEn(ZNAMEn), //
+    MAP_ZNAXIS(ZNAXIS), MAP_THEAP(THEAP) {
 
-                        @Override
-                        protected void restoreCard(HeaderCard card, Cursor<String, HeaderCard> headerIterator)
-                                throws HeaderCardException {
-                        }
-                    },
+        @Override
+        protected void backupCard(HeaderCard card, Cursor<String, HeaderCard> headerIterator) throws HeaderCardException {
+        }
+
+        @Override
+        protected void restoreCard(HeaderCard card, Cursor<String, HeaderCard> headerIterator) throws HeaderCardException {
+        }
+    },
+
     MAP_ZNAXISn(ZNAXISn) {
 
         @Override
@@ -170,8 +169,7 @@ enum CompressedCard {
         mapping.restoreCard(card, headerIterator);
     }
 
-    protected static CompressedCard selectMapping(
-            Map<IFitsHeader, CompressedCard> mappings, HeaderCard card) {
+    protected static CompressedCard selectMapping(Map<IFitsHeader, CompressedCard> mappings, HeaderCard card) {
         IFitsHeader key = GenericKey.lookup(card.getKey());
         if (key != null) {
             CompressedCard mapping = mappings.get(key);

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedImageData.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedImageData.java
@@ -15,7 +15,7 @@ import nom.tam.util.ArrayFuncs;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedImageHDU.java
@@ -32,7 +32,7 @@ import nom.tam.util.FitsOutputStream;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
@@ -19,7 +19,7 @@ import nom.tam.util.ColumnTable;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableHDU.java
@@ -15,7 +15,7 @@ import nom.tam.util.type.ElementType;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/hdu/package-info.java
+++ b/src/main/java/nom/tam/image/compression/hdu/package-info.java
@@ -11,7 +11,7 @@ package nom.tam.image.compression.hdu;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/compression/package-info.java
+++ b/src/main/java/nom/tam/image/compression/package-info.java
@@ -8,7 +8,7 @@ package nom.tam.image.compression;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/compression/tile/TileCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileCompressionOperation.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/TileCompressionType.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileCompressionType.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/TileCompressor.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileCompressor.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/TileCompressorInitialisation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileCompressorInitialisation.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/TileDecompressor.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileDecompressor.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/TileDecompressorInitialisation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileDecompressorInitialisation.java
@@ -9,7 +9,7 @@ import nom.tam.image.tile.operation.TileArea;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -28,7 +28,7 @@ import nom.tam.util.type.ElementType;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/AbstractNullPixelMask.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile.mask;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/mask/ImageNullPixelMask.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/ImageNullPixelMask.java
@@ -10,7 +10,7 @@ import nom.tam.image.tile.operation.buffer.TileBuffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/mask/NullPixelMaskPreserver.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/NullPixelMaskPreserver.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile.mask;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/mask/NullPixelMaskRestorer.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/NullPixelMaskRestorer.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile.mask;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/compression/tile/mask/package-info.java
+++ b/src/main/java/nom/tam/image/compression/tile/mask/package-info.java
@@ -20,7 +20,7 @@ package nom.tam.image.compression.tile.mask;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/compression/tile/package-info.java
+++ b/src/main/java/nom/tam/image/compression/tile/package-info.java
@@ -22,7 +22,7 @@ package nom.tam.image.compression.tile;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/package-info.java
+++ b/src/main/java/nom/tam/image/package-info.java
@@ -10,7 +10,7 @@ package nom.tam.image;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/tile/operation/AbstractTileOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/AbstractTileOperation.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/AbstractTiledImageOperation.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/ITileOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/ITileOperation.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/ITileOperationInitialisation.java
+++ b/src/main/java/nom/tam/image/tile/operation/ITileOperationInitialisation.java
@@ -6,7 +6,7 @@ import nom.tam.fits.FitsException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/ITiledImageOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/ITiledImageOperation.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/TileArea.java
+++ b/src/main/java/nom/tam/image/tile/operation/TileArea.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBuffer.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBuffer.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation.buffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferColumnBased.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferColumnBased.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation.buffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferFactory.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferFactory.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation.buffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferRowBased.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/TileBufferRowBased.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation.buffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/image/tile/operation/buffer/package-info.java
+++ b/src/main/java/nom/tam/image/tile/operation/buffer/package-info.java
@@ -19,7 +19,7 @@ package nom.tam.image.tile.operation.buffer;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/image/tile/operation/package-info.java
+++ b/src/main/java/nom/tam/image/tile/operation/package-info.java
@@ -19,7 +19,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/util/ArrayDataFile.java
+++ b/src/main/java/nom/tam/util/ArrayDataFile.java
@@ -6,7 +6,7 @@ import java.io.EOFException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ArrayDataInput.java
+++ b/src/main/java/nom/tam/util/ArrayDataInput.java
@@ -7,7 +7,7 @@ import java.io.EOFException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ArrayDataOutput.java
+++ b/src/main/java/nom/tam/util/ArrayDataOutput.java
@@ -6,7 +6,7 @@ import java.io.DataOutput;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ArrayInputStream.java
+++ b/src/main/java/nom/tam/util/ArrayInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ArrayOutputStream.java
+++ b/src/main/java/nom/tam/util/ArrayOutputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/AsciiFuncs.java
+++ b/src/main/java/nom/tam/util/AsciiFuncs.java
@@ -11,7 +11,7 @@ import java.text.ParsePosition;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/BufferDecoder.java
+++ b/src/main/java/nom/tam/util/BufferDecoder.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/BufferEncoder.java
+++ b/src/main/java/nom/tam/util/BufferEncoder.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/BufferPointer.java
+++ b/src/main/java/nom/tam/util/BufferPointer.java
@@ -6,7 +6,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/BufferedDataInputStream.java
+++ b/src/main/java/nom/tam/util/BufferedDataInputStream.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/BufferedDataOutputStream.java
+++ b/src/main/java/nom/tam/util/BufferedDataOutputStream.java
@@ -6,7 +6,7 @@ import java.io.IOException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/BufferedFile.java
+++ b/src/main/java/nom/tam/util/BufferedFile.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/BufferedFileIO.java
+++ b/src/main/java/nom/tam/util/BufferedFileIO.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ByteArrayIO.java
+++ b/src/main/java/nom/tam/util/ByteArrayIO.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ByteBufferInputStream.java
+++ b/src/main/java/nom/tam/util/ByteBufferInputStream.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ByteBufferOutputStream.java
+++ b/src/main/java/nom/tam/util/ByteBufferOutputStream.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ByteFormatter.java
+++ b/src/main/java/nom/tam/util/ByteFormatter.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ByteParser.java
+++ b/src/main/java/nom/tam/util/ByteParser.java
@@ -6,7 +6,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ColumnTable.java
+++ b/src/main/java/nom/tam/util/ColumnTable.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ComplexValue.java
+++ b/src/main/java/nom/tam/util/ComplexValue.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/Cursor.java
+++ b/src/main/java/nom/tam/util/Cursor.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/CursorValue.java
+++ b/src/main/java/nom/tam/util/CursorValue.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/DataTable.java
+++ b/src/main/java/nom/tam/util/DataTable.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FitsDecoder.java
+++ b/src/main/java/nom/tam/util/FitsDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FitsEncoder.java
+++ b/src/main/java/nom/tam/util/FitsEncoder.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FitsFile.java
+++ b/src/main/java/nom/tam/util/FitsFile.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FitsIO.java
+++ b/src/main/java/nom/tam/util/FitsIO.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FitsInputStream.java
+++ b/src/main/java/nom/tam/util/FitsInputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FitsOutput.java
+++ b/src/main/java/nom/tam/util/FitsOutput.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FitsOutputStream.java
+++ b/src/main/java/nom/tam/util/FitsOutputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FlexFormat.java
+++ b/src/main/java/nom/tam/util/FlexFormat.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/FormatException.java
+++ b/src/main/java/nom/tam/util/FormatException.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/HashedList.java
+++ b/src/main/java/nom/tam/util/HashedList.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/InputDecoder.java
+++ b/src/main/java/nom/tam/util/InputDecoder.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/InputReader.java
+++ b/src/main/java/nom/tam/util/InputReader.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/LoggerHelper.java
+++ b/src/main/java/nom/tam/util/LoggerHelper.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/OutputEncoder.java
+++ b/src/main/java/nom/tam/util/OutputEncoder.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/OutputWriter.java
+++ b/src/main/java/nom/tam/util/OutputWriter.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/RandomAccess.java
+++ b/src/main/java/nom/tam/util/RandomAccess.java
@@ -6,7 +6,7 @@ import java.io.IOException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/RandomAccessFileIO.java
+++ b/src/main/java/nom/tam/util/RandomAccessFileIO.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/ReadWriteAccess.java
+++ b/src/main/java/nom/tam/util/ReadWriteAccess.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/SafeClose.java
+++ b/src/main/java/nom/tam/util/SafeClose.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/TableException.java
+++ b/src/main/java/nom/tam/util/TableException.java
@@ -6,7 +6,7 @@ import nom.tam.fits.FitsException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/array/MultiArrayCopier.java
+++ b/src/main/java/nom/tam/util/array/MultiArrayCopier.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/array/MultiArrayCopyFactory.java
+++ b/src/main/java/nom/tam/util/array/MultiArrayCopyFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/array/MultiArrayIterator.java
+++ b/src/main/java/nom/tam/util/array/MultiArrayIterator.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/array/MultiArrayPointer.java
+++ b/src/main/java/nom/tam/util/array/MultiArrayPointer.java
@@ -4,7 +4,7 @@ package nom.tam.util.array;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/array/package-info.java
+++ b/src/main/java/nom/tam/util/array/package-info.java
@@ -2,7 +2,7 @@
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/util/package-info.java
+++ b/src/main/java/nom/tam/util/package-info.java
@@ -11,7 +11,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/main/java/nom/tam/util/type/BooleanType.java
+++ b/src/main/java/nom/tam/util/type/BooleanType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/ByteType.java
+++ b/src/main/java/nom/tam/util/type/ByteType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/CharType.java
+++ b/src/main/java/nom/tam/util/type/CharType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/DoubleType.java
+++ b/src/main/java/nom/tam/util/type/DoubleType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/ElementType.java
+++ b/src/main/java/nom/tam/util/type/ElementType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/FloatType.java
+++ b/src/main/java/nom/tam/util/type/FloatType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/IntType.java
+++ b/src/main/java/nom/tam/util/type/IntType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/LongType.java
+++ b/src/main/java/nom/tam/util/type/LongType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/PrimitiveType.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/PrimitiveTypeBase.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveTypeBase.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/PrimitiveTypeHandler.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveTypeHandler.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/PrimitiveTypes.java
+++ b/src/main/java/nom/tam/util/type/PrimitiveTypes.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/ShortType.java
+++ b/src/main/java/nom/tam/util/type/ShortType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/StringType.java
+++ b/src/main/java/nom/tam/util/type/StringType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/UnknownType.java
+++ b/src/main/java/nom/tam/util/type/UnknownType.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/main/java/nom/tam/util/type/package-info.java
+++ b/src/main/java/nom/tam/util/type/package-info.java
@@ -8,7 +8,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/fits/BadData.java
+++ b/src/test/java/nom/tam/fits/BadData.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/BasicHDUTest.java
+++ b/src/test/java/nom/tam/fits/BasicHDUTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/BasicHduFailureTest.java
+++ b/src/test/java/nom/tam/fits/BasicHduFailureTest.java
@@ -13,7 +13,7 @@ import nom.tam.util.test.ThrowAnyException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -10,7 +10,7 @@ import java.math.BigInteger;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/fits/BitpixTest.java
+++ b/src/test/java/nom/tam/fits/BitpixTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/DeferredTest.java
+++ b/src/test/java/nom/tam/fits/DeferredTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/DeprecatedTest.java
+++ b/src/test/java/nom/tam/fits/DeprecatedTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/FitsDateTest.java
+++ b/src/test/java/nom/tam/fits/FitsDateTest.java
@@ -8,7 +8,7 @@ import java.util.TimeZone;
  * * nom.tam FITS library
  * *
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * *
  * %%
  * This is free and unencumbered software released into the public domain.

--- a/src/test/java/nom/tam/fits/FitsHeapTest.java
+++ b/src/test/java/nom/tam/fits/FitsHeapTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/FitsUtilTest.java
+++ b/src/test/java/nom/tam/fits/FitsUtilTest.java
@@ -6,7 +6,7 @@ import java.text.ParsePosition;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/fits/GetHDUByNameTest.java
+++ b/src/test/java/nom/tam/fits/GetHDUByNameTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/HeaderOrderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderOrderTest.java
@@ -14,7 +14,7 @@ import nom.tam.util.FitsOutputStream;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -1,6 +1,7 @@
 package nom.tam.fits;
 
 import java.io.ByteArrayOutputStream;
+import java.util.NoSuchElementException;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -125,12 +126,12 @@ public class HeaderProtectedTest {
         Assert.assertEquals(123, GenericKey.getN(Standard.TFORMn.n(123).key()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
     public void testKeyIndexNegative() {
         Standard.TFORMn.n(-1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
     public void testKeyIndexTooLarge() {
         Standard.TFORMn.n(1000);
     }
@@ -155,7 +156,7 @@ public class HeaderProtectedTest {
         WCS.OBSGEO_X.alt('A');
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test(expected = NoSuchElementException.class)
     public void testTooManyIndices() {
         Standard.CTYPEn.n(1, 2);
     }

--- a/src/test/java/nom/tam/fits/HeaderProtectedTest.java
+++ b/src/test/java/nom/tam/fits/HeaderProtectedTest.java
@@ -21,7 +21,7 @@ import nom.tam.util.FitsOutputStream;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -45,7 +45,7 @@ import nom.tam.util.test.ThrowAnyException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -808,7 +808,7 @@ public class HeaderTest {
             assertTrue(result.indexOf("NAXIS1  =                  300") >= 0);
             assertTrue(result.indexOf("NAXIS2  =                  300") >= 0);
 
-            assertEquals("NAXIS1  =                  300 / size of the n'th axis", hdr.findKey("NAXIS1").trim());
+            assertEquals("NAXIS1  =                  300 / " + Standard.NAXIS1.comment(), hdr.findKey("NAXIS1").trim());
 
             assertEquals("SIMPLE", hdr.getKey(0));
             assertEquals(7, hdr.size());

--- a/src/test/java/nom/tam/fits/ImageProtectedTest.java
+++ b/src/test/java/nom/tam/fits/ImageProtectedTest.java
@@ -17,7 +17,7 @@ import nom.tam.util.test.ThrowAnyException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/IncrementalWriteTest.java
+++ b/src/test/java/nom/tam/fits/IncrementalWriteTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/KeyTypeTest.java
+++ b/src/test/java/nom/tam/fits/KeyTypeTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/NullDataTest.java
+++ b/src/test/java/nom/tam/fits/NullDataTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/ProtectedFitsTest.java
+++ b/src/test/java/nom/tam/fits/ProtectedFitsTest.java
@@ -13,7 +13,7 @@ import nom.tam.fits.header.Standard;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/RepositionTest.java
+++ b/src/test/java/nom/tam/fits/RepositionTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/SubstringTest.java
+++ b/src/test/java/nom/tam/fits/SubstringTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/fits/TruncatedFileExceptionTest.java
+++ b/src/test/java/nom/tam/fits/TruncatedFileExceptionTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/UndefinedDataTest.java
+++ b/src/test/java/nom/tam/fits/UndefinedDataTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/fits/compression/CreateTstImages.java
+++ b/src/test/java/nom/tam/fits/compression/CreateTstImages.java
@@ -23,7 +23,7 @@ import nom.tam.util.FitsFile;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/IHDUAsserter.java
+++ b/src/test/java/nom/tam/fits/compression/IHDUAsserter.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
+++ b/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertEquals;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/TileCompressorControlNameComputerTest.java
+++ b/src/test/java/nom/tam/fits/compression/TileCompressorControlNameComputerTest.java
@@ -13,7 +13,7 @@ import nom.tam.fits.header.Compression;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.gzip;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/algorithm/gzip2/GZip2CompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/gzip2/GZip2CompressTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.gzip2;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.hcompress;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/algorithm/plio/PLIOCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/plio/PLIOCompressTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.plio;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.quant;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.rice;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/algorithm/uncompressed/UnCompressedCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/uncompressed/UnCompressedCompressTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.algorithm.uncompressed;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/common/Options.java
+++ b/src/test/java/nom/tam/fits/compression/common/Options.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.common;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/provider/CompressionProviderTest.java
+++ b/src/test/java/nom/tam/fits/compression/provider/CompressionProviderTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/compression/provider/TileCompressorAlternativProvider.java
+++ b/src/test/java/nom/tam/fits/compression/provider/TileCompressorAlternativProvider.java
@@ -4,7 +4,7 @@ package nom.tam.fits.compression.provider;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/doc/GenerateReleaseNote.java
+++ b/src/test/java/nom/tam/fits/doc/GenerateReleaseNote.java
@@ -4,7 +4,7 @@ package nom.tam.fits.doc;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/BaseFitsTest.java
+++ b/src/test/java/nom/tam/fits/test/BaseFitsTest.java
@@ -71,7 +71,7 @@ import nom.tam.util.test.ThrowAnyException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/BinaryTableTest.java
+++ b/src/test/java/nom/tam/fits/test/BinaryTableTest.java
@@ -49,7 +49,7 @@ import nom.tam.util.TestArrayFuncs;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/BuilderApiTest.java
+++ b/src/test/java/nom/tam/fits/test/BuilderApiTest.java
@@ -17,7 +17,7 @@ import nom.tam.fits.header.Standard;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/ChecksumTest.java
+++ b/src/test/java/nom/tam/fits/test/ChecksumTest.java
@@ -39,7 +39,7 @@ import nom.tam.util.test.ThrowAnyException;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/ChecksumTest.java
+++ b/src/test/java/nom/tam/fits/test/ChecksumTest.java
@@ -139,7 +139,7 @@ public class ChecksumTest {
         fits.read();
         in.close();
         fits.setChecksum();
-        assertEquals("kGpMn9mJkEmJk9mJ", fits.getHDU(0).getHeader().getStringValue("CHECKSUM"));
+        assertEquals("Bd5LEb5LBb5LBb5L", fits.getHDU(0).getHeader().getStringValue("CHECKSUM"));
     }
 
     // TODO This test fails in the CI for some reason, but not locally.

--- a/src/test/java/nom/tam/fits/test/CompressTest.java
+++ b/src/test/java/nom/tam/fits/test/CompressTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertTrue;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/CompressWithoutDependenciesTest.java
+++ b/src/test/java/nom/tam/fits/test/CompressWithoutDependenciesTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/DupTest.java
+++ b/src/test/java/nom/tam/fits/test/DupTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertFalse;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -44,7 +44,7 @@ import nom.tam.fits.header.extra.STScIExt;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
+++ b/src/test/java/nom/tam/fits/test/EnumHeaderTest.java
@@ -19,6 +19,7 @@ import nom.tam.fits.Header;
 import nom.tam.fits.header.Checksum;
 import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.DataDescription;
+import nom.tam.fits.header.DateTime;
 import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.HierarchicalGrouping;
@@ -137,13 +138,13 @@ public class EnumHeaderTest {
         Class<?>[] classes = new Class<?>[] {Checksum.class, CXCExt.class, CXCStclSharedExt.class, DataDescription.class,
                 HierarchicalGrouping.class, InstrumentDescription.class, MaxImDLExt.class, NOAOExt.class, NonStandard.class,
                 ObservationDescription.class, ObservationDurationDescription.class, SBFitsExt.class, Standard.class,
-                STScIExt.class, Compression.class};
+                STScIExt.class, Compression.class, WCS.class, DateTime.class};
         for (Class<?> class1 : classes) {
             for (Object enumConst : class1.getEnumConstants()) {
                 Assert.assertNotNull(class1.getMethod("valueOf", String.class).invoke(class1,
                         enumConst.getClass().getMethod("name").invoke(enumConst)));
                 IFitsHeader iFitsHeader = (IFitsHeader) enumConst;
-                if (class1 != Standard.class) {
+                if (class1 != Standard.class && !FitsKey.isCommentStyleKey(iFitsHeader.key())) {
                     Assert.assertNotNull(iFitsHeader.comment());
                 }
                 String key = iFitsHeader.key();
@@ -157,13 +158,13 @@ public class EnumHeaderTest {
                 }
                 int nCount = 0;
                 int offset = 0;
-                while ((offset = key.indexOf('n', offset)) > 0) {
+                while ((offset = key.indexOf('n', offset)) >= 0) {
                     nCount++;
                     offset++;
                 }
                 int[] n = new int[nCount];
                 Arrays.fill(n, 9);
-                Assert.assertTrue(iFitsHeader.n(n).key().indexOf('n') < 0);
+                Assert.assertTrue(iFitsHeader.key(), iFitsHeader.n(n).key().indexOf('n') < 0);
             }
         }
 

--- a/src/test/java/nom/tam/fits/test/FitsFactoryTest.java
+++ b/src/test/java/nom/tam/fits/test/FitsFactoryTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/FitsLineAppenderTest.java
+++ b/src/test/java/nom/tam/fits/test/FitsLineAppenderTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/HeaderCardExceptionsTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardExceptionsTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/HeaderCardStaticTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardStaticTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/ImageTest.java
+++ b/src/test/java/nom/tam/fits/test/ImageTest.java
@@ -31,7 +31,7 @@ import nom.tam.util.TestArrayFuncs;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/JunkTest.java
+++ b/src/test/java/nom/tam/fits/test/JunkTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/LongCommentCardTest.java
+++ b/src/test/java/nom/tam/fits/test/LongCommentCardTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/MiscTest.java
+++ b/src/test/java/nom/tam/fits/test/MiscTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/PaddingTest.java
+++ b/src/test/java/nom/tam/fits/test/PaddingTest.java
@@ -28,7 +28,7 @@ import nom.tam.util.SafeClose;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
+++ b/src/test/java/nom/tam/fits/test/RandomGroupsTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/TestMain.java
+++ b/src/test/java/nom/tam/fits/test/TestMain.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/TilerTest.java
+++ b/src/test/java/nom/tam/fits/test/TilerTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/test/UserProvidedTest.java
+++ b/src/test/java/nom/tam/fits/test/UserProvidedTest.java
@@ -4,7 +4,7 @@ package nom.tam.fits.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/fits/util/BlackBoxImages.java
+++ b/src/test/java/nom/tam/fits/util/BlackBoxImages.java
@@ -4,7 +4,7 @@ package nom.tam.fits.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/ImageTilerTest.java
+++ b/src/test/java/nom/tam/image/ImageTilerTest.java
@@ -72,7 +72,7 @@ package nom.tam.image;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/StandardImageTilerTest.java
+++ b/src/test/java/nom/tam/image/StandardImageTilerTest.java
@@ -4,7 +4,7 @@ package nom.tam.image;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/StreamingTileImageDataTest.java
+++ b/src/test/java/nom/tam/image/StreamingTileImageDataTest.java
@@ -19,7 +19,7 @@ import nom.tam.fits.ImageHDU;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
+++ b/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
@@ -92,7 +92,7 @@ import org.junit.Test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/compression/HeaderAccessTest.java
+++ b/src/test/java/nom/tam/image/compression/HeaderAccessTest.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/image/compression/hdu/CompressedTableBlackBoxTest.java
+++ b/src/test/java/nom/tam/image/compression/hdu/CompressedTableBlackBoxTest.java
@@ -6,7 +6,7 @@ import java.io.File;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
+++ b/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
@@ -27,7 +27,7 @@ import nom.tam.util.SafeClose;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressionTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressionTest.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/TileCompressorProviderTest.java
@@ -39,7 +39,7 @@ import nom.tam.util.type.PrimitiveTypes;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/compression/tile/mask/ImageMaskTest.java
+++ b/src/test/java/nom/tam/image/compression/tile/mask/ImageMaskTest.java
@@ -4,7 +4,7 @@ package nom.tam.image.compression.tile.mask;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/tile/operation/Access.java
+++ b/src/test/java/nom/tam/image/tile/operation/Access.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/tile/operation/TileAreaTest.java
+++ b/src/test/java/nom/tam/image/tile/operation/TileAreaTest.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/image/tile/operation/TileImageCompressionOperationTest.java
+++ b/src/test/java/nom/tam/image/tile/operation/TileImageCompressionOperationTest.java
@@ -4,7 +4,7 @@ package nom.tam.image.tile.operation;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2022 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/manual/intergration/FitsBenchmark.java
+++ b/src/test/java/nom/tam/manual/intergration/FitsBenchmark.java
@@ -4,7 +4,7 @@ package nom.tam.manual.intergration;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/manual/intergration/TestFitsFileWithVeryBigHeaders.java
+++ b/src/test/java/nom/tam/manual/intergration/TestFitsFileWithVeryBigHeaders.java
@@ -4,7 +4,7 @@ package nom.tam.manual.intergration;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/manual/intergration/UtilTest.java
+++ b/src/test/java/nom/tam/manual/intergration/UtilTest.java
@@ -4,7 +4,7 @@ package nom.tam.manual.intergration;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/manual/intergration/VeryBigFileTest.java
+++ b/src/test/java/nom/tam/manual/intergration/VeryBigFileTest.java
@@ -4,7 +4,7 @@ package nom.tam.manual.intergration;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/ArrayDataOutputTest.java
+++ b/src/test/java/nom/tam/util/ArrayDataOutputTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/util/ArrayStreamTest.java
+++ b/src/test/java/nom/tam/util/ArrayStreamTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/AsciiFuncsTest.java
+++ b/src/test/java/nom/tam/util/AsciiFuncsTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/util/BufferedFileIOTest.java
+++ b/src/test/java/nom/tam/util/BufferedFileIOTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/BufferedFileTest.java
+++ b/src/test/java/nom/tam/util/BufferedFileTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/ByteArrayIOTest.java
+++ b/src/test/java/nom/tam/util/ByteArrayIOTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/ColumnTableTest.java
+++ b/src/test/java/nom/tam/util/ColumnTableTest.java
@@ -6,7 +6,7 @@ import java.io.EOFException;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/util/ComplexConversionTest.java
+++ b/src/test/java/nom/tam/util/ComplexConversionTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam.fits
  * %%
- * Copyright (C) 1996 - 2023 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  * 

--- a/src/test/java/nom/tam/util/ComplexValueTest.java
+++ b/src/test/java/nom/tam/util/ComplexValueTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/DefaultMethodsTest.java
+++ b/src/test/java/nom/tam/util/DefaultMethodsTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/DeprecatedTest.java
+++ b/src/test/java/nom/tam/util/DeprecatedTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/FitsDecoderTest.java
+++ b/src/test/java/nom/tam/util/FitsDecoderTest.java
@@ -5,7 +5,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/FitsEncoderTest.java
+++ b/src/test/java/nom/tam/util/FitsEncoderTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/FitsFileTest.java
+++ b/src/test/java/nom/tam/util/FitsFileTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertEquals;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/FitsStreamTest.java
+++ b/src/test/java/nom/tam/util/FitsStreamTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/FlexFormatTest.java
+++ b/src/test/java/nom/tam/util/FlexFormatTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/HashedListTest.java
+++ b/src/test/java/nom/tam/util/HashedListTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/PrimitiveTypeTest.java
+++ b/src/test/java/nom/tam/util/PrimitiveTypeTest.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/TestArrayFuncs.java
+++ b/src/test/java/nom/tam/util/TestArrayFuncs.java
@@ -4,7 +4,7 @@ package nom.tam.util;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/ArrayFuncs2Test.java
+++ b/src/test/java/nom/tam/util/test/ArrayFuncs2Test.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/test/ArrayFuncsTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/ArrayManipulationTest.java
+++ b/src/test/java/nom/tam/util/test/ArrayManipulationTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/BigFileTest.java
+++ b/src/test/java/nom/tam/util/test/BigFileTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/BufferedFileTest.java
+++ b/src/test/java/nom/tam/util/test/BufferedFileTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/ByteFormatParseTest.java
+++ b/src/test/java/nom/tam/util/test/ByteFormatParseTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 2004 - 2021 nom-tam-fits
+ * Copyright (C) 2004 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/ExtraTest.java
+++ b/src/test/java/nom/tam/util/test/ExtraTest.java
@@ -9,7 +9,7 @@ import nom.tam.fits.HeaderCard;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/FitsDateTest.java
+++ b/src/test/java/nom/tam/util/test/FitsDateTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/StreamFileTest.java
+++ b/src/test/java/nom/tam/util/test/StreamFileTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/StreamTest.java
+++ b/src/test/java/nom/tam/util/test/StreamTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/test/ThrowAnyException.java
+++ b/src/test/java/nom/tam/util/test/ThrowAnyException.java
@@ -4,7 +4,7 @@ package nom.tam.util.test;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/type/DeprecatedTest.java
+++ b/src/test/java/nom/tam/util/type/DeprecatedTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *

--- a/src/test/java/nom/tam/util/type/ElementTypeTest.java
+++ b/src/test/java/nom/tam/util/type/ElementTypeTest.java
@@ -4,7 +4,7 @@ package nom.tam.util.type;
  * #%L
  * nom.tam FITS library
  * %%
- * Copyright (C) 1996 - 2021 nom-tam-fits
+ * Copyright (C) 1996 - 2024 nom-tam-fits
  * %%
  * This is free and unencumbered software released into the public domain.
  *


### PR DESCRIPTION
- Further cleanup / corrections in `Standard` keywords enum
- Deprecate `StandardCommentReplacement` and related methods in `Standard` enum, as these are meant for internal use only.
- Change what exceptions are thrown by `IFitsHeader.n(int...)`. 
   * `IndexOutOfBoundsException` if any of the supplied indices are outside of the 0-999 range.
   * `NoSuchElementException` if too many indices were supplied
   * `IllegalStateException` (same as before) if the resulting indexed keyword exceeds the FITS 8-character keyword limit.
- Corrections to `changes.xml`
- Remove deprecated classes from online API docs, but keep the full docs locally in `target/apidocs` (the latter can be built with `mvn package`).
- Update copyright dates in source files.