### PR TITLE
Easier to use 'STOKES' coordinates

### DIFF
--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -354,7 +354,7 @@ public enum Stokes {
                     continue;
                 }
 
-                new AbstractMap.SimpleImmutableEntry(i, p);
+                return new AbstractMap.SimpleImmutableEntry(i, p);
             }
         }
 
@@ -407,7 +407,7 @@ public enum Stokes {
                     continue;
                 }
 
-                new AbstractMap.SimpleImmutableEntry(i, p);
+                return new AbstractMap.SimpleImmutableEntry(i, p);
             }
         }
 

--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -340,8 +340,8 @@ public enum Stokes {
      *                           coordinate axis.
      * 
      * @throws FitsException if the header does not contain an NAXIS keyword, necessary for translating Java array
-     *                           indices to FITS array indices, or if the CRPIXna or CDELTna values are inconsistent
-     *                           with a Stokes coordinate definition.
+     *                           indices to FITS array indices, or if the CRVALn, CRPIXna or CDELTna values for the
+     *                           'STOKES' dimension are inconsistent with a Stokes coordinate definition.
      * 
      * @see                  #fromTableHeader(Header, int)
      * @see                  Parameters#fillImageHeader(Header, int)
@@ -396,8 +396,9 @@ public enum Stokes {
      * 
      * @throws IndexOutOfBoundsException if the column index is invalid.
      * @throws FitsException             if the header does not contain an TDIMn keyword for the column, necessary for
-     *                                       translating Java array indices to FITS array indices, or if the iCRPXn or
-     *                                       iCDLTn values are inconsistent with a Stokes coordinate definition.
+     *                                       translating Java array indices to FITS array indices, or if the iCRVLn,
+     *                                       iCRPXn or iCDLTn values for the 'STOKES' dimension are inconsistent with a
+     *                                       Stokes coordinate definition.
      * 
      * @see                              #fromImageHeader(Header)
      * @see                              Parameters#fillTableHeader(Header, int, int)

--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -430,9 +430,17 @@ public enum Stokes {
 
         if (start == I.index && delt == 1.0) {
             return parameters();
-        } else if (start == V.index && delt == -1.0) {
+        }
+        if (start == V.index && delt == -1.0) {
             return parameters(REVERSED_ORDER);
-        } else if (start == RR.index && delt == -1.0) {
+        }
+
+        // Only cross-polarization at this point...
+        if (delt > 0.0) {
+            flag |= REVERSED_ORDER;
+        }
+
+        if (start == RR.index && delt == -1.0) {
             flag |= count <= STANDARD_PARAMETER_COUNT ? CIRCULAR_CROSS_POLARIZATION : FULL_CROSS_POLARIZATION;
         } else if (start == LR.index && delt == 1.0) {
             flag |= CIRCULAR_CROSS_POLARIZATION;
@@ -442,10 +450,6 @@ public enum Stokes {
             flag |= count <= STANDARD_PARAMETER_COUNT ? LINEAR_CROSS_POLARIZATION : FULL_CROSS_POLARIZATION;
         } else {
             return null;
-        }
-
-        if (delt > 0.0) {
-            flag |= REVERSED_ORDER;
         }
 
         return parameters(flag);

--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -1,0 +1,417 @@
+package nom.tam.fits.header;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import nom.tam.fits.FitsException;
+import nom.tam.fits.Header;
+
+/**
+ * <p>
+ * A mapping of image coordinate values for a coordinate axis with {@link WCS#CTYPEna} = <code>'STOKES'</code> (or
+ * equivalent). specifying polarization (or cross-polarization) data products along the image direction. The FITS
+ * standard (4.0) defines a mapping of pixel coordinates to Stokes parameters, and this enum provides an implementation
+ * of that for this library.
+ * </p>
+ * <p>
+ * An dataset may typically contain 4 or 8 Stokes parameters (or fewer), which depending on the type of measurement can
+ * be (I, Q, U, [V]), or (RR, LL, RL, LR) and/or (XX, YY, XY, YX). As such, the corresponding {@link WCS#CRPIXna} is
+ * typically 0 and {@link WCS#CDELTna} is +/- 1, and depending on the type of measurement {@link WCS#CRVALna} is 1, or
+ * -1, or -5. You can use the {@link Parameters} subclass to help populate or interpret Stokes parameters in headers.
+ * </p>
+ * 
+ * @author Attila Kovacs
+ * 
+ * @since  1.20
+ * 
+ * @see    WCS
+ */
+public enum Stokes {
+    /** Stokes I: total (polarized + unpolarized) power */
+    I(1),
+
+    /** Stokes Q: linear polarization Q component */
+    Q(2),
+
+    /** Stokes U: linear polarization U component */
+    U(3),
+
+    /** Stokes V: circularly polarization */
+    V(4),
+
+    /** circular cross-polarization between two right-handed wave components */
+    RR(-1),
+
+    /** circular cross-polarization between two left-handed wave components */
+    LL(-2),
+
+    /** circular cross-polarization between a right-handled (input 1) and a left-handed (input 2) wave component */
+    RL(-3),
+
+    /** circular cross-polarization between a left-handled (input 1) and a right-handed (input 2) wave component */
+    LR(-4),
+
+    /** linear cross-polarization between two 'horizontal' wave components (in local orientation) */
+    XX(-5),
+
+    /** linear cross-polarization between two 'vertical' wave components (in local orientation) */
+    YY(-6),
+
+    /**
+     * linear cross-polarization between a 'horizontal' (input 1) and a 'vertical' (input 2) wave component (in local
+     * orientation)
+     */
+    XY(-7),
+
+    /**
+     * linear cross-polarization between a 'vertical' (input 1) and a 'horizontal' (input 2) wave component (in local
+     * orientation)
+     */
+    YX(-8);
+
+    /** The value to use for CTYPE type keywords to indicate Stokes parameter data */
+    public static final String CTYPE = "STOKES";
+
+    private int index;
+
+    private static Stokes[] ordered = {YX, XY, YY, XX, LR, RL, LL, RR, null, V, U, Q, I};
+
+    Stokes(int value) {
+        this.index = value;
+    }
+
+    /**
+     * Returns the WCS coordinate value corresponding to this Stokes parameter for an image coordinate with
+     * {@link WCS#CTYPEna} = <code>'STOKES'</code>.
+     * 
+     * @return the WCS coordinate value corresponding to this Stokes parameter.
+     * 
+     * @see    #forCoordinateValue(int)
+     * @see    WCS#CTYPEna
+     * @see    WCS#CRVALna
+     */
+    public final int getCoordinateValue() {
+        return index;
+    }
+
+    /**
+     * Returns the Stokes parameter for the given pixel coordinate value for an image coordinate with
+     * {@link WCS#CTYPEna} = <code>'STOKES'</code>.
+     * 
+     * @param  value                     The image coordinate value
+     * 
+     * @return                           The Stokes parameter, which corresponds to that coordinate value.
+     * 
+     * @throws IndexOutOfBoundsException if the coordinate value is outt of the range of acceptable Stokes coordinate
+     *                                       values.
+     * 
+     * @see                              #getCoordinateValue()
+     */
+    public static Stokes forCoordinateValue(int value) throws IndexOutOfBoundsException {
+        return ordered[value + YX.getCoordinateValue()];
+    }
+
+    /**
+     * A helper for setting or interpreting WCS for a set of measured Stokes parameters.
+     * 
+     * @author Attila Kovacs
+     */
+    public enum Parameters {
+        /** Stokes parameters for a single-ended polarization measurement */
+        SINGLE_ENDED_POLARIZATION(Stokes.I.getCoordinateValue(), 1),
+
+        /**
+         * Stokes parameters for a dual-input cross polarization (circular, and possibly followed by linear
+         * cross-polarization components.
+         */
+        CROSS_POLARIZATION(Stokes.RR.getCoordinateValue(), -1),
+
+        /** Stokes parameters for linear only cross-polarization measurements */
+        LINEAR_CROSS_POLARIZATION(Stokes.XX.getCoordinateValue(), -1);
+
+        private int offset;
+        private int step;
+
+        Parameters(int rpix, int delt) {
+            this.offset = rpix;
+            this.step = delt;
+
+        }
+
+        /**
+         * Returns the Stokes parameter for a given Java array index for a dimension that corresponds to the Stokes
+         * parameters described by this instance.
+         * 
+         * @param  idx                       the zero-based Java array index, typically [0:3] for single-ended
+         *                                       polarization or circular or linear-only cross-polarization, or else
+         *                                       [0:7] for full cross-polarization.
+         * 
+         * @return                           The specific Stokes parameter corresponding to the specified array index.
+         * 
+         * @throws IndexOutOfBoundsException if the index is outside of the expected range.
+         * 
+         * @see                              #getArrayIndex(Stokes)
+         * @see                              #getAvailableParameters()
+         * 
+         * @since                            1.19.1
+         * 
+         * @author                           Attila Kovacs
+         */
+        public Stokes getParameter(int idx) throws IndexOutOfBoundsException {
+            if (idx < 0 || idx > -XX.getCoordinateValue()) {
+                throw new IndexOutOfBoundsException();
+            }
+            return Stokes.forCoordinateValue(offset + step * idx);
+        }
+
+        /**
+         * Returns the ordered list of parameters, which can be used to translate array indexes to Stokes values,
+         * supported by this parameter set.
+         * 
+         * @return the ordered list of available Stokes parameters in this measurement set.
+         * 
+         * @see    #getParameter(int)
+         */
+        public ArrayList<Stokes> getAvailableParameters() {
+            ArrayList<Stokes> list = new ArrayList<>(-Stokes.YX.index);
+            for (int i = offset; i != 0 && i < V.index; i++) {
+                list.add(Stokes.forCoordinateValue(i));
+            }
+            return list;
+        }
+
+        /**
+         * Returns the Java array index corresponding to a given Stokes parameters for this set of parameters.
+         * 
+         * @param  s the Stokes parameter of interest
+         * 
+         * @return   the zero-based Java array index corresponding to the given Stokes parameter.
+         * 
+         * @see      #getParameter(int)
+         * 
+         * @since    1.20
+         * 
+         * @author   Attila Kovacs
+         */
+        public int getArrayIndex(Stokes s) {
+            return (s.getCoordinateValue() - offset) / step;
+        }
+
+        private static Parameters forReferenceCoordinate(int value) {
+            for (Parameters p : values()) {
+                if (value == p.offset) {
+                    return p;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Adds WCS description for the coordinate axis containing Stokes parameters. The header must already contain a
+         * NAXIS keyword specifying the dimensionality of the data, or else a FitsException will be thrown.
+         * 
+         * @param  header          the FITS header to populate (it must already have an NAXIS keyword present).
+         * @param  coordinateIndex The 0-based Java coordinate index for the array dimension that corresponds to the
+         *                             stokes parameter.
+         * 
+         * @throws FitsException   if the header does not contain an NAXIS keyword, necessary for translating Java array
+         *                             indices to FITS array indices.
+         * 
+         * @see                    #fillTableHeader(Header, int, int)
+         * @see                    Stokes#fromImageHeader(Header)
+         * 
+         * @since                  1.20
+         * 
+         * @author                 Attila Kovacs
+         */
+        public void fillImageHeader(Header header, int coordinateIndex) throws FitsException {
+            int n = header.getIntValue(Standard.NAXIS);
+            if (n <= coordinateIndex) {
+                throw new FitsException("Missing, invalid, or insufficient NAXIS in header");
+            }
+            int i = n - coordinateIndex;
+
+            header.addValue(WCS.CTYPEna.n(i), Stokes.CTYPE);
+            header.addValue(WCS.CRPIXna.n(i), 0);
+            header.addValue(WCS.CRVALna.n(i), offset);
+            header.addValue(WCS.CDELTna.n(i), step);
+        }
+
+        /**
+         * Adds WCS description for the coordinate axis containing Stokes parameters to a table column containign
+         * images.
+         * 
+         * @param  header          the binary table header to populate (it should already contain a TDIMn keyword for
+         *                             the specified column, or else 1D data is assumed).
+         * @param  column          the zero-based Java column index containing the 'image' array.
+         * @param  coordinateIndex the zero-based Java coordinate index for the array dimension that corresponds to the
+         *                             stokes parameter.
+         * 
+         * @throws FitsException   if the header is not accessible
+         * 
+         * @see                    #fillImageHeader(Header, int)
+         * @see                    Stokes#fromTableHeader(Header, int)
+         * 
+         * @since                  1.20
+         * 
+         * @author                 Attila Kovacs
+         */
+        public void fillTableHeader(Header header, int column, int coordinateIndex) throws FitsException {
+            String dims = header.getStringValue(Standard.TDIMn.n(column));
+            int n = 1;
+            if (dims != null) {
+                StringTokenizer tokens = new StringTokenizer(dims, "(, )");
+                n = tokens.countTokens();
+            }
+
+            if (n < coordinateIndex) {
+                throw new FitsException("Invalid or insufficient TDIM" + column + " in header");
+            }
+
+            int i = n - coordinateIndex;
+
+            header.addValue(WCS.nCTYPn.n(column, i), Stokes.CTYPE);
+            header.addValue(WCS.nCRPXn.n(column, i), 0);
+            header.addValue(WCS.nCRVLn.n(column, i), offset);
+            header.addValue(WCS.nCDLTn.n(column, i), step);
+        }
+    }
+
+    /**
+     * Returns a mapping of a Java array dimension to a set of Stokes parameters, based on the WCS coordinate
+     * description in the image header. The header must already contain a NAXIS keyword specifying the dimensionality of
+     * the data, or else a FitsException will be thrown.
+     * 
+     * @param  header        the FITS header to populate (it must already have an NAXIS keyword present).
+     * 
+     * @return               A mapping from a zero-based Java array dimension which corresponds to the Stokes dimension
+     *                           of the data, to the set of stokes Parameters defined in that dimension; or
+     *                           <code>null</code> if the header does not contain a fully valid description of a Stokes
+     *                           coordinate axis.
+     * 
+     * @throws FitsException if the header does not contain an NAXIS keyword, necessary for translating Java array
+     *                           indices to FITS array indices.
+     * 
+     * @see                  #fromTableHeader(Header, int)
+     * @see                  Parameters#fillImageHeader(Header, int)
+     * 
+     * @since                1.20
+     * 
+     * @author               Attila Kovacs
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static Map.Entry<Integer, Parameters> fromImageHeader(Header header) throws FitsException {
+        int n = header.getIntValue(Standard.NAXIS);
+        if (n <= 0) {
+            throw new FitsException("Missing, invalid, or insufficient NAXIS in header");
+        }
+
+        for (int i = 1; i <= n; i++) {
+            if (Stokes.CTYPE.equalsIgnoreCase(header.getStringValue(WCS.CTYPEna.n(i)))) {
+                Parameters p = Parameters.forReferenceCoordinate(header.getIntValue(WCS.CRVALna.n(i)));
+                if (p == null) {
+                    continue;
+                }
+
+                if (header.getDoubleValue(WCS.CRPIXna.n(i)) != 0.0) {
+                    continue;
+                }
+
+                if (header.getDoubleValue(WCS.CDELTna.n(i)) != p.step) {
+                    continue;
+                }
+
+                new AbstractMap.SimpleImmutableEntry(i, p);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns a mapping of a Java array dimension to a set of Stokes parameters, based on the WCS coordinate
+     * description in the image header.
+     * 
+     * @param  header        the FITS header to populate.
+     * @param  column        the zero-based Java column index containing the 'image' array.
+     * 
+     * @return               A mapping from a zero-based Java array dimension which corresponds to the Stokes dimension
+     *                           of the data, to the set of stokes Parameters defined in that dimension; or
+     *                           <code>null</code> if the header does not contain a fully valid description of a Stokes
+     *                           coordinate axis.
+     * 
+     * @throws FitsException if there is an issue accessing the header values.
+     * 
+     * @see                  #fromImageHeader(Header)
+     * @see                  Parameters#fillTableHeader(Header, int, int)
+     * 
+     * @since                1.20
+     * 
+     * @author               Attila Kovacs
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static Map.Entry<Integer, Parameters> fromTableHeader(Header header, int column) throws FitsException {
+        String dims = header.getStringValue(Standard.TDIMn.n(column));
+        int n = 1;
+
+        if (dims != null) {
+            StringTokenizer tokens = new StringTokenizer(dims, "(, )");
+            n = tokens.countTokens();
+        }
+
+        for (int i = 1; i <= n; i++) {
+            if (Stokes.CTYPE.equalsIgnoreCase(header.getStringValue(WCS.nCTYPn.n(column, i)))) {
+                Parameters p = Parameters.forReferenceCoordinate(header.getIntValue(WCS.nCRVLn.n(column, i)));
+                if (p == null) {
+                    continue;
+                }
+
+                if (header.getDoubleValue(WCS.nCRPXn.n(column, i)) != 0.0) {
+                    continue;
+                }
+
+                if (header.getDoubleValue(WCS.nCDLTn.n(column, i)) != p.step) {
+                    continue;
+                }
+
+                new AbstractMap.SimpleImmutableEntry(i, p);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -444,11 +444,7 @@ public enum Stokes {
             return null;
         }
 
-        if (flag != 0) {
-            delt = -delt;
-        }
-
-        if (delt < 0.0) {
+        if (delt > 0.0) {
             flag |= REVERSED_ORDER;
         }
 

--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -107,7 +107,7 @@ public enum Stokes {
 
     private int index;
 
-    private static Stokes[] ordered = {YX, XY, YY, XX, LR, RL, LL, RR, null, V, U, Q, I};
+    private static Stokes[] ordered = {YX, XY, YY, XX, LR, RL, LL, RR, null, I, Q, U, V};
 
     Stokes(int value) {
         this.index = value;
@@ -141,7 +141,7 @@ public enum Stokes {
      * @see                              #getCoordinateValue()
      */
     public static Stokes forCoordinateValue(int value) throws IndexOutOfBoundsException {
-        return ordered[value + YX.getCoordinateValue()];
+        return ordered[value - YX.getCoordinateValue()];
     }
 
     /**
@@ -157,7 +157,7 @@ public enum Stokes {
          * Stokes parameters for a dual-input cross polarization (circular, and possibly followed by linear
          * cross-polarization components.
          */
-        CROSS_POLARIZATION(Stokes.RR.getCoordinateValue(), -1),
+        CIRCULAR_CROSS_POLARIZATION(Stokes.RR.getCoordinateValue(), -1),
 
         /** Stokes parameters for linear only cross-polarization measurements */
         LINEAR_CROSS_POLARIZATION(Stokes.XX.getCoordinateValue(), -1);
@@ -168,7 +168,6 @@ public enum Stokes {
         Parameters(int rpix, int delt) {
             this.offset = rpix;
             this.step = delt;
-
         }
 
         /**
@@ -191,7 +190,7 @@ public enum Stokes {
          * @author                           Attila Kovacs
          */
         public Stokes getParameter(int idx) throws IndexOutOfBoundsException {
-            if (idx < 0 || idx > -XX.getCoordinateValue()) {
+            if (idx < 0 || idx >= V.getCoordinateValue()) {
                 throw new IndexOutOfBoundsException();
             }
             return Stokes.forCoordinateValue(offset + step * idx);
@@ -206,9 +205,9 @@ public enum Stokes {
          * @see    #getParameter(int)
          */
         public ArrayList<Stokes> getAvailableParameters() {
-            ArrayList<Stokes> list = new ArrayList<>(-Stokes.YX.index);
-            for (int i = offset; i != 0 && i < V.index; i++) {
-                list.add(Stokes.forCoordinateValue(i));
+            ArrayList<Stokes> list = new ArrayList<>(V.index);
+            for (int i = 0; i < V.index; i++) {
+                list.add(getParameter(i));
             }
             return list;
         }
@@ -243,25 +242,32 @@ public enum Stokes {
          * Adds WCS description for the coordinate axis containing Stokes parameters. The header must already contain a
          * NAXIS keyword specifying the dimensionality of the data, or else a FitsException will be thrown.
          * 
-         * @param  header          the FITS header to populate (it must already have an NAXIS keyword present).
-         * @param  coordinateIndex The 0-based Java coordinate index for the array dimension that corresponds to the
-         *                             stokes parameter.
+         * @param  header                   the FITS header to populate (it must already have an NAXIS keyword present).
+         * @param  coordinateIndex          The 0-based Java coordinate index for the array dimension that corresponds
+         *                                      to the stokes parameter.
          * 
-         * @throws FitsException   if the header does not contain an NAXIS keyword, necessary for translating Java array
-         *                             indices to FITS array indices.
+         * @throws IllegalArgumentException if the coordinate index is negative or out of bounds for the array
+         *                                      dimensions
+         * @throws FitsException            if the header does not contain an NAXIS keyword, or if the header is not
+         *                                      accessible
          * 
-         * @see                    #fillTableHeader(Header, int, int)
-         * @see                    Stokes#fromImageHeader(Header)
+         * @see                             #fillTableHeader(Header, int, int)
+         * @see                             Stokes#fromImageHeader(Header)
          * 
-         * @since                  1.20
+         * @since                           1.20
          * 
-         * @author                 Attila Kovacs
+         * @author                          Attila Kovacs
          */
         public void fillImageHeader(Header header, int coordinateIndex) throws FitsException {
             int n = header.getIntValue(Standard.NAXIS);
-            if (n <= coordinateIndex) {
-                throw new FitsException("Missing, invalid, or insufficient NAXIS in header");
+            if (n == 0) {
+                throw new FitsException("Missing NAXIS in header");
             }
+            if (coordinateIndex < 0 || coordinateIndex >= n) {
+                throw new IllegalArgumentException(
+                        "Invalid Java coordinate index " + coordinateIndex + " (for " + n + " dimensions)");
+            }
+
             int i = n - coordinateIndex;
 
             header.addValue(WCS.CTYPEna.n(i), Stokes.CTYPE);
@@ -274,39 +280,47 @@ public enum Stokes {
          * Adds WCS description for the coordinate axis containing Stokes parameters to a table column containign
          * images.
          * 
-         * @param  header          the binary table header to populate (it should already contain a TDIMn keyword for
-         *                             the specified column, or else 1D data is assumed).
-         * @param  column          the zero-based Java column index containing the 'image' array.
-         * @param  coordinateIndex the zero-based Java coordinate index for the array dimension that corresponds to the
-         *                             stokes parameter.
+         * @param  header                   the binary table header to populate (it should already contain a TDIMn
+         *                                      keyword for the specified column, or else 1D data is assumed).
+         * @param  column                   the zero-based Java column index containing the 'image' array.
+         * @param  coordinateIndex          the zero-based Java coordinate index for the array dimension that
+         *                                      corresponds to the stokes parameter.
          * 
-         * @throws FitsException   if the header is not accessible
+         * @throws IllegalArgumentException if the coordinate index is negative or out of bounds for the array
+         *                                      dimensions, or if the column index is invalid.
+         * @throws FitsException            if the header does not specify the dimensionality of the array elements, or
+         *                                      if the header is not accessible
          * 
-         * @see                    #fillImageHeader(Header, int)
-         * @see                    Stokes#fromTableHeader(Header, int)
+         * @see                             #fillImageHeader(Header, int)
+         * @see                             Stokes#fromTableHeader(Header, int)
          * 
-         * @since                  1.20
+         * @since                           1.20
          * 
-         * @author                 Attila Kovacs
+         * @author                          Attila Kovacs
          */
         public void fillTableHeader(Header header, int column, int coordinateIndex) throws FitsException {
-            String dims = header.getStringValue(Standard.TDIMn.n(column));
-            int n = 1;
-            if (dims != null) {
-                StringTokenizer tokens = new StringTokenizer(dims, "(, )");
-                n = tokens.countTokens();
+            String dims = header.getStringValue(Standard.TDIMn.n(++column));
+            if (dims == null) {
+                throw new FitsException("Missing TDIM" + column + " in header");
             }
 
-            if (n < coordinateIndex) {
-                throw new FitsException("Invalid or insufficient TDIM" + column + " in header");
+            StringTokenizer tokens = new StringTokenizer(dims, "(, )");
+            int n = tokens.countTokens();
+
+            if (coordinateIndex < 0 || coordinateIndex >= n) {
+                throw new IllegalArgumentException(
+                        "Invalid Java coordinate index " + coordinateIndex + " (for " + n + " dimensions)");
+            }
+            if (column < 0) {
+                throw new IllegalArgumentException("Invalid Java column index " + column);
             }
 
             int i = n - coordinateIndex;
 
-            header.addValue(WCS.nCTYPn.n(column, i), Stokes.CTYPE);
-            header.addValue(WCS.nCRPXn.n(column, i), 0);
-            header.addValue(WCS.nCRVLn.n(column, i), offset);
-            header.addValue(WCS.nCDLTn.n(column, i), step);
+            header.addValue(WCS.nCTYPn.n(i, column), Stokes.CTYPE);
+            header.addValue(WCS.nCRPXn.n(i, column), 0);
+            header.addValue(WCS.nCRVLn.n(i, column), offset);
+            header.addValue(WCS.nCDLTn.n(i, column), step);
         }
     }
 
@@ -323,7 +337,8 @@ public enum Stokes {
      *                           coordinate axis.
      * 
      * @throws FitsException if the header does not contain an NAXIS keyword, necessary for translating Java array
-     *                           indices to FITS array indices.
+     *                           indices to FITS array indices, or if the CRPIXna or CDELTna values are inconsistent
+     *                           with a Stokes coordinate definition.
      * 
      * @see                  #fromTableHeader(Header, int)
      * @see                  Parameters#fillImageHeader(Header, int)
@@ -347,14 +362,16 @@ public enum Stokes {
                 }
 
                 if (header.getDoubleValue(WCS.CRPIXna.n(i)) != 0.0) {
-                    continue;
+                    throw new FitsException("Invalid Stokes " + WCS.CRPIXna.n(i).key() + " value: "
+                            + header.getDoubleValue(WCS.CRPIXna.n(i)) + ", expected 0");
                 }
 
                 if (header.getDoubleValue(WCS.CDELTna.n(i)) != p.step) {
-                    continue;
+                    throw new FitsException("Invalid Stokes " + WCS.CDELTna.n(i).key() + " value: "
+                            + header.getDoubleValue(WCS.CDELTna.n(i)) + ", expected " + p.step);
                 }
 
-                return new AbstractMap.SimpleImmutableEntry(i, p);
+                return new AbstractMap.SimpleImmutableEntry(n - i, p);
             }
         }
 
@@ -365,27 +382,34 @@ public enum Stokes {
      * Returns a mapping of a Java array dimension to a set of Stokes parameters, based on the WCS coordinate
      * description in the image header.
      * 
-     * @param  header        the FITS header to populate.
-     * @param  column        the zero-based Java column index containing the 'image' array.
+     * @param  header                   the FITS header to populate.
+     * @param  column                   the zero-based Java column index containing the 'image' array.
      * 
-     * @return               A mapping from a zero-based Java array dimension which corresponds to the Stokes dimension
-     *                           of the data, to the set of stokes Parameters defined in that dimension; or
-     *                           <code>null</code> if the header does not contain a fully valid description of a Stokes
-     *                           coordinate axis.
+     * @return                          A mapping from a zero-based Java array dimension which corresponds to the Stokes
+     *                                      dimension of the data, to the set of stokes Parameters defined in that
+     *                                      dimension; or <code>null</code> if the header does not contain a fully valid
+     *                                      description of a Stokes coordinate axis.
      * 
-     * @throws FitsException if there is an issue accessing the header values.
+     * @throws IllegalArgumentException if the column index is invalid.
+     * @throws FitsException            if the header does not contain an TDIMn keyword for the column, necessary for
+     *                                      translating Java array indices to FITS array indices, or if the iCRPXn or
+     *                                      iCDLTn values are inconsistent with a Stokes coordinate definition.
      * 
-     * @see                  #fromImageHeader(Header)
-     * @see                  Parameters#fillTableHeader(Header, int, int)
+     * @see                             #fromImageHeader(Header)
+     * @see                             Parameters#fillTableHeader(Header, int, int)
      * 
-     * @since                1.20
+     * @since                           1.20
      * 
-     * @author               Attila Kovacs
+     * @author                          Attila Kovacs
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static Map.Entry<Integer, Parameters> fromTableHeader(Header header, int column) throws FitsException {
-        String dims = header.getStringValue(Standard.TDIMn.n(column));
+        String dims = header.getStringValue(Standard.TDIMn.n(++column));
         int n = 1;
+
+        if (column < 0) {
+            throw new IllegalArgumentException("Invalid Java column index " + column);
+        }
 
         if (dims != null) {
             StringTokenizer tokens = new StringTokenizer(dims, "(, )");
@@ -393,21 +417,23 @@ public enum Stokes {
         }
 
         for (int i = 1; i <= n; i++) {
-            if (Stokes.CTYPE.equalsIgnoreCase(header.getStringValue(WCS.nCTYPn.n(column, i)))) {
-                Parameters p = Parameters.forReferenceCoordinate(header.getIntValue(WCS.nCRVLn.n(column, i)));
+            if (Stokes.CTYPE.equalsIgnoreCase(header.getStringValue(WCS.nCTYPn.n(i, column)))) {
+                Parameters p = Parameters.forReferenceCoordinate(header.getIntValue(WCS.nCRVLn.n(i, column)));
                 if (p == null) {
                     continue;
                 }
 
-                if (header.getDoubleValue(WCS.nCRPXn.n(column, i)) != 0.0) {
-                    continue;
+                if (header.getDoubleValue(WCS.nCRPXn.n(i, column)) != 0.0) {
+                    throw new FitsException("Invalid Stokes " + WCS.nCRPXn.n(i, column).key() + " value: "
+                            + header.getDoubleValue(WCS.nCRPXn.n(i, column)) + ", expected 0");
                 }
 
-                if (header.getDoubleValue(WCS.nCDLTn.n(column, i)) != p.step) {
-                    continue;
+                if (header.getDoubleValue(WCS.nCDLTn.n(i, column)) != p.step) {
+                    throw new FitsException("Invalid Stokes " + WCS.nCDLTn.n(i, column).key() + " value: "
+                            + header.getDoubleValue(WCS.nCDLTn.n(i, column)) + ", expected " + p.step);
                 }
 
-                return new AbstractMap.SimpleImmutableEntry(i, p);
+                return new AbstractMap.SimpleImmutableEntry(n - i, p);
             }
         }
 

--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -467,10 +467,6 @@ public enum Stokes {
     public static final int FULL_CROSS_POLARIZATION = LINEAR_CROSS_POLARIZATION | CIRCULAR_CROSS_POLARIZATION;
 
     private static Parameters forCoords(double start, double delt, int count) throws FitsException {
-        if (count < 1) {
-            throw new FitsException("Invalid Stokes coordinate element count: " + count);
-        }
-
         int offset = (int) start;
         if (start != offset) {
             throw new FitsException("Invalid (non-integer) Stokes coordinate start: " + start);

--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -500,11 +500,6 @@ public enum Stokes {
                             + header.getDoubleValue(WCS.CRPIXna.n(i)) + ", expected 0");
                 }
 
-                if (header.getDoubleValue(WCS.CDELTna.n(i)) != p.step) {
-                    throw new FitsException("Invalid Stokes " + WCS.CDELTna.n(i).key() + " value: "
-                            + header.getDoubleValue(WCS.CDELTna.n(i)) + ", expected " + p.step);
-                }
-
                 return new AbstractMap.SimpleImmutableEntry(n - i, p);
             }
         }
@@ -567,11 +562,6 @@ public enum Stokes {
                 if (header.getDoubleValue(WCS.nCRPXn.n(i, column)) != 0.0) {
                     throw new FitsException("Invalid Stokes " + WCS.nCRPXn.n(i, column).key() + " value: "
                             + header.getDoubleValue(WCS.nCRPXn.n(i, column)) + ", expected 0");
-                }
-
-                if (header.getDoubleValue(WCS.nCDLTn.n(i, column)) != p.step) {
-                    throw new FitsException("Invalid Stokes " + WCS.nCDLTn.n(i, column).key() + " value: "
-                            + header.getDoubleValue(WCS.nCDLTn.n(i, column)) + ", expected " + p.step);
                 }
 
                 return new AbstractMap.SimpleImmutableEntry(n - i, p);

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -505,6 +505,54 @@ public class StokesTest {
     }
 
     @Test(expected = FitsException.class)
+    public void testInvalidCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters();
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), -1.0);
+        Stokes.fromImageHeader(h).getValue();
+    }
+
+    @Test(expected = FitsException.class)
+    public void testInvalidCircularCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters(Stokes.CIRCULAR_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), 1.0);
+        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
+    }
+
+    @Test(expected = FitsException.class)
+    public void testInvalidLinearCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters(Stokes.LINEAR_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), 1.0);
+        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
+    }
+
+    @Test(expected = FitsException.class)
+    public void testInvalidFullCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 8);
+
+        Stokes.Parameters p0 = Stokes.parameters(Stokes.FULL_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), 1.0);
+        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
+    }
+
+    @Test(expected = FitsException.class)
     public void testReverseOrderInvalidCDELT() throws Exception {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -257,28 +257,35 @@ public class StokesTest {
         Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(new Header(), 0, 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
     public void testFillImageHeaderNegIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 3);
         Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, -1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
     public void testFillImageHeaderOutOfBoundsIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 3);
         Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 3);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testFillTableHeaderInvalidColumn() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(1), "(4)");
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, -1, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
     public void testFillTableHeaderNegIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
         Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, -1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IndexOutOfBoundsException.class)
     public void testFillTableHeaderOutOfBoundsIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
@@ -295,8 +302,28 @@ public class StokesTest {
     @Test
     public void testFromTableHeaderNoStokes() throws Exception {
         Header h = new Header();
-        h.addValue(Standard.TDIMn.n(0), "(4)");
+        h.addValue(Standard.TDIMn.n(1), "(4)");
         Assert.assertNull(Stokes.fromTableHeader(h, 0));
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromImageHeaderNoNAXIS() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 0);
+        h.deleteKey(Standard.NAXIS);
+        Stokes.fromImageHeader(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromImageHeaderInvalidCRVAL() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 0);
+        h.addValue("CRVAL1", 0.0, null);
+        Stokes.fromImageHeader(h);
     }
 
     @Test(expected = FitsException.class)
@@ -319,23 +346,49 @@ public class StokesTest {
         Stokes.fromImageHeader(h);
     }
 
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testFromTableHeaderInvalidColumn() throws Exception {
+        Header h = new Header();
+        Stokes.fromTableHeader(h, -1);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromTableHeaderNoTDIM() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(1), "(4)");
+
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
+        h.deleteKey(Standard.TDIMn.n(1));
+        Stokes.fromTableHeader(h, 0);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromTableHeaderInvalidCRVAL() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(1), "(4)");
+
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
+        h.addValue("1CRVL1", 0.0, null);
+        Stokes.fromTableHeader(h, 0);
+    }
+
     @Test(expected = FitsException.class)
     public void testFromTableHeaderInvalidCRPIX() throws Exception {
         Header h = new Header();
-        h.addValue(Standard.TDIMn.n(0), "(4)");
+        h.addValue(Standard.TDIMn.n(1), "(4)");
 
         Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
         h.addValue("1CRPX1", 1.0, null);
-        Stokes.fromImageHeader(h);
+        Stokes.fromTableHeader(h, 0);
     }
 
     @Test(expected = FitsException.class)
     public void testFromTableHeaderInvalidCDELT() throws Exception {
         Header h = new Header();
-        h.addValue(Standard.TDIMn.n(0), "(4)");
+        h.addValue(Standard.TDIMn.n(1), "(4)");
 
         Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
         h.addValue("1CDLT1", 2.0, null);
-        Stokes.fromImageHeader(h);
+        Stokes.fromTableHeader(h, 0);
     }
 }

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -80,7 +80,7 @@ public class StokesTest {
 
     @Test
     public void testSingleEndedParameters() throws Exception {
-        Stokes.Parameters p = Stokes.Parameters.SINGLE_ENDED_POLARIZATION;
+        Stokes.Parameters p = new Stokes.SingleEndedPolarization();
 
         Assert.assertEquals(Stokes.I, p.getParameter(0));
         Assert.assertEquals(Stokes.Q, p.getParameter(1));
@@ -114,7 +114,7 @@ public class StokesTest {
 
         Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p, e.getValue());
+        Assert.assertEquals(p.getClass(), e.getValue().getClass());
 
         h = new Header();
         h.addValue(Standard.TDIMn.n(4), "(2,4,3)");
@@ -127,13 +127,13 @@ public class StokesTest {
 
         e = Stokes.fromTableHeader(h, 3);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p, e.getValue());
+        Assert.assertEquals(p.getClass(), e.getValue().getClass());
 
     }
 
     @Test
     public void testCircularCrossParameters() throws Exception {
-        Stokes.Parameters p = Stokes.Parameters.CIRCULAR_CROSS_POLARIZATION;
+        Stokes.Parameters p = new Stokes.CircularCrossPolarization();
 
         Assert.assertEquals(Stokes.RR, p.getParameter(0));
         Assert.assertEquals(Stokes.LL, p.getParameter(1));
@@ -167,7 +167,7 @@ public class StokesTest {
 
         Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p, e.getValue());
+        Assert.assertEquals(p.getClass(), e.getValue().getClass());
 
         h = new Header();
         h.addValue(Standard.TDIMn.n(4), "(2,4,3)");
@@ -180,13 +180,13 @@ public class StokesTest {
 
         e = Stokes.fromTableHeader(h, 3);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p, e.getValue());
+        Assert.assertEquals(p.getClass(), e.getValue().getClass());
 
     }
 
     @Test
     public void testLinearCrossParameters() throws Exception {
-        Stokes.Parameters p = Stokes.Parameters.LINEAR_CROSS_POLARIZATION;
+        Stokes.Parameters p = new Stokes.LinearCrossPolarization();
 
         Assert.assertEquals(Stokes.XX, p.getParameter(0));
         Assert.assertEquals(Stokes.YY, p.getParameter(1));
@@ -220,7 +220,7 @@ public class StokesTest {
 
         Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p, e.getValue());
+        Assert.assertEquals(p.getClass(), e.getValue().getClass());
 
         h = new Header();
         h.addValue(Standard.TDIMn.n(4), "(2,4,3)");
@@ -233,63 +233,133 @@ public class StokesTest {
 
         e = Stokes.fromTableHeader(h, 3);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p, e.getValue());
+        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+
+    }
+
+    @Test
+    public void testFullCrossParameters() throws Exception {
+        Stokes.Parameters p = new Stokes.FullCrossPolarization();
+
+        Assert.assertEquals(Stokes.RR, p.getParameter(0));
+        Assert.assertEquals(Stokes.LL, p.getParameter(1));
+        Assert.assertEquals(Stokes.RL, p.getParameter(2));
+        Assert.assertEquals(Stokes.LR, p.getParameter(3));
+        Assert.assertEquals(Stokes.XX, p.getParameter(4));
+        Assert.assertEquals(Stokes.YY, p.getParameter(5));
+        Assert.assertEquals(Stokes.XY, p.getParameter(6));
+        Assert.assertEquals(Stokes.YX, p.getParameter(7));
+
+        ArrayList<Stokes> l = p.getAvailableParameters();
+        Assert.assertEquals(8, l.size());
+        Assert.assertTrue(l.contains(Stokes.RR));
+        Assert.assertTrue(l.contains(Stokes.LL));
+        Assert.assertTrue(l.contains(Stokes.RL));
+        Assert.assertTrue(l.contains(Stokes.LR));
+        Assert.assertTrue(l.contains(Stokes.XX));
+        Assert.assertTrue(l.contains(Stokes.YY));
+        Assert.assertTrue(l.contains(Stokes.XY));
+        Assert.assertTrue(l.contains(Stokes.YX));
+
+        Assert.assertEquals(Stokes.RR, p.getParameter(0));
+        Assert.assertEquals(Stokes.LL, p.getParameter(1));
+        Assert.assertEquals(Stokes.RL, p.getParameter(2));
+        Assert.assertEquals(Stokes.LR, p.getParameter(3));
+        Assert.assertEquals(Stokes.XX, p.getParameter(4));
+        Assert.assertEquals(Stokes.YY, p.getParameter(5));
+        Assert.assertEquals(Stokes.XY, p.getParameter(6));
+        Assert.assertEquals(Stokes.YX, p.getParameter(7));
+
+        Assert.assertEquals(0, p.getArrayIndex(Stokes.RR));
+        Assert.assertEquals(1, p.getArrayIndex(Stokes.LL));
+        Assert.assertEquals(2, p.getArrayIndex(Stokes.RL));
+        Assert.assertEquals(3, p.getArrayIndex(Stokes.LR));
+        Assert.assertEquals(4, p.getArrayIndex(Stokes.XX));
+        Assert.assertEquals(5, p.getArrayIndex(Stokes.YY));
+        Assert.assertEquals(6, p.getArrayIndex(Stokes.XY));
+        Assert.assertEquals(7, p.getArrayIndex(Stokes.YX));
+
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 3);
+        h.addValue(Standard.NAXIS2, 8);
+        p.fillImageHeader(h, 1);
+        Assert.assertEquals("STOKES", h.getStringValue("CTYPE2"));
+        Assert.assertEquals(0.0, h.getDoubleValue("CRPIX2"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("CDELT2"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("CRVAL2"), 1e-12);
+
+        Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
+        Assert.assertEquals(1, (int) e.getKey());
+        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+
+        h = new Header();
+        h.addValue(Standard.TDIMn.n(4), "(2,8,3)");
+        p.fillTableHeader(h, 3, 1);
+
+        Assert.assertEquals("STOKES", h.getStringValue("2CTYP4"));
+        Assert.assertEquals(0.0, h.getDoubleValue("2CRPX4"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("2CDLT4"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("2CRVL4"), 1e-12);
+
+        e = Stokes.fromTableHeader(h, 3);
+        Assert.assertEquals(1, (int) e.getKey());
+        Assert.assertEquals(p.getClass(), e.getValue().getClass());
 
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testGetNegParameter() throws Exception {
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.getParameter(-1);
+        new Stokes.SingleEndedPolarization().getParameter(-1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testGetOutOfBoundsParameter() throws Exception {
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.getParameter(4);
+        new Stokes.SingleEndedPolarization().getParameter(4);
     }
 
     @Test(expected = FitsException.class)
     public void testFillImageHeaderNoNAXIS() throws Exception {
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(new Header(), 0);
+        new Stokes.SingleEndedPolarization().fillImageHeader(new Header(), 0);
     }
 
     @Test(expected = FitsException.class)
     public void testFillTableHeaderNoTDIM() throws Exception {
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(new Header(), 0, 0);
+        new Stokes.SingleEndedPolarization().fillTableHeader(new Header(), 0, 0);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillImageHeaderNegIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 3);
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, -1);
+        new Stokes.SingleEndedPolarization().fillImageHeader(h, -1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillImageHeaderOutOfBoundsIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 3);
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 3);
+        new Stokes.SingleEndedPolarization().fillImageHeader(h, 3);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillTableHeaderInvalidColumn() throws Exception {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, -1, 0);
+        new Stokes.SingleEndedPolarization().fillTableHeader(h, -1, 0);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillTableHeaderNegIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, -1);
+        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, -1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillTableHeaderOutOfBoundsIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 3);
+        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 3);
     }
 
     @Test
@@ -311,7 +381,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
 
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 0);
+        new Stokes.SingleEndedPolarization().fillImageHeader(h, 0);
         h.deleteKey(Standard.NAXIS);
         Stokes.fromImageHeader(h);
     }
@@ -321,7 +391,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
 
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 0);
+        new Stokes.SingleEndedPolarization().fillImageHeader(h, 0);
         h.addValue("CRVAL1", 0.0, null);
         Stokes.fromImageHeader(h);
     }
@@ -331,7 +401,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
 
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 0);
+        new Stokes.SingleEndedPolarization().fillImageHeader(h, 0);
         h.addValue("CRPIX1", 1.0, null);
         Stokes.fromImageHeader(h);
     }
@@ -341,7 +411,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
 
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 0);
+        new Stokes.SingleEndedPolarization().fillImageHeader(h, 0);
         h.addValue("CDELT1", 2.0, null);
         Stokes.fromImageHeader(h);
     }
@@ -357,7 +427,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
+        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 0);
         h.deleteKey(Standard.TDIMn.n(1));
         Stokes.fromTableHeader(h, 0);
     }
