### PR TITLE
Add ArrayFuncs.sample() and .slice() methods

### DIFF
--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -1460,7 +1460,6 @@ public class Fits implements Closeable {
      *
      * @throws FitsException if the initialization failed
      */
-    @SuppressWarnings("resource")
     protected void streamInit(InputStream inputStream) throws FitsException {
         dataStr = new FitsInputStream(CompressionManager.decompress(inputStream));
     }

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -1055,13 +1055,11 @@ public final class ArrayFuncs {
      *                                       most as mant elements as there are array dimensions, but it can also have
      *                                       fewer.
      * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
-     *                                       original array (but forward in the slice -- resulting in a flipped axis).
-     *                                       Zero (values) are understood to mean the full size of the original along
-     *                                       the specific dimension, while a <code>null</code> size argument can be used
-     *                                       to sample the full original. The slice will end at index
-     *                                       <code>from[k] + size[k]</code> in dimension <code>k</code> in the original
-     *                                       (not including the ending index). It should have the same number of
-     *                                       elements as the <code>from</code> argument.
+     *                                       original array (but forward in the slice -- resulting in a flipped axis). A
+     *                                       <code>null</code> size argument can be used to sample the full original.
+     *                                       The slice will end at index <code>from[k] + size[k]</code> in dimension
+     *                                       <code>k</code> in the original (not including the ending index). It should
+     *                                       have the same number of elements as the <code>from</code> argument.
      * 
      * @return                           The requested slice from the original.
      * 
@@ -1091,13 +1089,11 @@ public final class ArrayFuncs {
      *                                       fewer. A <code>null</code> argument can be used to sample from the start or
      *                                       end of the array (depending on the direction).
      * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
-     *                                       original array (but forward in the slice -- resulting in a flipped axis).
-     *                                       Zero (values) are understood to mean the full size of the original along
-     *                                       the specific dimension, while a <code>null</code> size argument can be used
-     *                                       to sample the full original. The slice will end at index
-     *                                       <code>from[k] + size[k]</code> in dimension <code>k</code> in the original
-     *                                       (not including the ending index). It should have the same number of
-     *                                       elements as the <code>from</code> argument.
+     *                                       original array (but forward in the slice -- resulting in a flipped axis). A
+     *                                       <code>null</code> size argument can be used to sample the full original.
+     *                                       The slice will end at index <code>from[k] + size[k]</code> in dimension
+     *                                       <code>k</code> in the original (not including the ending index). It should
+     *                                       have the same number of elements as the <code>from</code> argument.
      * @param  step                      The sampling step size along each dimension for a subsampled slice. Only the
      *                                       absolute values are used since the direction of the slicing is determined
      *                                       by the size argument. 0 values are are automatically bumped to 1 (full
@@ -1129,21 +1125,21 @@ public final class ArrayFuncs {
     private static Object sample(Object orig, int[] from, int[] size, int[] step, int idx)
             throws IllegalArgumentException, IndexOutOfBoundsException {
         if (!orig.getClass().isArray()) {
-            return orig;
+            if (from == null || idx >= from.length) {
+                return orig;
+            }
+            throw new IllegalArgumentException("Not an array: " + orig.getClass().getName());
         }
 
         int l = Array.getLength(orig);
         int[] dims = getDimensions(orig);
+
         int ndim = from == null ? dims.length : from.length;
 
         boolean isReversed = (size != null && size[idx] < 0) || (size == null && step != null && step[idx] < 0);
 
         int ifrom = from == null ? (isReversed ? l - 1 : 0) : from[idx];
         int isize = size == null ? (isReversed ? ifrom - l : l - ifrom) : size[idx];
-
-        if (isize == 0) {
-            isize = dims[idx];
-        }
 
         int ito = ifrom + isize;
 

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -1138,7 +1138,7 @@ public final class ArrayFuncs {
 
         boolean isReversed = (size != null && size[idx] < 0) || (size == null && step != null && step[idx] < 0);
 
-        int ifrom = from == null ? (isReversed ? l : 0) : from[idx];
+        int ifrom = from == null ? (isReversed ? l - 1 : 0) : from[idx];
         int isize = size == null ? (isReversed ? ifrom - l : l - ifrom) : size[idx];
 
         if (isize == 0) {
@@ -1151,7 +1151,7 @@ public final class ArrayFuncs {
             throw new IndexOutOfBoundsException("Sampled bounds are out of range for original array");
         }
 
-        int istep = step == null ? 1 : Math.abs(isize);
+        int istep = step == null ? 1 : Math.abs(step[idx]);
 
         if (istep == 0) {
             istep = 1;

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -976,9 +976,9 @@ public final class ArrayFuncs {
      *                                       along every axis.
      * 
      * @return                           The requested sampling from the original. The returned array may share data
-     *                                       with the original, and so modifications to either may affect the other.
+     *                                       with the original, and so modifications to either may affect the other. The
+     *                                       orginal object is returned if it is not an array.
      * 
-     * @throws IllegalArgumentException  If the input is not an array
      * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
      *                                       original. That is if the original does not fully contain the requested
      *                                       slice. Or, if the from and size arguments have differing lengths.
@@ -990,7 +990,7 @@ public final class ArrayFuncs {
      * @see                              #sample(Object, int[])
      * @see                              #sample(Object, int[], int[], int[])
      */
-    public static Object sample(Object orig, int step) throws IllegalArgumentException, IndexOutOfBoundsException {
+    public static Object sample(Object orig, int step) throws IndexOutOfBoundsException {
         int[] n = getDimensions(orig);
         Arrays.fill(n, step);
         return sample(orig, n);
@@ -1005,9 +1005,9 @@ public final class ArrayFuncs {
      *                                       along the given axis.
      * 
      * @return                           The requested sampling from the original. The returned array may share data
-     *                                       with the original, and so modifications to either may affect the other.
+     *                                       with the original, and so modifications to either may affect the other. The
+     *                                       orginal object is returned if it is not an array.
      * 
-     * @throws IllegalArgumentException  If the input is not an array
      * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
      *                                       original. That is if the original does not fully contain the requested
      *                                       slice. Or, if the from and size arguments have differing lengths.
@@ -1019,7 +1019,7 @@ public final class ArrayFuncs {
      * @see                              #sample(Object, int)
      * @see                              #sample(Object, int[], int[], int[])
      */
-    public static Object sample(Object orig, int[] step) throws IllegalArgumentException, IndexOutOfBoundsException {
+    public static Object sample(Object orig, int[] step) throws IndexOutOfBoundsException {
         return sample(orig, null, null, step);
     }
 
@@ -1028,13 +1028,13 @@ public final class ArrayFuncs {
      * 
      * @param  orig                      The original array
      * @param  from                      The starting indices for the slice in the original array. It should have at
-     *                                       most as mant elements as there are array dimensions, but it can also have
+     *                                       most as many elements as there are array dimensions, but it can also have
      *                                       fewer.
      * 
      * @return                           The requested slice from the original. The returned array may share data with
-     *                                       the original, and so modifications to either may affect the other.
+     *                                       the original, and so modifications to either may affect the other. The
+     *                                       orginal object is returned if it is not an array.
      * 
-     * @throws IllegalArgumentException  If the input is not an array
      * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
      *                                       original. That is if the original does not fully contain the requested
      *                                       slice. Or, if the from and size arguments have differing lengths.
@@ -1046,7 +1046,7 @@ public final class ArrayFuncs {
      * @see                              #slice(Object, int[], int[])
      * @see                              #sample(Object, int[], int[], int[])
      */
-    public static Object slice(Object orig, int[] from) throws IllegalArgumentException, IndexOutOfBoundsException {
+    public static Object slice(Object orig, int[] from) throws IndexOutOfBoundsException {
         return slice(orig, from, null);
     }
 
@@ -1055,7 +1055,7 @@ public final class ArrayFuncs {
      * 
      * @param  orig                      The original array
      * @param  from                      The starting indices for the slice in the original array. It should have at
-     *                                       most as mant elements as there are array dimensions, but it can also have
+     *                                       most as many elements as there are array dimensions, but it can also have
      *                                       fewer.
      * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
      *                                       original array (but forward in the slice -- resulting in a flipped axis). A
@@ -1065,9 +1065,9 @@ public final class ArrayFuncs {
      *                                       have the same number of elements as the <code>from</code> argument.
      * 
      * @return                           The requested slice from the original. The returned array may share data with
-     *                                       the original, and so modifications to either may affect the other.
+     *                                       the original, and so modifications to either may affect the other. The
+     *                                       orginal object is returned if it is not an array.
      * 
-     * @throws IllegalArgumentException  If the input is not an array
      * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
      *                                       original. That is if the original does not fully contain the requested
      *                                       slice. Or, if the from and size arguments have differing lengths.
@@ -1079,8 +1079,7 @@ public final class ArrayFuncs {
      * @see                              #slice(Object, int[])
      * @see                              #sample(Object, int[], int[], int[])
      */
-    public static Object slice(Object orig, int[] from, int[] size)
-            throws IllegalArgumentException, IndexOutOfBoundsException {
+    public static Object slice(Object orig, int[] from, int[] size) throws IndexOutOfBoundsException {
         int[] step = null;
 
         if (size != null) {
@@ -1098,7 +1097,7 @@ public final class ArrayFuncs {
      * 
      * @param  orig                      The original array
      * @param  from                      The starting indices for the slice in the original array. It should have at
-     *                                       most as mant elements as there are array dimensions, but it can also have
+     *                                       most as many elements as there are array dimensions, but it can also have
      *                                       fewer. A <code>null</code> argument can be used to sample from the start or
      *                                       end of the array (depending on the direction).
      * @param  size                      The size of the sampled area in the original along each dimension. The
@@ -1113,9 +1112,9 @@ public final class ArrayFuncs {
      *                                       sampling along all dimensions.
      * 
      * @return                           The requested sampling from the original. The returned array may share data
-     *                                       with the original, and so modifications to either may affect the other.
+     *                                       with the original, and so modifications to either may affect the other. The
+     *                                       orginal object is returned if it is not an array.
      * 
-     * @throws IllegalArgumentException  If the input is not an array
      * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
      *                                       original. That is if the original does not fully contain the requested
      *                                       slice. Or, if the from and size arguments have differing lengths.
@@ -1128,13 +1127,12 @@ public final class ArrayFuncs {
      * @see                              #sample(Object, int[])
      * @see                              #slice(Object, int[], int[])
      */
-    public static Object sample(Object orig, int[] from, int[] size, int[] step)
-            throws IllegalArgumentException, IndexOutOfBoundsException {
+    public static Object sample(Object orig, int[] from, int[] size, int[] step) throws IndexOutOfBoundsException {
         return sample(orig, from, size, step, 0);
     }
 
     private static Object sample(Object orig, int[] from, int[] size, int[] step, int idx)
-            throws IllegalArgumentException, IndexOutOfBoundsException {
+            throws IndexOutOfBoundsException {
 
         // If leaf, return it as is...
         if (!orig.getClass().isArray() || (from != null && idx == from.length)) {

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -970,12 +970,12 @@ public final class ArrayFuncs {
     /**
      * Obtains a sparse sampling of from an array of one or more dimensions.
      * 
-     * @param  orig                      The original array
-     * @param  step                      The sampling step size along all dimensions for a subsampled slice. A negative
+     * @param  orig                      the original array
+     * @param  step                      the sampling step size along all dimensions for a subsampled slice. A negative
      *                                       value indicates that the sampling should proceed in the reverse direction
      *                                       along every axis.
      * 
-     * @return                           The requested sampling from the original. The returned array may share data
+     * @return                           the requested sampling from the original. The returned array may share data
      *                                       with the original, and so modifications to either may affect the other. The
      *                                       orginal object is returned if it is not an array.
      * 
@@ -999,12 +999,12 @@ public final class ArrayFuncs {
     /**
      * Obtains a sparse sampling of from an array of one or more dimensions.
      * 
-     * @param  orig                      The original array
-     * @param  step                      The sampling step size along each dimension for a subsampled slice. Negative
+     * @param  orig                      the original array
+     * @param  step                      the sampling step size along each dimension for a subsampled slice. Negative
      *                                       values indicate that the sampling should proceed in the reverse direction
      *                                       along the given axis.
      * 
-     * @return                           The requested sampling from the original. The returned array may share data
+     * @return                           the requested sampling from the original. The returned array may share data
      *                                       with the original, and so modifications to either may affect the other. The
      *                                       orginal object is returned if it is not an array.
      * 
@@ -1026,12 +1026,12 @@ public final class ArrayFuncs {
     /**
      * Obtains a slice (subarray) from an array of one or more dimensions.
      * 
-     * @param  orig                      The original array
-     * @param  from                      The starting indices for the slice in the original array. It should have at
+     * @param  orig                      the original array
+     * @param  from                      the starting indices for the slice in the original array. It should have at
      *                                       most as many elements as there are array dimensions, but it can also have
      *                                       fewer.
      * 
-     * @return                           The requested slice from the original. The returned array may share data with
+     * @return                           the requested slice from the original. The returned array may share data with
      *                                       the original, and so modifications to either may affect the other. The
      *                                       orginal object is returned if it is not an array.
      * 
@@ -1053,18 +1053,18 @@ public final class ArrayFuncs {
     /**
      * Obtains a slice (subarray) from an array of one or more dimensions.
      * 
-     * @param  orig                      The original array
-     * @param  from                      The starting indices for the slice in the original array. It should have at
+     * @param  orig                      the original array
+     * @param  from                      the starting indices for the slice in the original array. It should have at
      *                                       most as many elements as there are array dimensions, but it can also have
      *                                       fewer.
-     * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
+     * @param  size                      the size of the slice. Negative values can indicate moving backwards in the
      *                                       original array (but forward in the slice -- resulting in a flipped axis). A
      *                                       <code>null</code> size argument can be used to sample the full original.
      *                                       The slice will end at index <code>from[k] + size[k]</code> in dimension
      *                                       <code>k</code> in the original (not including the ending index). It should
      *                                       have the same number of elements as the <code>from</code> argument.
      * 
-     * @return                           The requested slice from the original. The returned array may share data with
+     * @return                           the requested slice from the original. The returned array may share data with
      *                                       the original, and so modifications to either may affect the other. The
      *                                       orginal object is returned if it is not an array.
      * 
@@ -1095,23 +1095,23 @@ public final class ArrayFuncs {
     /**
      * Obtains a sparse sampling from an array of one or more dimensions.
      * 
-     * @param  orig                      The original array
-     * @param  from                      The starting indices for the slice in the original array. It should have at
-     *                                       most as many elements as there are array dimensions, but it can also have
-     *                                       fewer. A <code>null</code> argument can be used to sample from the start or
-     *                                       end of the array (depending on the direction).
-     * @param  size                      The size of the sampled area in the original along each dimension. The
+     * @param  orig                      the original array
+     * @param  from                      the starting indices in the original array at which to start sampling. It
+     *                                       should have at most as many elements as there are array dimensions, but it
+     *                                       can also have fewer. A <code>null</code> argument can be used to sample
+     *                                       from the start or end of the array (depending on the direction).
+     * @param  size                      the size of the sampled area in the original along each dimension. The
      *                                       signature of the values is irrelevant as the direction of sampling is
      *                                       determined by the step argument. Zero entries can be used to indicate that
      *                                       the full array should be sampled along the given dimension, while a
      *                                       <code>null</code> argument will sample the full array in all dimensions.
-     * @param  step                      The sampling step size along each dimension for a subsampled slice. Negative
+     * @param  step                      the sampling step size along each dimension for a subsampled slice. Negative
      *                                       values indicate sampling the original in the reverse direction along the
      *                                       given dimension. 0 values are are automatically bumped to 1 (full
      *                                       sampling), and a <code>null</code> argument is understood to mean full
      *                                       sampling along all dimensions.
      * 
-     * @return                           The requested sampling from the original. The returned array may share data
+     * @return                           the requested sampling from the original. The returned array may share data
      *                                       with the original, and so modifications to either may affect the other. The
      *                                       orginal object is returned if it is not an array.
      * 
@@ -1168,7 +1168,7 @@ public final class ArrayFuncs {
         Object slice = Array.newInstance(orig.getClass().getComponentType(), n);
 
         if (!isReversed && ndim == 1 && istep == 1) {
-            // Faster special case for in-order slicing along last dim...
+            // Special case for fast in-order slicing along last dim...
             System.arraycopy(orig, ifrom, slice, 0, isize);
         } else {
             // Generic sampling with the parameters...

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -992,7 +992,7 @@ public final class ArrayFuncs {
     public static Object sample(Object orig, int step) throws IllegalArgumentException, IndexOutOfBoundsException {
         int[] n = getDimensions(orig);
         Arrays.fill(n, step);
-        return sample(orig, null, null, n, 0);
+        return sample(orig, n);
     }
 
     /**
@@ -1018,7 +1018,7 @@ public final class ArrayFuncs {
      * @see                              #sample(Object, int[], int[], int[])
      */
     public static Object sample(Object orig, int[] step) throws IllegalArgumentException, IndexOutOfBoundsException {
-        return sample(orig, null, null, step, 0);
+        return sample(orig, null, null, step);
     }
 
     /**

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -967,4 +967,171 @@ public final class ArrayFuncs {
         return t;
     }
 
+    /**
+     * Obtains a sparse sampling of from a one or higher dimensional array.
+     * 
+     * @param  orig                      The original array
+     * @param  step                      The sampling step size along all dimensions for a subsampled slice. A negative
+     *                                       value indicates that the sampling should proceed in the reverse direction
+     *                                       along every axis.
+     * 
+     * @return                           The requested slice from the original.
+     * 
+     * @throws IllegalArgumentException  If the input is not an array
+     * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
+     *                                       original. That is if the original does not fully contain the requested
+     *                                       slice. Or, if the from and size arguments have differing lengths.
+     * 
+     * @since                            1.20
+     * 
+     * @author                           Attila Kovacs
+     * 
+     * @see                              #sample(Object, int[])
+     * @see                              #sample(Object, int[], int[], int[])
+     */
+    public static Object sample(Object orig, int step) throws IllegalArgumentException, IndexOutOfBoundsException {
+        int[] n = getDimensions(orig);
+        Arrays.fill(n, step);
+        return sample(orig, null, null, n, 0);
+    }
+
+    /**
+     * Obtains a sparse sampling of from a one or higher dimensional array.
+     * 
+     * @param  orig                      The original array
+     * @param  step                      The sampling step size along each dimension for a subsampled slice. Negative
+     *                                       values indicate that the sampling should proceed in the reverse direction
+     *                                       along the given axis.
+     * 
+     * @return                           The requested slice from the original.
+     * 
+     * @throws IllegalArgumentException  If the input is not an array
+     * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
+     *                                       original. That is if the original does not fully contain the requested
+     *                                       slice. Or, if the from and size arguments have differing lengths.
+     * 
+     * @since                            1.20
+     * 
+     * @author                           Attila Kovacs
+     * 
+     * @see                              #sample(Object, int)
+     * @see                              #sample(Object, int[], int[], int[])
+     */
+    public static Object sample(Object orig, int[] step) throws IllegalArgumentException, IndexOutOfBoundsException {
+        return sample(orig, null, null, step, 0);
+    }
+
+    /**
+     * Obtains a slice (subarray) from a one or higher dimensional array.
+     * 
+     * @param  orig                      The original array
+     * @param  from                      The starting indices for the slice in the original array. It should have at
+     *                                       most as mant elements as there are array dimensions, but it can also have
+     *                                       fewer.
+     * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
+     *                                       original array (but forward in the slice -- resulting in a flipped axis).
+     *                                       The slice will end at index <code>from[k] + size[k]</code> in dimension
+     *                                       <code>k</code> in the original (not including the ending index). It should
+     *                                       have the same number of elements as from. Zero (values) are understood to
+     *                                       mean the full size of the original along the specific dimension, while a
+     *                                       <code>null</code> size argument can be used to sample the full original.
+     * 
+     * @return                           The requested slice from the original.
+     * 
+     * @throws IllegalArgumentException  If the input is not an array
+     * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
+     *                                       original. That is if the original does not fully contain the requested
+     *                                       slice. Or, if the from and size arguments have differing lengths.
+     * 
+     * @since                            1.20
+     * 
+     * @author                           Attila Kovacs
+     * 
+     * @see                              #sample(Object, int[], int[], int[])
+     */
+    public static Object slice(Object orig, int[] from, int[] size)
+            throws IllegalArgumentException, IndexOutOfBoundsException {
+        return sample(orig, from, size, null, 0);
+    }
+
+    /**
+     * Obtains a slice (subarray) from a one or higher dimensional array.
+     * 
+     * @param  orig                      The original array
+     * @param  from                      The starting indices for the slice in the original array. It should have at
+     *                                       most as mant elements as there are array dimensions, but it can also have
+     *                                       fewer. A <code>null</code> argument can be used to sample from the start or
+     *                                       end of the array (depending on the direction).
+     * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
+     *                                       original array (but forward in the slice -- resulting in a flipped axis).
+     *                                       The slice will end at index <code>from[k] + size[k]</code> in dimension
+     *                                       <code>k</code> in the original (not including the ending index). It should
+     *                                       have the same number of elements as from. Zero (values) are understood to
+     *                                       mean the full size of the original along the specific dimension, while a
+     *                                       <code>null</code> size argument can be used to sample the full original.
+     * @param  step                      The sampling step size along each dimension for a subsampled slice. Only the
+     *                                       absolute values are used since the direction of the slicing is determined
+     *                                       by the size argument. 0 values are are automatically bumped to 1 (full
+     *                                       sampling), and a <code>null</code> argument is understood to mean full
+     *                                       sampling along all axes. If the size argument is <code>null</code> the sign
+     *                                       of the step argument is used to determine the direction of sampling in the
+     *                                       original array.
+     * 
+     * @return                           The requested slice from the original.
+     * 
+     * @throws IllegalArgumentException  If the input is not an array
+     * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
+     *                                       original. That is if the original does not fully contain the requested
+     *                                       slice. Or, if the from and size arguments have differing lengths.
+     * 
+     * @since                            1.20
+     * 
+     * @author                           Attila Kovacs
+     * 
+     * @see                              #sample(Object, int)
+     * @see                              #sample(Object, int[])
+     * @see                              #slice(Object, int[], int[])
+     */
+    public static Object sample(Object orig, int[] from, int[] size, int[] step)
+            throws IllegalArgumentException, IndexOutOfBoundsException {
+        return sample(orig, from, size, step, 0);
+    }
+
+    private static Object sample(Object orig, int[] from, int[] size, int[] step, int idx)
+            throws IllegalArgumentException, IndexOutOfBoundsException {
+        int l = Array.getLength(orig);
+        int ndim = from == null ? getDimensions(orig).length : from.length;
+
+        boolean isReversed = (step != null && step[idx] < 0) || (size != null && size[idx] < 0);
+
+        int ifrom = from == null ? (isReversed ? l : 0) : from[idx];
+        int isize = size == null ? (isReversed ? -l : l) : size[idx];
+
+        int ito = ifrom + isize;
+
+        if (ifrom < 0 || ito < 0 || ifrom > l || ito > l) {
+            throw new IndexOutOfBoundsException("Slice bounds are out of range for original array");
+        }
+
+        int istep = step == null ? 1 : Math.abs(isize);
+
+        if (istep == 0) {
+            istep = 1;
+        }
+
+        int n = Math.abs((isize + istep - 1) / istep);
+        Object slice = Array.newInstance(orig.getClass().getComponentType(), n);
+
+        if (isReversed) {
+            istep = -istep;
+        }
+
+        for (int i = 0; i < n; i++) {
+            Object efrom = Array.get(orig, ifrom + i * istep);
+            Array.set(slice, i, idx < ndim ? sample(efrom, from, size, step, idx + 1) : efrom);
+        }
+
+        return slice;
+    }
+
 }

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -1081,7 +1081,7 @@ public final class ArrayFuncs {
 
         if (size != null) {
             step = new int[size.length];
-            for (int i = 0; i < step.length; i++) {
+            for (int i = 0; i < size.length; i++) {
                 step[i] = size[i] < 0 ? -1 : 1;
             }
         }
@@ -1097,14 +1097,16 @@ public final class ArrayFuncs {
      *                                       most as mant elements as there are array dimensions, but it can also have
      *                                       fewer. A <code>null</code> argument can be used to sample from the start or
      *                                       end of the array (depending on the direction).
-     * @param  size                      The size of the returned array along each dimension. A zero value will sample
-     *                                       the full array along the given dimension, while a <code>null</code>
-     *                                       argument will sample the full array in all dimensions.
+     * @param  size                      The size of the returned array along each dimension. The signature of the
+     *                                       values is irrelevant as the direction of sampling is determined by the step
+     *                                       argument. Zero entries can be used to indicate that the full array should
+     *                                       be sampled along the given dimension, while a <code>null</code> argument
+     *                                       will sample the full array in all dimensions.
      * @param  step                      The sampling step size along each dimension for a subsampled slice. Negative
      *                                       values indicate sampling the original in the reverse direction along the
      *                                       given dimension. 0 values are are automatically bumped to 1 (full
      *                                       sampling), and a <code>null</code> argument is understood to mean full
-     *                                       sampling along all axes.
+     *                                       sampling along all dimensions.
      * 
      * @return                           The requested sampling from the original.
      * 
@@ -1144,6 +1146,8 @@ public final class ArrayFuncs {
         int isize = size == null ? 0 : size[idx];
         if (isize == 0) {
             isize = isReversed ? ifrom - l : l - ifrom;
+        } else if (isReversed && isize > 0) {
+            isize = -isize;
         }
 
         int ito = ifrom + isize;

--- a/src/main/java/nom/tam/util/ArrayFuncs.java
+++ b/src/main/java/nom/tam/util/ArrayFuncs.java
@@ -968,14 +968,14 @@ public final class ArrayFuncs {
     }
 
     /**
-     * Obtains a sparse sampling of from a one or higher dimensional array.
+     * Obtains a sparse sampling of from an array of one or more dimensions.
      * 
      * @param  orig                      The original array
      * @param  step                      The sampling step size along all dimensions for a subsampled slice. A negative
      *                                       value indicates that the sampling should proceed in the reverse direction
      *                                       along every axis.
      * 
-     * @return                           The requested slice from the original.
+     * @return                           The requested sampling from the original.
      * 
      * @throws IllegalArgumentException  If the input is not an array
      * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
@@ -996,14 +996,14 @@ public final class ArrayFuncs {
     }
 
     /**
-     * Obtains a sparse sampling of from a one or higher dimensional array.
+     * Obtains a sparse sampling of from an array of one or more dimensions.
      * 
      * @param  orig                      The original array
      * @param  step                      The sampling step size along each dimension for a subsampled slice. Negative
      *                                       values indicate that the sampling should proceed in the reverse direction
      *                                       along the given axis.
      * 
-     * @return                           The requested slice from the original.
+     * @return                           The requested sampling from the original.
      * 
      * @throws IllegalArgumentException  If the input is not an array
      * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
@@ -1022,19 +1022,12 @@ public final class ArrayFuncs {
     }
 
     /**
-     * Obtains a slice (subarray) from a one or higher dimensional array.
+     * Obtains a slice (subarray) from an array of one or more dimensions.
      * 
      * @param  orig                      The original array
      * @param  from                      The starting indices for the slice in the original array. It should have at
      *                                       most as mant elements as there are array dimensions, but it can also have
      *                                       fewer.
-     * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
-     *                                       original array (but forward in the slice -- resulting in a flipped axis).
-     *                                       The slice will end at index <code>from[k] + size[k]</code> in dimension
-     *                                       <code>k</code> in the original (not including the ending index). It should
-     *                                       have the same number of elements as from. Zero (values) are understood to
-     *                                       mean the full size of the original along the specific dimension, while a
-     *                                       <code>null</code> size argument can be used to sample the full original.
      * 
      * @return                           The requested slice from the original.
      * 
@@ -1047,6 +1040,41 @@ public final class ArrayFuncs {
      * 
      * @author                           Attila Kovacs
      * 
+     * @see                              #slice(Object, int[], int[])
+     * @see                              #sample(Object, int[], int[], int[])
+     */
+    public static Object slice(Object orig, int[] from) throws IllegalArgumentException, IndexOutOfBoundsException {
+        return slice(orig, from, null);
+    }
+
+    /**
+     * Obtains a slice (subarray) from an array of one or more dimensions.
+     * 
+     * @param  orig                      The original array
+     * @param  from                      The starting indices for the slice in the original array. It should have at
+     *                                       most as mant elements as there are array dimensions, but it can also have
+     *                                       fewer.
+     * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
+     *                                       original array (but forward in the slice -- resulting in a flipped axis).
+     *                                       Zero (values) are understood to mean the full size of the original along
+     *                                       the specific dimension, while a <code>null</code> size argument can be used
+     *                                       to sample the full original. The slice will end at index
+     *                                       <code>from[k] + size[k]</code> in dimension <code>k</code> in the original
+     *                                       (not including the ending index). It should have the same number of
+     *                                       elements as the <code>from</code> argument.
+     * 
+     * @return                           The requested slice from the original.
+     * 
+     * @throws IllegalArgumentException  If the input is not an array
+     * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
+     *                                       original. That is if the original does not fully contain the requested
+     *                                       slice. Or, if the from and size arguments have differing lengths.
+     * 
+     * @since                            1.20
+     * 
+     * @author                           Attila Kovacs
+     * 
+     * @see                              #slice(Object, int[])
      * @see                              #sample(Object, int[], int[], int[])
      */
     public static Object slice(Object orig, int[] from, int[] size)
@@ -1055,7 +1083,7 @@ public final class ArrayFuncs {
     }
 
     /**
-     * Obtains a slice (subarray) from a one or higher dimensional array.
+     * Obtains a sparse sampling from an array of one or more dimensions.
      * 
      * @param  orig                      The original array
      * @param  from                      The starting indices for the slice in the original array. It should have at
@@ -1064,11 +1092,12 @@ public final class ArrayFuncs {
      *                                       end of the array (depending on the direction).
      * @param  size                      The size of the slice. Negative values can indicate moving backwards in the
      *                                       original array (but forward in the slice -- resulting in a flipped axis).
-     *                                       The slice will end at index <code>from[k] + size[k]</code> in dimension
-     *                                       <code>k</code> in the original (not including the ending index). It should
-     *                                       have the same number of elements as from. Zero (values) are understood to
-     *                                       mean the full size of the original along the specific dimension, while a
-     *                                       <code>null</code> size argument can be used to sample the full original.
+     *                                       Zero (values) are understood to mean the full size of the original along
+     *                                       the specific dimension, while a <code>null</code> size argument can be used
+     *                                       to sample the full original. The slice will end at index
+     *                                       <code>from[k] + size[k]</code> in dimension <code>k</code> in the original
+     *                                       (not including the ending index). It should have the same number of
+     *                                       elements as the <code>from</code> argument.
      * @param  step                      The sampling step size along each dimension for a subsampled slice. Only the
      *                                       absolute values are used since the direction of the slicing is determined
      *                                       by the size argument. 0 values are are automatically bumped to 1 (full
@@ -1077,7 +1106,7 @@ public final class ArrayFuncs {
      *                                       of the step argument is used to determine the direction of sampling in the
      *                                       original array.
      * 
-     * @return                           The requested slice from the original.
+     * @return                           The requested sampling from the original.
      * 
      * @throws IllegalArgumentException  If the input is not an array
      * @throws IndexOutOfBoundsException if any of the indices for the requested slice are out of bounds for the
@@ -1099,18 +1128,27 @@ public final class ArrayFuncs {
 
     private static Object sample(Object orig, int[] from, int[] size, int[] step, int idx)
             throws IllegalArgumentException, IndexOutOfBoundsException {
-        int l = Array.getLength(orig);
-        int ndim = from == null ? getDimensions(orig).length : from.length;
+        if (!orig.getClass().isArray()) {
+            return orig;
+        }
 
-        boolean isReversed = (step != null && step[idx] < 0) || (size != null && size[idx] < 0);
+        int l = Array.getLength(orig);
+        int[] dims = getDimensions(orig);
+        int ndim = from == null ? dims.length : from.length;
+
+        boolean isReversed = (size != null && size[idx] < 0) || (size == null && step != null && step[idx] < 0);
 
         int ifrom = from == null ? (isReversed ? l : 0) : from[idx];
-        int isize = size == null ? (isReversed ? -l : l) : size[idx];
+        int isize = size == null ? (isReversed ? ifrom - l : l - ifrom) : size[idx];
+
+        if (isize == 0) {
+            isize = dims[idx];
+        }
 
         int ito = ifrom + isize;
 
         if (ifrom < 0 || ito < 0 || ifrom > l || ito > l) {
-            throw new IndexOutOfBoundsException("Slice bounds are out of range for original array");
+            throw new IndexOutOfBoundsException("Sampled bounds are out of range for original array");
         }
 
         int istep = step == null ? 1 : Math.abs(isize);

--- a/src/main/java/nom/tam/util/Quantizer.java
+++ b/src/main/java/nom/tam/util/Quantizer.java
@@ -37,9 +37,11 @@ import nom.tam.fits.header.Standard;
 
 /**
  * <p>
- * Quantizes floating point values as integers. FITS allows representing floating-point values as integers, e.g. to
- * allow more compact storage at some tolerable level of precision loss. For example, you may store floating-point
- * values (4 bytes) discretized into 64k levels as 16-bit integers. The conversion involves a linear transformation:
+ * Quantizes floating point values as integers. FITS allows representing
+ * floating-point values as integers, e.g. to allow more compact storage at some
+ * tolerable level of precision loss. For example, you may store floating-point
+ * values (4 bytes) discretized into 64k levels as 16-bit integers. The
+ * conversion involves a linear transformation:
  * </p>
  * 
  * <pre>
@@ -53,22 +55,25 @@ import nom.tam.fits.header.Standard;
  *   {int-value} = round(({float-value} - {offset}) / {scaling})
  * </pre>
  * <p>
- * The latter floating-point to integer conversion naturally results in some loss of precision, comparable to the level
- * of the scaling factor, i.e. the peration of discrete levels at which information is preserved.
+ * The latter floating-point to integer conversion naturally results in some
+ * loss of precision, comparable to the level of the scaling factor, i.e. the
+ * peration of discrete levels at which information is preserved.
  * </p>
  * <p>
- * In addition to the scaling conversion, FITS also allows designating an integer blanking value to indicate missing or
- * invalid data, which is mapped to NaN in the floating point representation.
+ * In addition to the scaling conversion, FITS also allows designating an
+ * integer blanking value to indicate missing or invalid data, which is mapped
+ * to NaN in the floating point representation.
  * </p>
  * <p>
- * Fits allows for quantized representations of floating-point data both in image HDUs and for columns in binary table
- * HDUs. The quantization parameters are stored differently for the two types of HDUs, using the BSCALE, BZERO, and
- * BLANK keywords for images, and the TSCALn, TZEROn, and TNULLn keywords for individual columns in a table.
+ * Fits allows for quantized representations of floating-point data both in
+ * image HDUs and for columns in binary table HDUs. The quantization parameters
+ * are stored differently for the two types of HDUs, using the BSCALE, BZERO,
+ * and BLANK keywords for images, and the TSCALn, TZEROn, and TNULLn keywords
+ * for individual columns in a table.
  * </p>
  * 
  * @author Attila Kovacs
- * 
- * @since  1.20
+ * @since 1.20
  */
 public class Quantizer {
 
@@ -81,10 +86,14 @@ public class Quantizer {
     /**
      * Constructs a new decimal/integer conversion rule.
      * 
-     * @param scale         The scaling value, that is the spacing of the qunatized levels
-     * @param offset        The floating-point value that corresponds to an integer value of 0 (zero).
-     * @param blankingValue The value to use to represent NaN values in the integer representation, that is missing or
-     *                          invalid data.
+     * @param scale
+     *            The scaling value, that is the spacing of the qunatized levels
+     * @param offset
+     *            The floating-point value that corresponds to an integer value
+     *            of 0 (zero).
+     * @param blankingValue
+     *            The value to use to represent NaN values in the integer
+     *            representation, that is missing or invalid data.
      */
     public Quantizer(double scale, double offset, int blankingValue) {
         this(scale, offset, (long) blankingValue);
@@ -93,11 +102,16 @@ public class Quantizer {
     /**
      * Constructs a new decimal/integer conversion rule.
      * 
-     * @param scale         The scaling value, that is the spacing of the qunatized levels
-     * @param offset        The floating-point value that corresponds to an integer value of 0 (zero).
-     * @param blankingValue The value to use to represent NaN values in the integer representation, that is missing or
-     *                          invalid data. It may be <code>null</code> if the floating-point data is not expected to
-     *                          contain NaN values ever.
+     * @param scale
+     *            The scaling value, that is the spacing of the qunatized levels
+     * @param offset
+     *            The floating-point value that corresponds to an integer value
+     *            of 0 (zero).
+     * @param blankingValue
+     *            The value to use to represent NaN values in the integer
+     *            representation, that is missing or invalid data. It may be
+     *            <code>null</code> if the floating-point data is not expected
+     *            to contain NaN values ever.
      */
     public Quantizer(double scale, double offset, Long blankingValue) {
         this.scale = scale;
@@ -106,13 +120,13 @@ public class Quantizer {
     }
 
     /**
-     * Converts a floating point value to its integer representation using the quantization.
+     * Converts a floating point value to its integer representation using the
+     * quantization.
      * 
-     * @param  value the floating point value
-     * 
-     * @return       the corresponding qunatized integer value
-     * 
-     * @see          #toDouble(long)
+     * @param value
+     *            the floating point value
+     * @return the corresponding qunatized integer value
+     * @see #toDouble(long)
      */
     public long toLong(double value) {
         if (!Double.isFinite(value)) {
@@ -125,13 +139,13 @@ public class Quantizer {
     }
 
     /**
-     * Converts an integer value to the floating-point value it represents under the qunatization.
+     * Converts an integer value to the floating-point value it represents under
+     * the qunatization.
      * 
-     * @param  value the integer value
-     * 
-     * @return       the corresponding floating-point value, which may be NaN.
-     * 
-     * @see          #toLong(double)
+     * @param value
+     *            the integer value
+     * @return the corresponding floating-point value, which may be NaN.
+     * @see #toLong(double)
      */
     public double toDouble(long value) {
         if (blankingValue != null && value == blankingValue) {
@@ -141,12 +155,15 @@ public class Quantizer {
     }
 
     /**
-     * Checks if the quantization is the same as the default quantization. For example, maybe we don't need to (want to)
-     * write the quantization keywords into the FITS headers if these are irrelevant and/or not meaningful. So this
-     * method might help us decide when quantization is necessary / meaningful vs when it is irrelevant.
+     * Checks if the quantization is the same as the default quantization. For
+     * example, maybe we don't need to (want to) write the quantization keywords
+     * into the FITS headers if these are irrelevant and/or not meaningful. So
+     * this method might help us decide when quantization is necessary /
+     * meaningful vs when it is irrelevant.
      * 
-     * @return <code>true</code> if the scaling is 1.0, the offset 0.0, and the blanking value is <code>null</code>.
-     *             Otherwise <code>false</code> .
+     * @return <code>true</code> if the scaling is 1.0, the offset 0.0, and the
+     *         blanking value is <code>null</code>. Otherwise <code>false</code>
+     *         .
      */
     public boolean isDefault() {
         return scale == 1.0 && offset == 0.0 && blankingValue == null;
@@ -155,10 +172,10 @@ public class Quantizer {
     /**
      * Adds the quantization parameters to an image header,
      * 
-     * @param h the image header.
-     * 
-     * @see     #fromImageHeader(Header)
-     * @see     #editTableHeader(Header, int)
+     * @param h
+     *            the image header.
+     * @see #fromImageHeader(Header)
+     * @see #editTableHeader(Header, int)
      */
     public void editImageHeader(Header h) {
         h.addValue(Standard.BSCALE, scale);
@@ -174,11 +191,12 @@ public class Quantizer {
     /**
      * Adds the quantization parameters to a binaty table header,
      * 
-     * @param h   the binary table header.
-     * @param col the zero-based Java column index
-     * 
-     * @see       #fromTableHeader(Header, int)
-     * @see       #editImageHeader(Header)
+     * @param h
+     *            the binary table header.
+     * @param col
+     *            the zero-based Java column index
+     * @see #fromTableHeader(Header, int)
+     * @see #editImageHeader(Header)
      */
     public void editTableHeader(Header h, int col) {
         Cursor<String, HeaderCard> c = h.iterator();
@@ -197,14 +215,14 @@ public class Quantizer {
     /**
      * Returns the quantizer that is described by an image header.
      * 
-     * @param  h an image header
-     * 
-     * @return   the quantizer that id described by the header. It may be the default quantizer if the header does not
-     *               contain any of the quantization keywords.
-     * 
-     * @see      #editImageHeader(Header)
-     * @see      #fromTableHeader(Header, int)
-     * @see      #isDefault()
+     * @param h
+     *            an image header
+     * @return the quantizer that id described by the header. It may be the
+     *         default quantizer if the header does not contain any of the
+     *         quantization keywords.
+     * @see #editImageHeader(Header)
+     * @see #fromTableHeader(Header, int)
+     * @see #isDefault()
      */
     public static Quantizer fromImageHeader(Header h) {
         return new Quantizer(h.getDoubleValue(Standard.BSCALE, 1.0), h.getDoubleValue(Standard.BZERO, 0.0), //
@@ -214,15 +232,16 @@ public class Quantizer {
     /**
      * Returns the quantizer that is described by a binary table header.
      * 
-     * @param  h   a binary table header
-     * @param  col the zero-based Java column index
-     * 
-     * @return     the quantizer that id described by the header. It may be the default quantizer if the header does not
-     *                 contain any of the quantization keywords.
-     * 
-     * @see        #editTableHeader(Header, int)
-     * @see        #fromImageHeader(Header)
-     * @see        #isDefault()
+     * @param h
+     *            a binary table header
+     * @param col
+     *            the zero-based Java column index
+     * @return the quantizer that id described by the header. It may be the
+     *         default quantizer if the header does not contain any of the
+     *         quantization keywords.
+     * @see #editTableHeader(Header, int)
+     * @see #fromImageHeader(Header)
+     * @see #isDefault()
      */
     public static Quantizer fromTableHeader(Header h, int col) {
         return new Quantizer(h.getDoubleValue(Standard.TSCALn.n(col + 1), 1.0), //

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -333,6 +333,21 @@ public class ArrayFuncsTest {
     }
 
     @Test
+    public void sliceSubReverseTest() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.slice(array, new int[] {1}, new int[] {-2});
+
+        Assert.assertEquals(2, sub.length);
+        Assert.assertEquals(3, sub[0].length);
+
+        Assert.assertEquals(4, sub[0][0]);
+        Assert.assertEquals(5, sub[0][1]);
+        Assert.assertEquals(1, sub[1][0]);
+        Assert.assertEquals(2, sub[1][1]);
+    }
+
+    @Test
     public void reverseSliceTest() throws Exception {
         int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
 

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -303,4 +303,48 @@ public class ArrayFuncsTest {
     public void convertNotArray() throws Exception {
         ArrayFuncs.convertArray("blah", int.class, null);
     }
+
+    @Test
+    public void sliceTest() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.slice(array, new int[] {1, 2});
+
+        Assert.assertEquals(2, sub.length);
+        Assert.assertEquals(1, sub[0].length);
+
+        Assert.assertEquals(6, sub[0][0]);
+        Assert.assertEquals(9, sub[1][0]);
+    }
+
+    @Test
+    public void reverseSliceTest() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.slice(array, null, new int[] {-2, -2});
+
+        Assert.assertEquals(2, sub.length);
+        Assert.assertEquals(1, sub[0].length);
+
+        Assert.assertEquals(9, sub[0][0]);
+        Assert.assertEquals(8, sub[0][1]);
+        Assert.assertEquals(6, sub[1][0]);
+        Assert.assertEquals(5, sub[1][1]);
+    }
+
+    @Test
+    public void sampleTest() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.sample(array, 2);
+
+        Assert.assertEquals(2, sub.length);
+        Assert.assertEquals(2, sub[0].length);
+
+        Assert.assertEquals(1, sub[0][0]);
+        Assert.assertEquals(3, sub[0][1]);
+        Assert.assertEquals(7, sub[1][0]);
+        Assert.assertEquals(9, sub[1][1]);
+    }
+
 }

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -318,6 +318,21 @@ public class ArrayFuncsTest {
     }
 
     @Test
+    public void sliceSubTest() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.slice(array, new int[] {1}, new int[] {2});
+
+        Assert.assertEquals(2, sub.length);
+        Assert.assertEquals(3, sub[0].length);
+
+        Assert.assertEquals(4, sub[0][0]);
+        Assert.assertEquals(5, sub[0][1]);
+        Assert.assertEquals(7, sub[1][0]);
+        Assert.assertEquals(8, sub[1][1]);
+    }
+
+    @Test
     public void reverseSliceTest() throws Exception {
         int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
 
@@ -375,6 +390,45 @@ public class ArrayFuncsTest {
         Assert.assertEquals(2, sub[0][1]);
         Assert.assertEquals(4, sub[1][0]);
         Assert.assertEquals(5, sub[1][1]);
+    }
+
+    @Test
+    public void sampleReverseTest() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.sample(array, null, new int[] {3, -3}, new int[] {-2, -2});
+
+        Assert.assertEquals(2, sub.length);
+        Assert.assertEquals(2, sub[0].length);
+
+        Assert.assertEquals(9, sub[0][0]);
+        Assert.assertEquals(7, sub[0][1]);
+        Assert.assertEquals(3, sub[1][0]);
+        Assert.assertEquals(1, sub[1][1]);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void sliceFromLow() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+        ArrayFuncs.slice(array, new int[] {-1});
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void sliceFromHigh() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+        ArrayFuncs.slice(array, new int[] {3});
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void sliceToLow() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+        ArrayFuncs.slice(array, null, new int[] {-4});
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void sliceToHigh() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+        ArrayFuncs.slice(array, null, new int[] {4});
     }
 
 }

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -353,8 +353,8 @@ public class ArrayFuncsTest {
 
         int[][] sub = (int[][]) ArrayFuncs.sample(array, 0);
 
-        Assert.assertEquals(2, sub.length);
-        Assert.assertEquals(2, sub[0].length);
+        Assert.assertEquals(3, sub.length);
+        Assert.assertEquals(3, sub[0].length);
 
         Assert.assertEquals(1, sub[0][0]);
         Assert.assertEquals(2, sub[0][1]);

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -362,14 +362,4 @@ public class ArrayFuncsTest {
         Assert.assertEquals(5, sub[1][1]);
     }
 
-    @Test
-    public void sampleTestSize0() throws Exception {
-        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
-
-        int[][] sub = (int[][]) ArrayFuncs.sample(array, new int[2], new int[2], null);
-
-        Assert.assertEquals(3, sub.length);
-        Assert.assertEquals(3, sub[0].length);
-    }
-
 }

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -324,7 +324,7 @@ public class ArrayFuncsTest {
         int[][] sub = (int[][]) ArrayFuncs.slice(array, null, new int[] {-2, -2});
 
         Assert.assertEquals(2, sub.length);
-        Assert.assertEquals(1, sub[0].length);
+        Assert.assertEquals(2, sub[0].length);
 
         Assert.assertEquals(9, sub[0][0]);
         Assert.assertEquals(8, sub[0][1]);

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -362,4 +362,19 @@ public class ArrayFuncsTest {
         Assert.assertEquals(5, sub[1][1]);
     }
 
+    @Test
+    public void sampleTestSize0() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.sample(array, null, new int[2], null);
+
+        Assert.assertEquals(3, sub.length);
+        Assert.assertEquals(3, sub[0].length);
+
+        Assert.assertEquals(1, sub[0][0]);
+        Assert.assertEquals(2, sub[0][1]);
+        Assert.assertEquals(4, sub[1][0]);
+        Assert.assertEquals(5, sub[1][1]);
+    }
+
 }

--- a/src/test/java/nom/tam/util/ArrayFuncsTest.java
+++ b/src/test/java/nom/tam/util/ArrayFuncsTest.java
@@ -347,4 +347,29 @@ public class ArrayFuncsTest {
         Assert.assertEquals(9, sub[1][1]);
     }
 
+    @Test
+    public void sampleTestStep0() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.sample(array, 0);
+
+        Assert.assertEquals(2, sub.length);
+        Assert.assertEquals(2, sub[0].length);
+
+        Assert.assertEquals(1, sub[0][0]);
+        Assert.assertEquals(2, sub[0][1]);
+        Assert.assertEquals(4, sub[1][0]);
+        Assert.assertEquals(5, sub[1][1]);
+    }
+
+    @Test
+    public void sampleTestSize0() throws Exception {
+        int[][] array = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+
+        int[][] sub = (int[][]) ArrayFuncs.sample(array, new int[2], new int[2], null);
+
+        Assert.assertEquals(3, sub.length);
+        Assert.assertEquals(3, sub[0].length);
+    }
+
 }


### PR DESCRIPTION
Convenience methods for obtaining a sampling of an array in 1 or more dimensions, including in reversed order along individual axes. Based on discussion #618.