### PR TITLE
Default column names

### DIFF
--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -176,6 +176,13 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
         return hdr;
     }
 
+    @Override
+    public void setColumnName(int index, String name, String comment)
+            throws IllegalArgumentException, IndexOutOfBoundsException, HeaderCardException {
+        super.setColumnName(index, name, comment);
+        myData.setColumnName(index, name);
+    }
+
     @SuppressWarnings("deprecation")
     @Override
     public int addColumn(Object newCol) throws FitsException {

--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -180,11 +180,7 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
     public void setColumnName(int index, String name, String comment)
             throws IndexOutOfBoundsException, HeaderCardException {
         super.setColumnName(index, name, comment);
-        try {
-            myData.setColumnName(index, name);
-        } catch (IllegalArgumentException e) {
-            throw new HeaderCardException(e.getMessage(), e);
-        }
+        myData.setColumnName(index, name);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/nom/tam/fits/AsciiTableHDU.java
+++ b/src/main/java/nom/tam/fits/AsciiTableHDU.java
@@ -178,9 +178,13 @@ public class AsciiTableHDU extends TableHDU<AsciiTable> {
 
     @Override
     public void setColumnName(int index, String name, String comment)
-            throws IllegalArgumentException, IndexOutOfBoundsException, HeaderCardException {
+            throws IndexOutOfBoundsException, HeaderCardException {
         super.setColumnName(index, name, comment);
-        myData.setColumnName(index, name);
+        try {
+            myData.setColumnName(index, name);
+        } catch (IllegalArgumentException e) {
+            throw new HeaderCardException(e.getMessage(), e);
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -1949,17 +1949,16 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
 
         // Load any deferred data (we will not be able to do that once we alter the column structure)
         ensureData();
+
+        // Set the default column name
+        c.name(TableHDU.getDefaultColumnName(columns.size()));
+
         table.addColumn(o, c.getTableBaseCount());
         columns.add(c);
 
         if (nRow == 0) {
             // Set the table row count to match first colum
             nRow = rows;
-        }
-
-        if (c.name() == null) {
-            // Set the default column name
-            c.name(TableHDU.getDefaultColumnName(columns.size()));
         }
 
         return columns.size();

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -1768,11 +1768,11 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
         }
         descriptor.offset = rowLen;
         rowLen += descriptor.rowLen();
-        columns.add(descriptor);
         if (descriptor.name() == null) {
             // Set default column name;
             descriptor.name(TableHDU.getDefaultColumnName(columns.size()));
         }
+        columns.add(descriptor);
         return columns.size();
     }
 

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -205,7 +205,7 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
         myHeader.addValue(Standard.NAXISn.n(1), myData.getRowBytes());
         Cursor<String, HeaderCard> c = myHeader.iterator();
         c.end();
-        myData.fillForColumn(c, n - 1);
+        myData.fillForColumn(myHeader, c, n - 1);
         return super.addColumn(data);
     }
 
@@ -286,6 +286,13 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
      */
     public BinaryTable.ColumnDesc getColumnDescriptor(int col) {
         return myData.getDescriptor(col);
+    }
+
+    @Override
+    public void setColumnName(int index, String name, String comment)
+            throws IllegalArgumentException, IndexOutOfBoundsException, HeaderCardException {
+        super.setColumnName(index, name, comment);
+        getColumnDescriptor(index).name(name);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/BinaryTableHDU.java
+++ b/src/main/java/nom/tam/fits/BinaryTableHDU.java
@@ -290,7 +290,7 @@ public class BinaryTableHDU extends TableHDU<BinaryTable> {
 
     @Override
     public void setColumnName(int index, String name, String comment)
-            throws IllegalArgumentException, IndexOutOfBoundsException, HeaderCardException {
+            throws IndexOutOfBoundsException, HeaderCardException {
         super.setColumnName(index, name, comment);
         getColumnDescriptor(index).name(name);
     }

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -48,6 +48,23 @@ import static nom.tam.fits.header.Standard.TTYPEn;
 public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> {
 
     /**
+     * Returns the default name for a columns with the specified index, to use if no column name was explicitly defined
+     * 
+     * @param  col The zero-based Java index of the column
+     * 
+     * @return     The default column name to use if no other name was defined.
+     * 
+     * @since      1.20
+     * 
+     * @author     Attila Kovacs
+     * 
+     * @see        #setColumnName(int, String, String)
+     */
+    public static String getDefaultColumnName(int col) {
+        return "Column " + (col + 1);
+    }
+
+    /**
      * Create the TableHDU. Note that this will normally only be invoked by subclasses in the FITS package.
      *
      * @deprecated     intended for internal use. Its visibility should be reduced to package level in the future.
@@ -57,11 +74,6 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
      */
     protected TableHDU(Header hdr, T td) {
         super(hdr, td);
-        for (int i = getNCols(); --i >= 0;) {
-            if (getColumnName(i) == null) {
-                setDefaultColumnName(i);
-            }
-        }
     }
 
     /**
@@ -81,7 +93,6 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
     public int addColumn(Object newCol) throws FitsException {
         int nCols = getNCols();
         myHeader.findCard(TFIELDS).setValue(nCols);
-        setDefaultColumnName(nCols);
         return nCols;
     }
 
@@ -356,11 +367,14 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
     }
 
     /**
-     * Get the name of a column in the table.
+     * Gets the name of a column in the table, as it appears in this HDU's header. It may differ from a more currently
+     * assigned name of the binary table data column after the HDU creation or reading.
      *
      * @param  index The 0-based column index.
      *
      * @return       The column name.
+     * 
+     * @see          BinaryTable.ColumnDesc#name()
      */
     public String getColumnName(int index) {
 
@@ -620,33 +634,28 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
      * Sets the name / ID of a specific column in this table. Naming columns is generally a good idea so that people can
      * figure out what sort of data actually appears in specific table columns.
      * 
-     * @param  index               the column index
-     * @param  name                the name or ID we want to assing to the column
-     * @param  comment             Any additional comment we would like to store alongside in the FITS header. (The
-     *                                 comment may be truncated or even ommitted, depending on space constraints in the
-     *                                 FITS header.
+     * @param  index                     the column index
+     * @param  name                      the name or ID we want to assing to the column
+     * @param  comment                   Any additional comment we would like to store alongside in the FITS header.
+     *                                       (The comment may be truncated or even ommitted, depending on space
+     *                                       constraints in the FITS header.
      * 
-     * @throws HeaderCardException if there was a problem wil adding the associated descriptive FITS header keywords to
-     *                                 this table's header.
+     * @throws IllegalArgumentException  if the name contains characters outside of the legal ASCII range of 0x20
+     *                                       through 0x7F
+     * @throws IndexOutOfBoundsException if the table has no column matching the index
+     * @throws HeaderCardException       if there was a problem wil adding the associated descriptive FITS header
+     *                                       keywords to this table's header.
+     * 
+     * @see                              #getColumnName(int)
+     * @see                              #getDefaultColumnName(int)
      */
-    public void setColumnName(int index, String name, String comment) throws HeaderCardException {
+    public void setColumnName(int index, String name, String comment)
+            throws IllegalArgumentException, IndexOutOfBoundsException, HeaderCardException {
+        if (index < 0 || index >= getNCols()) {
+            throw new IndexOutOfBoundsException(
+                    "column index " + index + " is out of bounds for table with " + getNCols() + " columns");
+        }
         setColumnMeta(index, TTYPEn, name, comment, true);
-    }
-
-    private void setDefaultColumnName(int index) {
-        // TODO
-        // AK: We currently allow undefined column names, but some other software, such as fv, have
-        // problemss processing such files. By uncommenting the lines below, we can enable
-        // setting default column names when columns are created or added to the table...
-        // This should not break anything in principle, but can increase header size,
-        // and therefore some of out unit tests may fail, unless adjusted...
-
-        // try {
-        // setColumnName(index, "Column" + (index + 1), "default column name");
-        // } catch (Exception e) {
-        // // Should not happen.
-        // e.printStackTrace();
-        // }
     }
 
     /**

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -640,8 +640,6 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
      *                                       (The comment may be truncated or even ommitted, depending on space
      *                                       constraints in the FITS header.
      * 
-     * @throws IllegalArgumentException  if the name contains characters outside of the legal ASCII range of 0x20
-     *                                       through 0x7F
      * @throws IndexOutOfBoundsException if the table has no column matching the index
      * @throws HeaderCardException       if there was a problem wil adding the associated descriptive FITS header
      *                                       keywords to this table's header.
@@ -650,7 +648,7 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
      * @see                              #getDefaultColumnName(int)
      */
     public void setColumnName(int index, String name, String comment)
-            throws IllegalArgumentException, IndexOutOfBoundsException, HeaderCardException {
+            throws IndexOutOfBoundsException, HeaderCardException {
         if (index < 0 || index >= getNCols()) {
             throw new IndexOutOfBoundsException(
                     "column index " + index + " is out of bounds for table with " + getNCols() + " columns");

--- a/src/test/java/nom/tam/fits/AsciiTableNewTest.java
+++ b/src/test/java/nom/tam/fits/AsciiTableNewTest.java
@@ -1,0 +1,52 @@
+package nom.tam.fits;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import nom.tam.fits.header.Standard;
+
+public class AsciiTableNewTest {
+
+    @Test
+    public void testSetColumnNameNull() throws Exception {
+        AsciiTable tab = new AsciiTable();
+        tab.addColumn(new float[3]);
+        tab.addColumn(new int[3]);
+        tab.setColumnName(1, null);
+        AsciiTableHDU hdu = tab.toHDU();
+
+        Assert.assertEquals(TableHDU.getDefaultColumnName(0), hdu.getHeader().getStringValue(Standard.TTYPEn.n(1)));
+        Assert.assertFalse(hdu.getHeader().containsKey(Standard.TTYPEn.n(2)));
+    }
+}

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -1895,4 +1895,16 @@ public class BinaryTableNewTest {
         Assert.assertNull(tab.getDescriptor("not in this table"));
     }
 
+    @Test
+    public void testSetColumnNameNull() throws Exception {
+        BinaryTable tab = new BinaryTable();
+        tab.addColumn(BinaryTable.ColumnDesc.createForScalars(byte.class));
+        tab.addColumn(BinaryTable.ColumnDesc.createForScalars(int.class));
+        tab.getDescriptor(1).name(null);
+        BinaryTableHDU hdu = tab.toHDU();
+
+        Assert.assertEquals(TableHDU.getDefaultColumnName(0), hdu.getHeader().getStringValue(Standard.TTYPEn.n(1)));
+        Assert.assertFalse(hdu.getHeader().containsKey(Standard.TTYPEn.n(2)));
+    }
+
 }

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -1873,4 +1873,26 @@ public class BinaryTableNewTest {
         Assert.assertEquals(4 * FitsFactory.FITS_BLOCK_SIZE, file.length());
     }
 
+    @Test
+    public void testIndexOf() throws Exception {
+        BinaryTable tab = new BinaryTable();
+        tab.addColumn(BinaryTable.ColumnDesc.createForScalars(byte.class));
+        tab.addColumn(BinaryTable.ColumnDesc.createForScalars(int.class).name("my column"));
+
+        Assert.assertEquals(0, tab.indexOf(TableHDU.getDefaultColumnName(0)));
+        Assert.assertEquals(1, tab.indexOf("my column"));
+        Assert.assertEquals(-1, tab.indexOf("not in this table"));
+    }
+
+    @Test
+    public void testGetDescriptorString() throws Exception {
+        BinaryTable tab = new BinaryTable();
+        tab.addColumn(BinaryTable.ColumnDesc.createForScalars(byte.class));
+        tab.addColumn(BinaryTable.ColumnDesc.createForScalars(int.class).name("my column"));
+
+        Assert.assertEquals(tab.getDescriptor(0), tab.getDescriptor(TableHDU.getDefaultColumnName(0)));
+        Assert.assertEquals(tab.getDescriptor(1), tab.getDescriptor("my column"));
+        Assert.assertNull(tab.getDescriptor("not in this table"));
+    }
+
 }

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -59,6 +59,7 @@ import nom.tam.fits.Fits;
 import nom.tam.fits.FitsException;
 import nom.tam.fits.FitsFactory;
 import nom.tam.fits.Header;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.PaddingException;
 import nom.tam.fits.TableHDU;
 import nom.tam.fits.header.NonStandard;
@@ -1359,5 +1360,44 @@ public class AsciiTableTest {
     public void testFromColumnMajorRecastException() throws Exception {
         Object[] cols = new Object[] {new int[3], "blah"};
         AsciiTable.fromColumnMajor(cols); /// addColumn("blah") throws IllegalArgumentException, recast to FitsException
+    }
+
+    @Test
+    public void testSetColumnName() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        AsciiTableHDU hdu = tab.toHDU();
+
+        hdu.setColumnName(1, "my column", "custom column name");
+
+        Assert.assertEquals(TableHDU.getDefaultColumnName(0), hdu.getColumnName(0));
+        Assert.assertEquals("my column", hdu.getColumnName(1));
+    }
+
+    @Test(expected = HeaderCardException.class)
+    public void testSetColumnNameInvalidString() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        AsciiTableHDU hdu = tab.toHDU();
+
+        hdu.setColumnName(1, "my column\n", "invalid column name");
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSetColumnNameNegativeIndex() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        AsciiTableHDU hdu = tab.toHDU();
+
+        hdu.setColumnName(-1, "my column", "invalid column name");
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSetColumnNameIndexOutOfBounds() throws Exception {
+        Object[] cols = new Object[] {new int[3], new float[3]};
+        AsciiTable tab = AsciiTable.fromColumnMajor(cols);
+        AsciiTableHDU hdu = tab.toHDU();
+
+        hdu.setColumnName(2, "my column", "invalid column name");
     }
 }

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -653,7 +653,7 @@ public class AsciiTableTest {
         AsciiTableHDU hdu = (AsciiTableHDU) makeAsciiTable().getHDU(1);
         assertEquals("I10", hdu.getColumnFormat(1));
         assertEquals("I10", hdu.getColumnMeta(1, "TFORM"));
-        Assert.assertNull(hdu.getColumnName(1));
+        Assert.assertEquals(TableHDU.getDefaultColumnName(1), hdu.getColumnName(1));
 
         hdu.setColumnMeta(1, "TTYPE", "TATA", null);
         assertEquals("TATA", hdu.getColumnName(1));
@@ -675,10 +675,8 @@ public class AsciiTableTest {
     public void testDelete() throws Exception {
         AsciiTableHDU hdu = (AsciiTableHDU) makeAsciiTable().getHDU(1);
         assertEquals(5, hdu.getNCols());
-        assertEquals(18, hdu.getHeader().size());
         hdu.deleteColumnsIndexOne(1, 1, new String[] {});
         assertEquals(4, hdu.getNCols());
-        assertEquals(17, hdu.getHeader().size());
     }
 
     @Test(expected = FitsException.class)
@@ -692,7 +690,6 @@ public class AsciiTableTest {
         AsciiTableHDU hdu = (AsciiTableHDU) makeAsciiTable().getHDU(1);
         hdu.deleteColumnsIndexOne(1, 0, new String[] {});
         assertEquals(5, hdu.getNCols());
-        assertEquals(18, hdu.getHeader().size());
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -1400,4 +1400,5 @@ public class AsciiTableTest {
 
         hdu.setColumnName(2, "my column", "invalid column name");
     }
+
 }

--- a/src/test/java/nom/tam/fits/test/BinaryTableTest.java
+++ b/src/test/java/nom/tam/fits/test/BinaryTableTest.java
@@ -909,18 +909,9 @@ public class BinaryTableTest {
 
             Fits f = new Fits();
             Object[] data = new Object[] {bytes, bits, bools, shorts, ints, floats, doubles, longs, strings};
-            // complex,
-            // dcomplex, complex_arr, dcomplex_arr, vcomplex};
             BinaryTableHDU bhdu = (BinaryTableHDU) Fits.makeHDU(data);
 
-            bhdu.setComplexColumn(9);
-            bhdu.setComplexColumn(10);
-            bhdu.setComplexColumn(11);
-            bhdu.setComplexColumn(12);
-            bhdu.setComplexColumn(13);
-
             f.addHDU(bhdu);
-            bhdu.setColumnName(9, "Complex1", null);
 
             FitsFile bf = new FitsFile("target/bt1c.fits", "rw");
             f.write(bf);


### PR DESCRIPTION
## Added

- `ColumnDesc.name(String)` to set user-specified column names for binary table descriptors
- `ColumnDesc.name()` to retrieve the current name of the binary table column descriptor
- `BinaryTable.indexOf(String)` to find the first column index that matches the name
- `BinaryTable.getDescriptor(String)` to return the descriptor of the first column whose name matches
- `static String TableHDU.getDefaultColumnName(int)` to return the default column name by Java column index.

## Changes

- `TableHDU.setColumnName(...)` now sets the name of the column in the table in addition to setting it in the header. It will also check the column index and throw an `IndexOutOfBoundsException` if it is out of range for the table; and checks the name to ensure it contains only ASCII characters between 0x20 and 0x7E or else throws and `HeaderCardException`.