@@ -367,7 +437,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
+        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 0);
         h.addValue("1CRVL1", 0.0, null);
         Stokes.fromTableHeader(h, 0);
     }
@@ -377,7 +447,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
+        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 0);
         h.addValue("1CRPX1", 1.0, null);
         Stokes.fromTableHeader(h, 0);
     }
@@ -387,7 +457,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
-        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
+        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 0);
         h.addValue("1CDLT1", 2.0, null);
         Stokes.fromTableHeader(h, 0);
     }

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -80,7 +80,7 @@ public class StokesTest {
 
     @Test
     public void testSingleEndedParameters() throws Exception {
-        Stokes.Parameters p = new Stokes.SingleEndedPolarization();
+        Stokes.Parameters p = Stokes.parameters();
 
         Assert.assertEquals(Stokes.I, p.getParameter(0));
         Assert.assertEquals(Stokes.Q, p.getParameter(1));
@@ -133,7 +133,7 @@ public class StokesTest {
 
     @Test
     public void testCircularCrossParameters() throws Exception {
-        Stokes.Parameters p = new Stokes.CircularCrossPolarization();
+        Stokes.Parameters p = Stokes.parameters(Stokes.CIRCULAR_CROSS_POLARIZATION);
 
         Assert.assertEquals(Stokes.RR, p.getParameter(0));
         Assert.assertEquals(Stokes.LL, p.getParameter(1));
@@ -186,7 +186,7 @@ public class StokesTest {
 
     @Test
     public void testLinearCrossParameters() throws Exception {
-        Stokes.Parameters p = new Stokes.LinearCrossPolarization();
+        Stokes.Parameters p = Stokes.parameters(Stokes.LINEAR_CROSS_POLARIZATION);
 
         Assert.assertEquals(Stokes.XX, p.getParameter(0));
         Assert.assertEquals(Stokes.YY, p.getParameter(1));
@@ -239,7 +239,7 @@ public class StokesTest {
 
     @Test
     public void testFullCrossParameters() throws Exception {
-        Stokes.Parameters p = new Stokes.FullCrossPolarization();
+        Stokes.Parameters p = Stokes.parameters(Stokes.FULL_CROSS_POLARIZATION);
 
         Assert.assertEquals(Stokes.RR, p.getParameter(0));
         Assert.assertEquals(Stokes.LL, p.getParameter(1));
@@ -309,57 +309,57 @@ public class StokesTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testGetNegParameter() throws Exception {
-        new Stokes.SingleEndedPolarization().getParameter(-1);
+        Stokes.parameters().getParameter(-1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testGetOutOfBoundsParameter() throws Exception {
-        new Stokes.SingleEndedPolarization().getParameter(4);
+        Stokes.parameters().getParameter(4);
     }
 
     @Test(expected = FitsException.class)
     public void testFillImageHeaderNoNAXIS() throws Exception {
-        new Stokes.SingleEndedPolarization().fillImageHeader(new Header(), 0);
+        Stokes.parameters().fillImageHeader(new Header(), 0);
     }
 
     @Test(expected = FitsException.class)
     public void testFillTableHeaderNoTDIM() throws Exception {
-        new Stokes.SingleEndedPolarization().fillTableHeader(new Header(), 0, 0);
+        Stokes.parameters().fillTableHeader(new Header(), 0, 0);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillImageHeaderNegIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 3);
-        new Stokes.SingleEndedPolarization().fillImageHeader(h, -1);
+        Stokes.parameters().fillImageHeader(h, -1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillImageHeaderOutOfBoundsIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 3);
-        new Stokes.SingleEndedPolarization().fillImageHeader(h, 3);
+        Stokes.parameters().fillImageHeader(h, 3);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillTableHeaderInvalidColumn() throws Exception {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
-        new Stokes.SingleEndedPolarization().fillTableHeader(h, -1, 0);
+        Stokes.parameters().fillTableHeader(h, -1, 0);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillTableHeaderNegIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
-        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, -1);
+        Stokes.parameters().fillTableHeader(h, 0, -1);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void testFillTableHeaderOutOfBoundsIndex() throws Exception {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
-        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 3);
+        Stokes.parameters().fillTableHeader(h, 0, 3);
     }
 
     @Test
@@ -381,7 +381,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
 
-        new Stokes.SingleEndedPolarization().fillImageHeader(h, 0);
+        Stokes.parameters().fillImageHeader(h, 0);
         h.deleteKey(Standard.NAXIS);
         Stokes.fromImageHeader(h);
     }
@@ -391,7 +391,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
 
-        new Stokes.SingleEndedPolarization().fillImageHeader(h, 0);
+        Stokes.parameters().fillImageHeader(h, 0);
         h.addValue("CRVAL1", 0.0, null);
         Stokes.fromImageHeader(h);
     }
@@ -401,7 +401,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
 
-        new Stokes.SingleEndedPolarization().fillImageHeader(h, 0);
+        Stokes.parameters().fillImageHeader(h, 0);
         h.addValue("CRPIX1", 1.0, null);
         Stokes.fromImageHeader(h);
     }
@@ -411,7 +411,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
 
-        new Stokes.SingleEndedPolarization().fillImageHeader(h, 0);
+        Stokes.parameters().fillImageHeader(h, 0);
         h.addValue("CDELT1", 2.0, null);
         Stokes.fromImageHeader(h);
     }
@@ -427,7 +427,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
-        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 0);
+        Stokes.parameters().fillTableHeader(h, 0, 0);
         h.deleteKey(Standard.TDIMn.n(1));
         Stokes.fromTableHeader(h, 0);
     }
@@ -437,7 +437,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
-        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 0);
+        Stokes.parameters().fillTableHeader(h, 0, 0);
         h.addValue("1CRVL1", 0.0, null);
         Stokes.fromTableHeader(h, 0);
     }
@@ -447,7 +447,7 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
-        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 0);
+        Stokes.parameters().fillTableHeader(h, 0, 0);
         h.addValue("1CRPX1", 1.0, null);
         Stokes.fromTableHeader(h, 0);
     }
