### PR TITLE
Issue #636: Keep column names in compressed tables.

### DIFF
--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableData.java
@@ -164,6 +164,7 @@ public class CompressedTableData extends BinaryTable {
             // Create compressed columns...
             for (int column = 0; column < ncols; column++) {
                 addColumn(BinaryTable.ColumnDesc.createForVariableSize(byte.class));
+                getDescriptor(column).name(null);
             }
 
             // Initialized compressed rows...

--- a/src/main/java/nom/tam/image/compression/hdu/CompressedTableHDU.java
+++ b/src/main/java/nom/tam/image/compression/hdu/CompressedTableHDU.java
@@ -207,11 +207,11 @@ public class CompressedTableHDU extends BinaryTableHDU {
             CompressedCard.restore(card, headerIterator);
         }
 
-        CompressedTableHDU compressedImageHDU = new CompressedTableHDU(header, compressedData);
+        CompressedTableHDU compressedHDU = new CompressedTableHDU(header, compressedData);
         compressedData.prepareUncompressedData(binaryTableHDU.getData());
         compressedData.fillHeader(header);
 
-        return compressedImageHDU;
+        return compressedHDU;
     }
 
     /**

--- a/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
+++ b/src/test/java/nom/tam/image/compression/hdu/CompressedTableTest.java
@@ -555,6 +555,23 @@ public class CompressedTableTest {
         Assert.assertEquals("BLAH", h.getStringValue(Compression.ZCTYPn.n(1)));
     }
 
+    @Test
+    public void testCompressedTableColumnNames() throws Exception {
+        String name = "Test Name";
+        BinaryTable btab = new BinaryTable();
+
+        btab.addColumn(BinaryTable.ColumnDesc.createForFixedArrays(int.class, 6));
+        btab.getDescriptor(0).name(name);
+        Assert.assertEquals(name, btab.getDescriptor(0).name());
+
+        for (int i = 0; i < 100; i++) {
+            btab.addRowEntries(new int[] {i, i + 1, i + 2, i + 3, i + 4, i + 5});
+        }
+
+        CompressedTableHDU chdu = CompressedTableHDU.fromBinaryTableHDU(btab.toHDU(), 0);
+        Assert.assertEquals(name, chdu.getHeader().getStringValue(Standard.TTYPEn.n(1)));
+    }
+
     @Test(expected = IllegalStateException.class)
     public void testBinaryTableTileCompressorError() throws Exception {
         class MyCompressor extends BinaryTableTileCompressor {


### PR DESCRIPTION
Do not set default column names when creating compressed tables