### PR TITLE
Fix heap growth beyond 1 GB.

### DIFF
--- a/src/main/java/nom/tam/util/ByteArrayIO.java
+++ b/src/main/java/nom/tam/util/ByteArrayIO.java
@@ -206,12 +206,12 @@ public class ByteArrayIO implements ReadWriteAccess {
      * @param need the minimum number of extra bytes needed beyond the current capacity.
      */
     private synchronized void grow(int need) {
-        int size = capacity() + need;
-        int below = Integer.highestOneBit(size);
+        long size = capacity() + need;
+        long below = Long.highestOneBit(size);
         if (below != size) {
             size = below << 1;
         }
-        byte[] newbuf = new byte[size];
+        byte[] newbuf = new byte[(int) Math.min(size, Integer.MAX_VALUE)];
         System.arraycopy(buf, 0, newbuf, 0, buf.length);
         buf = newbuf;
     }

--- a/src/main/java/nom/tam/util/ColumnTable.java
+++ b/src/main/java/nom/tam/util/ColumnTable.java
@@ -323,7 +323,7 @@ public class ColumnTable<T> implements DataTable, Cloneable {
             return MIN_CAPACITY;
         }
         // Predictable doubling beyond the minimum size...
-        return (int) Math.min(Long.highestOneBit(nrow) << 1, Integer.MAX_VALUE);
+        return (int) Math.min(Long.highestOneBit(rows) << 1, Integer.MAX_VALUE);
     }
 
     /**


### PR DESCRIPTION
Heaps beyond 1 GB were not properly supported prior to this fix, Now they should be good up to the 2GB limit of Java `byte[]` arrays...