@@ -457,8 +457,27 @@ public class StokesTest {
         Header h = new Header();
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
-        new Stokes.SingleEndedPolarization().fillTableHeader(h, 0, 0);
+        Stokes.parameters().fillTableHeader(h, 0, 0);
         h.addValue("1CDLT1", 2.0, null);
         Stokes.fromTableHeader(h, 0);
+    }
+
+    @Test
+    public void testParameters() throws Exception {
+        for (int i = 0; i < 8; i++) {
+            Stokes.Parameters p = Stokes.parameters(i);
+            Assert.assertEquals((i & Stokes.REVERSED_ORDER) != 0, p.isReversedOrder());
+            Assert.assertEquals((i & Stokes.FULL_CROSS_POLARIZATION) != 0, p.isCrossPolarization());
+
+            if (p.isCrossPolarization()) {
+                Assert.assertEquals((i & Stokes.CIRCULAR_CROSS_POLARIZATION) != 0, p.hasCircularPolarization());
+                Assert.assertEquals((i & Stokes.LINEAR_CROSS_POLARIZATION) != 0, p.hasLinearPolarization());
+            } else {
+                Assert.assertTrue(p.hasCircularPolarization());
+                Assert.assertTrue(p.hasLinearPolarization());
+            }
+
+        }
+
     }
 }

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -108,26 +108,26 @@ public class StokesTest {
         h.addValue(Standard.NAXIS, 3);
         p.fillImageHeader(h, 1);
         Assert.assertEquals("STOKES", h.getStringValue("CTYPE2"));
-        Assert.assertEquals(0.0, h.getDoubleValue("CRPIX2"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("CRPIX2"), 1e-12);
         Assert.assertEquals(1.0, h.getDoubleValue("CDELT2"), 1e-12);
         Assert.assertEquals(1.0, h.getDoubleValue("CRVAL2"), 1e-12);
 
         Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+        Assert.assertEquals(p, e.getValue());
 
         h = new Header();
         h.addValue(Standard.TDIMn.n(4), "(2,4,3)");
         p.fillTableHeader(h, 3, 1);
 
         Assert.assertEquals("STOKES", h.getStringValue("2CTYP4"));
-        Assert.assertEquals(0.0, h.getDoubleValue("2CRPX4"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("2CRPX4"), 1e-12);
         Assert.assertEquals(1.0, h.getDoubleValue("2CDLT4"), 1e-12);
         Assert.assertEquals(1.0, h.getDoubleValue("2CRVL4"), 1e-12);
 
         e = Stokes.fromTableHeader(h, 3);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+        Assert.assertEquals(p, e.getValue());
 
     }
 
@@ -161,7 +161,7 @@ public class StokesTest {
         h.addValue(Standard.NAXIS, 3);
         p.fillImageHeader(h, 1);
         Assert.assertEquals("STOKES", h.getStringValue("CTYPE2"));
-        Assert.assertEquals(0.0, h.getDoubleValue("CRPIX2"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("CRPIX2"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("CDELT2"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("CRVAL2"), 1e-12);
 
@@ -174,13 +174,13 @@ public class StokesTest {
         p.fillTableHeader(h, 3, 1);
 
         Assert.assertEquals("STOKES", h.getStringValue("2CTYP4"));
-        Assert.assertEquals(0.0, h.getDoubleValue("2CRPX4"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("2CRPX4"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("2CDLT4"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("2CRVL4"), 1e-12);
 
         e = Stokes.fromTableHeader(h, 3);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+        Assert.assertEquals(p, e.getValue());
 
     }
 
@@ -214,26 +214,26 @@ public class StokesTest {
         h.addValue(Standard.NAXIS, 3);
         p.fillImageHeader(h, 1);
         Assert.assertEquals("STOKES", h.getStringValue("CTYPE2"));
-        Assert.assertEquals(0.0, h.getDoubleValue("CRPIX2"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("CRPIX2"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("CDELT2"), 1e-12);
         Assert.assertEquals(-5.0, h.getDoubleValue("CRVAL2"), 1e-12);
 
         Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+        Assert.assertEquals(p, e.getValue());
 
         h = new Header();
         h.addValue(Standard.TDIMn.n(4), "(2,4,3)");
         p.fillTableHeader(h, 3, 1);
 
         Assert.assertEquals("STOKES", h.getStringValue("2CTYP4"));
-        Assert.assertEquals(0.0, h.getDoubleValue("2CRPX4"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("2CRPX4"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("2CDLT4"), 1e-12);
         Assert.assertEquals(-5.0, h.getDoubleValue("2CRVL4"), 1e-12);
 
         e = Stokes.fromTableHeader(h, 3);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+        Assert.assertEquals(p, e.getValue());
 
     }
 
@@ -284,26 +284,26 @@ public class StokesTest {
         h.addValue(Standard.NAXIS2, 8);
         p.fillImageHeader(h, 1);
         Assert.assertEquals("STOKES", h.getStringValue("CTYPE2"));
-        Assert.assertEquals(0.0, h.getDoubleValue("CRPIX2"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("CRPIX2"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("CDELT2"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("CRVAL2"), 1e-12);
 
         Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+        Assert.assertEquals(p, e.getValue());
 
         h = new Header();
         h.addValue(Standard.TDIMn.n(4), "(2,8,3)");
         p.fillTableHeader(h, 3, 1);
 
         Assert.assertEquals("STOKES", h.getStringValue("2CTYP4"));
-        Assert.assertEquals(0.0, h.getDoubleValue("2CRPX4"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("2CRPX4"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("2CDLT4"), 1e-12);
         Assert.assertEquals(-1.0, h.getDoubleValue("2CRVL4"), 1e-12);
 
         e = Stokes.fromTableHeader(h, 3);
         Assert.assertEquals(1, (int) e.getKey());
-        Assert.assertEquals(p.getClass(), e.getValue().getClass());
+        Assert.assertEquals(p, e.getValue());
 
     }
 
@@ -402,7 +402,7 @@ public class StokesTest {
         h.addValue(Standard.NAXIS, 1);
 
         Stokes.parameters().fillImageHeader(h, 0);
-        h.addValue("CRPIX1", 1.0, null);
+        h.addValue("CRPIX1", 1.5, null);
         Stokes.fromImageHeader(h);
     }
 
@@ -412,7 +412,7 @@ public class StokesTest {
         h.addValue(Standard.NAXIS, 1);
 
         Stokes.parameters().fillImageHeader(h, 0);
-        h.addValue("CDELT1", 2.0, null);
+        h.addValue("CDELT1", 1.5, null);
         Stokes.fromImageHeader(h);
     }
 
@@ -448,7 +448,7 @@ public class StokesTest {
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
         Stokes.parameters().fillTableHeader(h, 0, 0);
-        h.addValue("1CRPX1", 1.0, null);
+        h.addValue("1CRPX1", 1.5, null);
         Stokes.fromTableHeader(h, 0);
     }
 
@@ -458,7 +458,7 @@ public class StokesTest {
         h.addValue(Standard.TDIMn.n(1), "(4)");
 
         Stokes.parameters().fillTableHeader(h, 0, 0);
-        h.addValue("1CDLT1", 2.0, null);
+        h.addValue("1CDLT1", 1.5, null);
         Stokes.fromTableHeader(h, 0);
     }
 
@@ -512,92 +512,8 @@ public class StokesTest {
 
         Stokes.Parameters p0 = Stokes.parameters();
         p0.fillImageHeader(h, 0);
-        h.addValue(Standard.CDELTn.n(1), -1.0);
+        h.addValue(Standard.CDELTn.n(1), 1.5);
         Stokes.fromImageHeader(h).getValue();
-    }
-
-    @Test(expected = FitsException.class)
-    public void testInvalidCircularCDELT() throws Exception {
-        Header h = new Header();
-        h.addValue(Standard.NAXIS, 1);
-        h.addValue(Standard.NAXIS1, 4);
-
-        Stokes.Parameters p0 = Stokes.parameters(Stokes.CIRCULAR_CROSS_POLARIZATION);
-        p0.fillImageHeader(h, 0);
-        h.addValue(Standard.CDELTn.n(1), 1.0);
-        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
-    }
-
-    @Test(expected = FitsException.class)
-    public void testInvalidLinearCDELT() throws Exception {
-        Header h = new Header();
-        h.addValue(Standard.NAXIS, 1);
-        h.addValue(Standard.NAXIS1, 4);
-
-        Stokes.Parameters p0 = Stokes.parameters(Stokes.LINEAR_CROSS_POLARIZATION);
-        p0.fillImageHeader(h, 0);
-        h.addValue(Standard.CDELTn.n(1), 1.0);
-        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
-    }
-
-    @Test(expected = FitsException.class)
-    public void testInvalidFullCDELT() throws Exception {
-        Header h = new Header();
-        h.addValue(Standard.NAXIS, 1);
-        h.addValue(Standard.NAXIS1, 8);
-
-        Stokes.Parameters p0 = Stokes.parameters(Stokes.FULL_CROSS_POLARIZATION);
-        p0.fillImageHeader(h, 0);
-        h.addValue(Standard.CDELTn.n(1), 1.0);
-        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
-    }
-
-    @Test(expected = FitsException.class)
-    public void testReverseOrderInvalidCDELT() throws Exception {
-        Header h = new Header();
-        h.addValue(Standard.NAXIS, 1);
-        h.addValue(Standard.NAXIS1, 4);
-
-        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER);
-        p0.fillImageHeader(h, 0);
-        h.addValue(Standard.CDELTn.n(1), 1.0);
-        Stokes.fromImageHeader(h).getValue();
-    }
-
-    @Test(expected = FitsException.class)
-    public void testReverseOrderInvalidCircularCDELT() throws Exception {
-        Header h = new Header();
-        h.addValue(Standard.NAXIS, 1);
-        h.addValue(Standard.NAXIS1, 4);
-
-        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.CIRCULAR_CROSS_POLARIZATION);
-        p0.fillImageHeader(h, 0);
-        h.addValue(Standard.CDELTn.n(1), -1.0);
-        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
-    }
-
-    @Test(expected = FitsException.class)
-    public void testReverseOrderInvalidLinearCDELT() throws Exception {
-        Header h = new Header();
-        h.addValue(Standard.NAXIS, 1);
-        h.addValue(Standard.NAXIS1, 4);
-
-        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.LINEAR_CROSS_POLARIZATION);
-        p0.fillImageHeader(h, 0);
-        h.addValue(Standard.CDELTn.n(1), -1.0);
-        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
-    }
-
-    @Test(expected = FitsException.class)
-    public void testReverseOrderInvalidFullCDELT() throws Exception {
-        Header h = new Header();
-        h.addValue(Standard.NAXIS, 1);
-        h.addValue(Standard.NAXIS1, 8);
-
-        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.FULL_CROSS_POLARIZATION);
-        p0.fillImageHeader(h, 0);
-        h.addValue(Standard.CDELTn.n(1), -1.0);
-        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
     }
 
     @Test
@@ -608,6 +524,32 @@ public class StokesTest {
     @Test
     public void testEqualsOther() throws Exception {
         Assert.assertFalse(Stokes.parameters().equals("blah"));
+    }
+
+    @Test
+    public void testEqualsOffset() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters();
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CRVALn.n(1), 2);
+
+        Assert.assertNotEquals(p0, Stokes.fromImageHeader(h).getValue());
+    }
+
+    @Test
+    public void testEqualsStep() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters();
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), 2);
+
+        Assert.assertNotEquals(p0, Stokes.fromImageHeader(h).getValue());
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -503,4 +503,52 @@ public class StokesTest {
         p0.fillImageHeader(h, 0);
         Assert.assertEquals(p0, Stokes.fromImageHeader(h).getValue());
     }
+
+    @Test(expected = FitsException.class)
+    public void testReverseOrderInvalidCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER);
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), 1.0);
+        Stokes.fromImageHeader(h).getValue();
+    }
+
+    @Test(expected = FitsException.class)
+    public void testReverseOrderInvalidCircularCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.CIRCULAR_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), -1.0);
+        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
+    }
+
+    @Test(expected = FitsException.class)
+    public void testReverseOrderInvalidLinearCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.LINEAR_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), -1.0);
+        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
+    }
+
+    @Test(expected = FitsException.class)
+    public void testReverseOrderInvalidFullCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 8);
+
+        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.FULL_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        h.addValue(Standard.CDELTn.n(1), -1.0);
+        Assert.assertNull(Stokes.fromImageHeader(h).getValue());
+    }
 }

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -397,6 +397,16 @@ public class StokesTest {
     }
 
     @Test(expected = FitsException.class)
+    public void testFromImageHeaderFractionalCRVAL() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+
+        Stokes.parameters().fillImageHeader(h, 0);
+        h.addValue("CRVAL1", 1.5, null);
+        Stokes.fromImageHeader(h);
+    }
+
+    @Test(expected = FitsException.class)
     public void testFromImageHeaderInvalidCRPIX() throws Exception {
         Header h = new Header();
         h.addValue(Standard.NAXIS, 1);
@@ -439,6 +449,16 @@ public class StokesTest {
 
         Stokes.parameters().fillTableHeader(h, 0, 0);
         h.addValue("1CRVL1", 0.0, null);
+        Stokes.fromTableHeader(h, 0);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromTableHeaderFractionalCRVAL() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(1), "(4)");
+
+        Stokes.parameters().fillTableHeader(h, 0, 0);
+        h.addValue("1CRVL1", 1.5, null);
         Stokes.fromTableHeader(h, 0);
     }
 
@@ -557,6 +577,9 @@ public class StokesTest {
         for (int i = 0; i < 8; i++) {
             for (int j = 0; j < 8; j++) {
                 Assert.assertEquals(i + ", " + j, (i == j), Stokes.parameters(i).equals(Stokes.parameters(j)));
+                if (i == j) {
+                    Assert.assertEquals("hash " + i, Stokes.parameters(i).hashCode(), Stokes.parameters(j).hashCode());
+                }
             }
         }
     }

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -599,4 +599,23 @@ public class StokesTest {
         h.addValue(Standard.CDELTn.n(1), -1.0);
         Assert.assertNull(Stokes.fromImageHeader(h).getValue());
     }
+
+    @Test
+    public void testEqualsNull() throws Exception {
+        Assert.assertFalse(Stokes.parameters().equals(null));
+    }
+
+    @Test
+    public void testEqualsOther() throws Exception {
+        Assert.assertFalse(Stokes.parameters().equals("blah"));
+    }
+
+    @Test
+    public void testEquals() throws Exception {
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 8; j++) {
+                Assert.assertEquals(i + ", " + j, (i == j), Stokes.parameters(i).equals(Stokes.parameters(j)));
+            }
+        }
+    }
 }

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -478,6 +478,29 @@ public class StokesTest {
             }
 
         }
+    }
 
+    @Test
+    public void testReverseOrderHeaders() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        h.addValue(Standard.NAXIS1, 4);
+
+        Stokes.Parameters p0 = Stokes.parameters(Stokes.REVERSED_ORDER);
+        p0.fillImageHeader(h, 0);
+        Assert.assertEquals(p0, Stokes.fromImageHeader(h).getValue());
+
+        p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.CIRCULAR_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        Assert.assertEquals(p0, Stokes.fromImageHeader(h).getValue());
+
+        p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.LINEAR_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        Assert.assertEquals(p0, Stokes.fromImageHeader(h).getValue());
+
+        h.addValue(Standard.NAXIS1, 8);
+        p0 = Stokes.parameters(Stokes.REVERSED_ORDER | Stokes.FULL_CROSS_POLARIZATION);
+        p0.fillImageHeader(h, 0);
+        Assert.assertEquals(p0, Stokes.fromImageHeader(h).getValue());
     }
 }

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -1,0 +1,341 @@
+package nom.tam.fits.header;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import nom.tam.fits.FitsException;
+import nom.tam.fits.Header;
+
+public class StokesTest {
+
+    @Test
+    public void testStokesValues() throws Exception {
+        Assert.assertEquals(1, Stokes.I.getCoordinateValue());
+        Assert.assertEquals(2, Stokes.Q.getCoordinateValue());
+        Assert.assertEquals(3, Stokes.U.getCoordinateValue());
+        Assert.assertEquals(4, Stokes.V.getCoordinateValue());
+
+        Assert.assertEquals(-1, Stokes.RR.getCoordinateValue());
+        Assert.assertEquals(-2, Stokes.LL.getCoordinateValue());
+        Assert.assertEquals(-3, Stokes.RL.getCoordinateValue());
+        Assert.assertEquals(-4, Stokes.LR.getCoordinateValue());
+
+        Assert.assertEquals(-5, Stokes.XX.getCoordinateValue());
+        Assert.assertEquals(-6, Stokes.YY.getCoordinateValue());
+        Assert.assertEquals(-7, Stokes.XY.getCoordinateValue());
+        Assert.assertEquals(-8, Stokes.YX.getCoordinateValue());
+    }
+
+    @Test
+    public void testForCoordinateValues() throws Exception {
+        Assert.assertEquals(Stokes.I, Stokes.forCoordinateValue(1));
+        Assert.assertEquals(Stokes.Q, Stokes.forCoordinateValue(2));
+        Assert.assertEquals(Stokes.U, Stokes.forCoordinateValue(3));
+        Assert.assertEquals(Stokes.V, Stokes.forCoordinateValue(4));
+
+        Assert.assertEquals(Stokes.RR, Stokes.forCoordinateValue(-1));
+        Assert.assertEquals(Stokes.LL, Stokes.forCoordinateValue(-2));
+        Assert.assertEquals(Stokes.RL, Stokes.forCoordinateValue(-3));
+        Assert.assertEquals(Stokes.LR, Stokes.forCoordinateValue(-4));
+
+        Assert.assertEquals(Stokes.XX, Stokes.forCoordinateValue(-5));
+        Assert.assertEquals(Stokes.YY, Stokes.forCoordinateValue(-6));
+        Assert.assertEquals(Stokes.XY, Stokes.forCoordinateValue(-7));
+        Assert.assertEquals(Stokes.YX, Stokes.forCoordinateValue(-8));
+    }
+
+    @Test
+    public void testSingleEndedParameters() throws Exception {
+        Stokes.Parameters p = Stokes.Parameters.SINGLE_ENDED_POLARIZATION;
+
+        Assert.assertEquals(Stokes.I, p.getParameter(0));
+        Assert.assertEquals(Stokes.Q, p.getParameter(1));
+        Assert.assertEquals(Stokes.U, p.getParameter(2));
+        Assert.assertEquals(Stokes.V, p.getParameter(3));
+
+        ArrayList<Stokes> l = p.getAvailableParameters();
+        Assert.assertEquals(4, l.size());
+        Assert.assertTrue(l.contains(Stokes.I));
+        Assert.assertTrue(l.contains(Stokes.Q));
+        Assert.assertTrue(l.contains(Stokes.U));
+        Assert.assertTrue(l.contains(Stokes.V));
+
+        Assert.assertEquals(Stokes.I, p.getParameter(0));
+        Assert.assertEquals(Stokes.Q, p.getParameter(1));
+        Assert.assertEquals(Stokes.U, p.getParameter(2));
+        Assert.assertEquals(Stokes.V, p.getParameter(3));
+
+        Assert.assertEquals(0, p.getArrayIndex(Stokes.I));
+        Assert.assertEquals(1, p.getArrayIndex(Stokes.Q));
+        Assert.assertEquals(2, p.getArrayIndex(Stokes.U));
+        Assert.assertEquals(3, p.getArrayIndex(Stokes.V));
+
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 3);
+        p.fillImageHeader(h, 1);
+        Assert.assertEquals("STOKES", h.getStringValue("CTYPE2"));
+        Assert.assertEquals(0.0, h.getDoubleValue("CRPIX2"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("CDELT2"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("CRVAL2"), 1e-12);
+
+        Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
+        Assert.assertEquals(1, (int) e.getKey());
+        Assert.assertEquals(p, e.getValue());
+
+        h = new Header();
+        h.addValue(Standard.TDIMn.n(4), "(2,4,3)");
+        p.fillTableHeader(h, 3, 1);
+
+        Assert.assertEquals("STOKES", h.getStringValue("2CTYP4"));
+        Assert.assertEquals(0.0, h.getDoubleValue("2CRPX4"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("2CDLT4"), 1e-12);
+        Assert.assertEquals(1.0, h.getDoubleValue("2CRVL4"), 1e-12);
+
+        e = Stokes.fromTableHeader(h, 3);
+        Assert.assertEquals(1, (int) e.getKey());
+        Assert.assertEquals(p, e.getValue());
+
+    }
+
+    @Test
+    public void testCircularCrossParameters() throws Exception {
+        Stokes.Parameters p = Stokes.Parameters.CIRCULAR_CROSS_POLARIZATION;
+
+        Assert.assertEquals(Stokes.RR, p.getParameter(0));
+        Assert.assertEquals(Stokes.LL, p.getParameter(1));
+        Assert.assertEquals(Stokes.RL, p.getParameter(2));
+        Assert.assertEquals(Stokes.LR, p.getParameter(3));
+
+        ArrayList<Stokes> l = p.getAvailableParameters();
+        Assert.assertEquals(4, l.size());
+        Assert.assertTrue(l.contains(Stokes.RR));
+        Assert.assertTrue(l.contains(Stokes.LL));
+        Assert.assertTrue(l.contains(Stokes.RL));
+        Assert.assertTrue(l.contains(Stokes.LR));
+
+        Assert.assertEquals(Stokes.RR, p.getParameter(0));
+        Assert.assertEquals(Stokes.LL, p.getParameter(1));
+        Assert.assertEquals(Stokes.RL, p.getParameter(2));
+        Assert.assertEquals(Stokes.LR, p.getParameter(3));
+
+        Assert.assertEquals(0, p.getArrayIndex(Stokes.RR));
+        Assert.assertEquals(1, p.getArrayIndex(Stokes.LL));
+        Assert.assertEquals(2, p.getArrayIndex(Stokes.RL));
+        Assert.assertEquals(3, p.getArrayIndex(Stokes.LR));
+
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 3);
+        p.fillImageHeader(h, 1);
+        Assert.assertEquals("STOKES", h.getStringValue("CTYPE2"));
+        Assert.assertEquals(0.0, h.getDoubleValue("CRPIX2"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("CDELT2"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("CRVAL2"), 1e-12);
+
+        Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
+        Assert.assertEquals(1, (int) e.getKey());
+        Assert.assertEquals(p, e.getValue());
+
+        h = new Header();
+        h.addValue(Standard.TDIMn.n(4), "(2,4,3)");
+        p.fillTableHeader(h, 3, 1);
+
+        Assert.assertEquals("STOKES", h.getStringValue("2CTYP4"));
+        Assert.assertEquals(0.0, h.getDoubleValue("2CRPX4"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("2CDLT4"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("2CRVL4"), 1e-12);
+
+        e = Stokes.fromTableHeader(h, 3);
+        Assert.assertEquals(1, (int) e.getKey());
+        Assert.assertEquals(p, e.getValue());
+
+    }
+
+    @Test
+    public void testLinearCrossParameters() throws Exception {
+        Stokes.Parameters p = Stokes.Parameters.LINEAR_CROSS_POLARIZATION;
+
+        Assert.assertEquals(Stokes.XX, p.getParameter(0));
+        Assert.assertEquals(Stokes.YY, p.getParameter(1));
+        Assert.assertEquals(Stokes.XY, p.getParameter(2));
+        Assert.assertEquals(Stokes.YX, p.getParameter(3));
+
+        ArrayList<Stokes> l = p.getAvailableParameters();
+        Assert.assertEquals(4, l.size());
+        Assert.assertTrue(l.contains(Stokes.XX));
+        Assert.assertTrue(l.contains(Stokes.YY));
+        Assert.assertTrue(l.contains(Stokes.XY));
+        Assert.assertTrue(l.contains(Stokes.YX));
+
+        Assert.assertEquals(Stokes.XX, p.getParameter(0));
+        Assert.assertEquals(Stokes.YY, p.getParameter(1));
+        Assert.assertEquals(Stokes.XY, p.getParameter(2));
+        Assert.assertEquals(Stokes.YX, p.getParameter(3));
+
+        Assert.assertEquals(0, p.getArrayIndex(Stokes.XX));
+        Assert.assertEquals(1, p.getArrayIndex(Stokes.YY));
+        Assert.assertEquals(2, p.getArrayIndex(Stokes.XY));
+        Assert.assertEquals(3, p.getArrayIndex(Stokes.YX));
+
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 3);
+        p.fillImageHeader(h, 1);
+        Assert.assertEquals("STOKES", h.getStringValue("CTYPE2"));
+        Assert.assertEquals(0.0, h.getDoubleValue("CRPIX2"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("CDELT2"), 1e-12);
+        Assert.assertEquals(-5.0, h.getDoubleValue("CRVAL2"), 1e-12);
+
+        Map.Entry<Integer, Stokes.Parameters> e = Stokes.fromImageHeader(h);
+        Assert.assertEquals(1, (int) e.getKey());
+        Assert.assertEquals(p, e.getValue());
+
+        h = new Header();
+        h.addValue(Standard.TDIMn.n(4), "(2,4,3)");
+        p.fillTableHeader(h, 3, 1);
+
+        Assert.assertEquals("STOKES", h.getStringValue("2CTYP4"));
+        Assert.assertEquals(0.0, h.getDoubleValue("2CRPX4"), 1e-12);
+        Assert.assertEquals(-1.0, h.getDoubleValue("2CDLT4"), 1e-12);
+        Assert.assertEquals(-5.0, h.getDoubleValue("2CRVL4"), 1e-12);
+
+        e = Stokes.fromTableHeader(h, 3);
+        Assert.assertEquals(1, (int) e.getKey());
+        Assert.assertEquals(p, e.getValue());
+
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testGetNegParameter() throws Exception {
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.getParameter(-1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testGetOutOfBoundsParameter() throws Exception {
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.getParameter(4);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFillImageHeaderNoNAXIS() throws Exception {
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(new Header(), 0);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFillTableHeaderNoTDIM() throws Exception {
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(new Header(), 0, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFillImageHeaderNegIndex() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 3);
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFillImageHeaderOutOfBoundsIndex() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 3);
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 3);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFillTableHeaderNegIndex() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(1), "(4)");
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFillTableHeaderOutOfBoundsIndex() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(1), "(4)");
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 3);
+    }
+
+    @Test
+    public void testFromImageHeaderNoStokes() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+        Assert.assertNull(Stokes.fromImageHeader(h));
+    }
+
+    @Test
+    public void testFromTableHeaderNoStokes() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(0), "(4)");
+        Assert.assertNull(Stokes.fromTableHeader(h, 0));
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromImageHeaderInvalidCRPIX() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 0);
+        h.addValue("CRPIX1", 1.0, null);
+        Stokes.fromImageHeader(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromImageHeaderInvalidCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.NAXIS, 1);
+
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillImageHeader(h, 0);
+        h.addValue("CDELT1", 2.0, null);
+        Stokes.fromImageHeader(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromTableHeaderInvalidCRPIX() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(0), "(4)");
+
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
+        h.addValue("1CRPX1", 1.0, null);
+        Stokes.fromImageHeader(h);
+    }
+
+    @Test(expected = FitsException.class)
+    public void testFromTableHeaderInvalidCDELT() throws Exception {
+        Header h = new Header();
+        h.addValue(Standard.TDIMn.n(0), "(4)");
+
+        Stokes.Parameters.SINGLE_ENDED_POLARIZATION.fillTableHeader(h, 0, 0);
+        h.addValue("1CDLT1", 2.0, null);
+        Stokes.fromImageHeader(h);
+    }
+}


### PR DESCRIPTION
The image coordinate type 'STOKES' is special, as the set of values along that 'coordinate' translate to a set of specific polarization Stokes parameters. We now add mappings between the coordinate indices and the associated parameters, and utilities to populate and parse Stokes 'coordinates' in FITS files properly.

New `Stokes` enum and its static methods can help handle these special values with ease.