### PR TITLE
Revised definitions of FITS keyword extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1155,13 +1155,16 @@ commonly used keyword, which as also collected in the `nom.tam.fits.header` pack
  
 Finally, many organisations (or groups of organisations) have defined their own sets of FITS keywords. Some of 
 these can be found under the `nom.tam.fits-header.extra` package, such as:
- 
+
+ * `CommonExt` -- Commonly used keywords in the amateur astronomy community
+ * `CXCExt` -- [keywords defined for the Chandra X-ray Observatory](https://cxc.harvard.edu/contrib/arots/fits/content.txt) 
+ * `ESOExt` -- keywords specific to the ESO 
+    [DataInterface Control Document](https://archive.eso.org/cms/tools-documentation/dicb/ESO-044156_7_DataInterfaceControlDocument.pdf)
  * `NOAOExt` -- keywords used by the National Optical Astronomy Observatory (_no longer available since the IRAF 
     project is no longer supported_) 
  * `SBFitsExt` -- [Santa Barbara Instrument Group FITS Extension 
-   (SBFITSEXT)](https://diffractionlimited.com/wp-content/uploads/2016/11/sbfitsext_1r0.pdf)
+   (SBFITSEXT)](https://diffractionlimited.com/wp-content/uploads/2016/11/sbfitsext_1r0.pdf), a.k.a. SBIG keywords.
    * `MaxImDLExt` -- [MaxIm DL Astronomy and Scientific Imaging Solutions](https://www.cyanogen.com/help/maximdl/FITS_File_Header_Definitions.htm)
- * `CXCExt` -- [keywords defined for the Chandra X-ray Observatory](https://cxc.harvard.edu/contrib/arots/fits/content.txt)
  * `STScIExt` -- [keywords used by the Space Telescope Science Institute](https://outerspace.stsci.edu/display/MASTDOCS/Required+Metadata)
 
 You can use the standardized keywords contained in these enums to populate headers or access header values. For 

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,9 @@
     <contributor>
       <name>Jonathan Cook</name>
     </contributor>
+    <contributor>
+      <name>John Murphy</name>
+    </contributor>
   </contributors>
   <scm>
     <connection>scm:git:https://github.com/nom-tam-fits/nom-tam-fits.git</connection>

--- a/src/main/java/nom/tam/fits/header/DataDescription.java
+++ b/src/main/java/nom/tam/fits/header/DataDescription.java
@@ -52,6 +52,7 @@ public enum DataDescription implements IFitsHeader {
      * version of a single program.
      */
     CONFIGUR(SOURCE.UNKNOWN, HDU.ANY, VALUE.STRING, "software configuration used to process the data"),
+
     /**
      * The value field shall contain a character string giving the name, and optionally, the version of the program that
      * originally created the current FITS HDU. This keyword is synonymous with the PROGRAM keyword. Example: 'TASKNAME
@@ -96,6 +97,7 @@ public enum DataDescription implements IFitsHeader {
      * should not both be given in the same HDU key, but if they are, then the HDULEVEL keyword will have precedence.
      */
     HDULEVEL(SOURCE.UNKNOWN, HDU.ANY, VALUE.INTEGER, "hierarchical level of the HDU"),
+
     /**
      * This keyword is synonymous to the standard EXTNAME keyword except. It is recommended that the HDUNAME and EXTNAME
      * keywords should not both be given in the same HDU key, but if they are, then the HDUNAME keyword will have
@@ -108,28 +110,33 @@ public enum DataDescription implements IFitsHeader {
      * should not both be given in the same HDU key, but if they are, then the HDUVER keyword will have precedence.
      */
     HDUVER(SOURCE.UNKNOWN, HDU.ANY, VALUE.INTEGER, "version number of the HDU"),
+
     /**
      * The value field shall contain a character string that gives the specific version of the document referenced by
      * HDUDOC.
      */
     HDUVERS(SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "specific version of the document referenced by HDUDOC"),
+
     /**
      * The value field shall contain an integer giving the number of standard extensions contained in the FITS file.
      * This keyword may only be used in the primary array key.
      */
     NEXTEND(SOURCE.STScI, HDU.PRIMARY, VALUE.INTEGER, "Number of standard extensions"),
+
     /**
      * The value field shall contain a character string giving the name, and optionally, the version of the program that
      * originally created the current FITS HDU. This keyword is synonymous with the CREATOR keyword. Example: 'TASKNAME
      * V1.2.3'
      */
     PROGRAM(SOURCE.UCOLICK, HDU.ANY, VALUE.STRING, "the name of the software task that created the file"),
+
     /**
      * The value field shall contain a character string giving the root of the host file name. The full file name
      * typically consists of the root name followed by a file type suffix (see FILETYPE), separated by the period ('.')
      * character.
      */
     ROOTNAME(SOURCE.UNKNOWN, HDU.ANY, VALUE.STRING, "rootname of the file"),
+
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the suggested bin size
      * when producing a histogram of the values in column n. This keyword is typically used in conjunction the TLMINn
@@ -138,6 +145,7 @@ public enum DataDescription implements IFitsHeader {
      * 'BINTABLE' extensions.
      */
     TDBINn(SOURCE.CXC, HDU.TABLE, VALUE.REAL, "default histogram bin size for the column"),
+
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the maximum valid
      * physical value represented in column n of the table, exclusive of any special values. This keyword may only be
@@ -146,6 +154,7 @@ public enum DataDescription implements IFitsHeader {
      * @deprecated Use {@link Standard#TDMAXn} instead.
      */
     TDMAXn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "maximum value in the column"),
+
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the minimum valid
      * physical value represented in column n of the table, exclusive of any special values. This keyword may only be
@@ -154,11 +163,13 @@ public enum DataDescription implements IFitsHeader {
      * @deprecated Use {@link Standard#TDMINn} instead.
      */
     TDMINn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "minimum value in the column"),
+
     /**
      * The value field shall contain a character string giving a title that is suitable for display purposes, e.g., for
      * annotation on images or plots of the data contained in the HDU.
      */
     TITLE(SOURCE.ROSAT, HDU.ANY, VALUE.STRING, "title for the observation or data"),
+
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the upper bound of the
      * legal range of physical values that may be represented in column n of the table. The column may contain values
@@ -168,6 +179,7 @@ public enum DataDescription implements IFitsHeader {
      * 
      * @deprecated Use {@link Standard#TLMAXn} instead.
      */
+
     TLMAXn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "maximum legal value in the column"),
     /**
      * The value field of this indexed keyword shall contain a floating point number specifying the lower bound of the
@@ -178,6 +190,7 @@ public enum DataDescription implements IFitsHeader {
      * 
      * @deprecated Use {@link Standard#TLMINn} instead.
      */
+
     TLMINn(SOURCE.HEASARC, HDU.TABLE, VALUE.REAL, "minimum legal value in the column"),
     /**
      * The value field shall contain a character string that defines the order in which the rows in the current FITS

--- a/src/main/java/nom/tam/fits/header/DateTime.java
+++ b/src/main/java/nom/tam/fits/header/DateTime.java
@@ -171,18 +171,20 @@ public enum DateTime implements IFitsHeader {
     JDREF(SOURCE.RESERVED, HDU.ANY, VALUE.REAL, "[day] reference Julian Date"),
 
     /**
-     * The start time of the observation, in the format specified in the FITS Standard, in the format HH:MM:SS[.s...]'.
+     * The start time of the observation, in the format specified in the FITS Standard, as decimal or in the format
+     * HH:MM:SS[.s...]'.
      * 
      * @since 1.19
      */
-    TSTART(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "start time of observation"),
+    TSTART(SOURCE.RESERVED, HDU.ANY, VALUE.ANY, "start time of observation"),
 
     /**
-     * The end time of the observation, in the format specified in the FITS Standard, in the format HH:MM:SS[.s...]'.
+     * The end time of the observation, in the format specified in the FITS Standard, as decimal or in the format
+     * HH:MM:SS[.s...]'.
      * 
      * @since 1.19
      */
-    TSTOP(SOURCE.RESERVED, HDU.ANY, VALUE.STRING, "end time of observation"),
+    TSTOP(SOURCE.RESERVED, HDU.ANY, VALUE.ANY, "end time of observation"),
 
     /**
      * [yr] Besselian epoch of observation

--- a/src/main/java/nom/tam/fits/header/InstrumentDescription.java
+++ b/src/main/java/nom/tam/fits/header/InstrumentDescription.java
@@ -99,6 +99,20 @@ public enum InstrumentDescription implements IFitsHeader {
      */
     SATURATE(SOURCE.STScI, HDU.ANY, VALUE.INTEGER, "data value at which saturation occurs");
 
+    /**
+     * Standard {@link #FILTER} name when no filter was used.
+     * 
+     * @since 1.20.1
+     */
+    public static final String FILTER_NONE = "NONE";
+
+    /**
+     * Standard {@link #GRATING} name when no filter was used.
+     * 
+     * @since 1.20.1
+     */
+    public static final String GRATING_NONE = "NONE";
+
     private final FitsKey key;
 
     InstrumentDescription(IFitsHeader.SOURCE status, HDU hdu, VALUE valueType, String comment) {

--- a/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
+++ b/src/main/java/nom/tam/fits/header/ObservationDurationDescription.java
@@ -59,9 +59,9 @@ public enum ObservationDurationDescription implements IFitsHeader {
     DATE_END("DATE-END", SOURCE.HEASARC, HDU.ANY, VALUE.STRING, "date of the end of observation"),
     /**
      * The value field shall contain a floating point number giving the difference between the stop and start times of
-     * the observation in units of seconds. This keyword is synonymous with the TELAPSE keyword.
+     * the observation in units of seconds. This keyword is synonymous with the {@link #TELAPSE} keyword.
      * 
-     * @see DateTime#TELAPSE
+     * @see #TELAPSE
      */
     ELAPTIME(SOURCE.UCOLICK, HDU.ANY, VALUE.REAL, "[s] elapsed time of the observation"),
     /**

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -2,6 +2,8 @@ package nom.tam.fits.header;
 
 import java.util.Arrays;
 
+import nom.tam.fits.header.extra.CommonExt;
+import nom.tam.fits.header.extra.MaxImDLExt;
 import nom.tam.fits.header.extra.NOAOExt;
 import nom.tam.fits.header.extra.SBFitsExt;
 import nom.tam.fits.header.extra.STScIExt;
@@ -41,7 +43,7 @@ import nom.tam.fits.header.extra.STScIExt;
  * This enum wil try to list synonyms inside or over different dictionaries. So please use always the highest level
  * keyword you can find.
  *
- * @author Richard van Nieuwenhoven
+ * @author Richard van Nieuwenhoven, Attila Kovacs, and John Murphy
  */
 @SuppressWarnings("deprecation")
 public enum Synonyms {
@@ -148,7 +150,119 @@ public enum Synonyms {
     TSTOP(DateTime.TSTOP, ObservationDurationDescription.TIME_END),
 
     /** DARKTIME appears in multiple conventions */
-    DARKTIME(NOAOExt.DARKTIME, SBFitsExt.DARKTIME);
+    DARKTIME(NOAOExt.DARKTIME, SBFitsExt.DARKTIME),
+
+    /**
+     * Image rotation angle in degrees
+     * 
+     * @since 1.20.1
+     */
+    OBJCTROT(CommonExt.OBJCTROT, CommonExt.ANGLE),
+
+    /**
+     * Electronic gain -- electrons per ADU
+     * 
+     * @since 1.20.1
+     */
+    EGAIN(SBFitsExt.EGAIN, CommonExt.GAINADU),
+
+    /**
+     * Focuser name
+     * 
+     * @since 1.20.1
+     */
+    FOCUSER(CommonExt.FOCUSER, CommonExt.FOCNAME),
+
+    /**
+     * Focus position steps
+     * 
+     * @since 1.20.1
+     */
+    FOCUSPOS(MaxImDLExt.FOCUSPOS, CommonExt.FOCPOS),
+
+    /**
+     * Focus temperature in degrees Celsius.
+     * 
+     * @since 1.20.1
+     */
+    FOCUSTEM(MaxImDLExt.FOCUSTEM, CommonExt.FOCTEMP),
+
+    /**
+     * Camera gain / ISO speed
+     * 
+     * @since 1.20.1
+     */
+    ISOSPEED(MaxImDLExt.ISOSPEED, CommonExt.GAINRAW),
+
+    /**
+     * Pixel binning in X direction
+     * 
+     * @since 1.20.1
+     */
+    XBINNING(SBFitsExt.XBINNING, CommonExt.CCDXBIN),
+
+    /**
+     * Pixel binning in Y direction
+     * 
+     * @since 1.20.1
+     */
+    YBINNING(SBFitsExt.YBINNING, CommonExt.CCDYBIN),
+
+    /**
+     * Image scale (arcsec/pixel)
+     *
+     * @since 1.20.1
+     */
+    PIXSCALE(CommonExt.PIXSCALE, CommonExt.SCALE),
+
+    /**
+     * Cloud cover percentage
+     *
+     * @since 1.20.1
+     */
+    CLOUDCVR(CommonExt.CLOUDCVR, MaxImDLExt.AOCCLOUD),
+
+    /**
+     * Relative humidity in percent
+     *
+     * @since 1.20.1
+     */
+    HUMIDITY(CommonExt.HUMIDITY, MaxImDLExt.AOCHUM, MaxImDLExt.BOLTHUM, MaxImDLExt.DAVHUM),
+
+    /**
+     * Dew point in degrees Celsius
+     * 
+     * @since 1.20.1
+     */
+    DEWPOINT(CommonExt.DEWPOINT, MaxImDLExt.AOCDEW, MaxImDLExt.BOLTDEW, MaxImDLExt.DAVDEW),
+
+    /**
+     * Ambient temperature in degrees Celsius
+     * 
+     * @since 1.20.1
+     */
+    AMBTEMP(CommonExt.AMBTEMP, MaxImDLExt.AOCAMBT, MaxImDLExt.BOLTAMBT, MaxImDLExt.DAVAMBT),
+
+    /**
+     * Wind speed in km/h
+     *
+     * @since 1.20.1
+     */
+    WINDSPD(CommonExt.WINDSPD, MaxImDLExt.BOLTWIND, MaxImDLExt.DAVWIND), // MaxImDLExt.AOCWIND, uses different units
+
+    /**
+     * Wind direction in degrees, clockwise from North
+     * 
+     * @since 1.20.1
+     */
+    WINDDIR(CommonExt.WINDDIR, MaxImDLExt.AOCWINDD, MaxImDLExt.DAVWINDD),
+
+    /**
+     * Atmospheric pressure in hPA
+     *
+     * @since 1.20.1
+     */
+    PRESSURE(CommonExt.PRESSURE, MaxImDLExt.AOCBAROM, MaxImDLExt.DAVBAROM);
 
     private final IFitsHeader primaryKeyword;
 
@@ -183,10 +297,10 @@ public enum Synonyms {
      * 
      * @param  key the standard or conventional header keyword.
      * 
-     * @return        the primary (or preferred) FITS header keyword form to use
+     * @return     the primary (or preferred) FITS header keyword form to use
      * 
-     * @see           #primaryKeyword(String)
-     * @see           #primaryKeyword()
+     * @see        #primaryKeyword(String)
+     * @see        #primaryKeyword()
      */
     public static IFitsHeader primaryKeyword(IFitsHeader key) {
         for (Synonyms synonym : values()) {

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -2,7 +2,6 @@ package nom.tam.fits.header;
 
 import java.util.Arrays;
 
-import nom.tam.fits.header.extra.CXCExt;
 import nom.tam.fits.header.extra.CommonExt;
 import nom.tam.fits.header.extra.MaxImDLExt;
 import nom.tam.fits.header.extra.NOAOExt;
@@ -51,9 +50,6 @@ public enum Synonyms {
 
     /** EQUINOX is now preferred over the old EPOCH */
     EQUINOX(Standard.EQUINOX, Standard.EPOCH),
-
-    /** TIMESYS appears in multiple conventions */
-    TIMESYS(NOAOExt.TIMESYS, STScIExt.TIMESYS),
 
     /** RADESYS is now preferred over the old RADECSYS */
     RADESYS(Standard.RADESYS, Standard.RADECSYS),
@@ -120,7 +116,7 @@ public enum Synonyms {
     /**
      * EXTNAME and HDUNAME are synonymous, but EXTNAME is part of the standard since 1.19
      */
-    EXTNAME(Standard.EXTNAME, DataDescription.HDUNAME, CXCExt.HDUNAME),
+    EXTNAME(Standard.EXTNAME, DataDescription.HDUNAME),
 
     /**
      * EXTVER and HDUVER are synonymous, but EXTVER is part of the standard since 1.19
@@ -138,7 +134,7 @@ public enum Synonyms {
      * @see DateTime#XPOSURE
      */
     EXPOSURE(ObservationDurationDescription.EXPOSURE, ObservationDurationDescription.EXPTIME,
-            ObservationDurationDescription.ONTIME),
+            ObservationDurationDescription.ONTIME, STScIExt.XPOSURE),
 
     /**
      * Variants for recording the start time of observation in HH:MM:SS[.s...] format
@@ -270,14 +266,14 @@ public enum Synonyms {
      * 
      * @since 1.20.1
      */
-    CREATOR(DataDescription.CREATOR, CommonExt.PROGRAM),
+    CREATOR(DataDescription.CREATOR, DataDescription.PROGRAM),
 
     /**
      * Clock time duration of observation.
      * 
      * @since 1.20.1
      */
-    TELAPSE(CommonExt.TELAPSE, CommonExt.ELAPTIME);
+    TELAPSE(DateTime.TELAPSE, ObservationDurationDescription.ELAPTIME);
 
     private final IFitsHeader primaryKeyword;
 

--- a/src/main/java/nom/tam/fits/header/Synonyms.java
+++ b/src/main/java/nom/tam/fits/header/Synonyms.java
@@ -2,6 +2,7 @@ package nom.tam.fits.header;
 
 import java.util.Arrays;
 
+import nom.tam.fits.header.extra.CXCExt;
 import nom.tam.fits.header.extra.CommonExt;
 import nom.tam.fits.header.extra.MaxImDLExt;
 import nom.tam.fits.header.extra.NOAOExt;
@@ -119,7 +120,7 @@ public enum Synonyms {
     /**
      * EXTNAME and HDUNAME are synonymous, but EXTNAME is part of the standard since 1.19
      */
-    EXTNAME(Standard.EXTNAME, DataDescription.HDUNAME),
+    EXTNAME(Standard.EXTNAME, DataDescription.HDUNAME, CXCExt.HDUNAME),
 
     /**
      * EXTVER and HDUVER are synonymous, but EXTVER is part of the standard since 1.19
@@ -262,7 +263,21 @@ public enum Synonyms {
      *
      * @since 1.20.1
      */
-    PRESSURE(CommonExt.PRESSURE, MaxImDLExt.AOCBAROM, MaxImDLExt.DAVBAROM);
+    PRESSURE(CommonExt.PRESSURE, MaxImDLExt.AOCBAROM, MaxImDLExt.DAVBAROM),
+
+    /**
+     * Software that created the original FITS file.
+     * 
+     * @since 1.20.1
+     */
+    CREATOR(DataDescription.CREATOR, CommonExt.PROGRAM),
+
+    /**
+     * Clock time duration of observation.
+     * 
+     * @since 1.20.1
+     */
+    TELAPSE(CommonExt.TELAPSE, CommonExt.ELAPTIME);
 
     private final IFitsHeader primaryKeyword;
 

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -41,12 +41,12 @@ import nom.tam.fits.header.IFitsHeader;
  * <p>
  * All files are identified by the CONTENT value of their principal HDUs.
  * </p>
- *
- * <pre>
- * http://cxc.harvard.edu/contrib/arots/fits/content.txt
- * </pre>
- *
- * @author Richard van Nieuwenhoven and Attila Kovacs
+ * Originally based on the <a href="http://cxc.harvard.edu/contrib/arots/fits/content.txt">Guide to Chandra Data
+ * Products</a>, with additional keyword entries added in 1.20.1 based on the
+ * <a href="https://planet4589.org/astro/sds/asc/ps/sds73.pdf">FITS Keyword Conventions in CXC Data Model files
+ * SDS-7.3</a>.
+ * 
+ * @author Attila Kovacs and Richard van Nieuwenhoven
  */
 @SuppressWarnings({"deprecation", "javadoc"})
 public enum CXCExt implements IFitsHeader {
@@ -87,14 +87,17 @@ public enum CXCExt implements IFitsHeader {
     CONVERS(VALUE.STRING, "version info"),
 
     /**
-     * Data class
+     * Data class: 'observed' or 'simulated'
+     * 
+     * @see #DATACLAS_OBSERVED
+     * @see #DATACLAS_SIMULATED
      */
-    DATACLAS(VALUE.STRING, "data class"),
+    DATACLAS(VALUE.STRING, "observed or simulated"),
 
     /**
-     * Dead time correction factor
+     * Dead time correction factor [0.0:1.0].
      */
-    DTCOR(VALUE.REAL, "[s] dead time correction factor"),
+    DTCOR(VALUE.REAL, "[s] dead time correction [0.0:1.0]"),
 
     /**
      * Assumed focal length, mm; Level 1 and up
@@ -262,7 +265,235 @@ public enum CXCExt implements IFitsHeader {
     /**
      * Same as {@link CXCStclSharedExt#TSTOP}.
      */
-    TSTOP(CXCStclSharedExt.TSTOP);
+    TSTOP(CXCStclSharedExt.TSTOP),
+
+    // ---- Added in 1.20.1 from the CXC Data Model specification ------------>
+
+    // Standard header keywords
+    // MISSION(VALUE.STRING, "Grouping of related telesopes"),
+
+    /**
+     * Observation ID
+     * 
+     * @since 1.20.1
+     */
+    OBS_ID(VALUE.STRING, "Observation ID"),
+
+    // SEQ_NUM(VALUE.INTEGER, "Sequence_number"),
+
+    // ASCDSVER(VALUE.STRING, "Processing system revision"),
+
+    /**
+     * Defocus distance of instrument in mm rel to best.
+     * 
+     * @since 1.20.1
+     */
+    DEFOCUS(VALUE.REAL, "[mm] Defocus distance from best"),
+
+    // FOC_LEN(VALUE.REAL, "Telessope focal length in mm"),
+
+    /**
+     * Observing mode: "pointing", "slewing", or "ground cal".
+     * 
+     * @see   #OBSMODE_POINTING
+     * @see   #OBSMODE_SLEWING
+     * @see   #OBSMODE_GROUND_CAL
+     * 
+     * @since 1.20.1
+     */
+    OBS_MODE(VALUE.STRING, "observing mode"),
+
+    /**
+     * Configuration of on-board processing
+     * 
+     * @since 1.20.1
+     */
+    DATAMODE(VALUE.STRING, "on-board processing config"),
+
+    /**
+     * Configuration of instrument
+     * 
+     * @since 1.20.1
+     */
+    READMODE(VALUE.STRING, "instrument config"),
+
+    /** Data class "observed" or "simulated". */
+    // DATACLAS(VALUE.STRING, "observed or simulated"),
+
+    // ONTIME(VALUE.REAL, "Sum of GTIs"),
+
+    // DTCOR(VALUE.REAL, "Dead time corretion [0.0:1.0]"),
+
+    /**
+     * {@link #ONTIME} times {@link #DTCOR}
+     * 
+     * @since 1.20.1
+     */
+    LIVETIME(VALUE.REAL, "ONTIME times DTCOR"),
+
+    /**
+     * CALDB file for gain corretion
+     * 
+     * @since 1.20.1
+     */
+    GAINFILE(VALUE.STRING, "CALDB file for gain correction"),
+
+    /**
+     * CALDB file for grade correction
+     * 
+     * @since 1.20.1
+     */
+    GRD_FILE(VALUE.STRING, "CALDB file for grade correction"),
+
+    // Data model keywords
+
+    /**
+     * Override {@link Standard#CTYPEn} image coordinate axis name
+     * 
+     * @since 1.20.1
+     */
+    CNAMEn(VALUE.STRING, "coordinate axis name"),
+
+    /**
+     * List of 'preferred cols' for making image from table
+     * 
+     * @since 1.20.1
+     */
+    CPREF(VALUE.STRING, "list of image columns"),
+
+    /**
+     * Data Subspace column name for column <i>n</i>.
+     * 
+     * @since 1.20.1
+     */
+    DSTYPn(VALUE.STRING, "data subspace column name"),
+
+    /**
+     * Data Subspace data type name (optional) for column <i>n</i>.
+     * 
+     * @since 1.20.1
+     */
+    DSFORMn(VALUE.STRING, "data subspace data type"),
+
+    /**
+     * Data Subspace unit name (optional) for column <i>n</i>.
+     * 
+     * @since 1.20.1
+     */
+    DSUNITn(VALUE.STRING, "data subspace unit"),
+
+    /**
+     * Data Subspace filter list for column <i>n</i>.
+     * 
+     * @since 1.20.1
+     */
+    DSVALn(VALUE.STRING, "data subspace filter list"),
+
+    /**
+     * Data Subspace filter list for component <i>i</i> (leading index) and column <i>n</i> (trailing index).
+     * 
+     * @since 1.20.1
+     * 
+     * @see   #DSVALn
+     */
+    nDSVALn(VALUE.STRING, "data subspace filter list for component"),
+
+    /**
+     * Data Subspace table pointer for column <i>n</i>.
+     * 
+     * @since 1.20.1
+     */
+    DSREFn(VALUE.STRING, "data subspace table pointer"),
+
+    /**
+     * Data Subspace table pointer for component <i>i</i> (leading index) and column <i>n</i> (trailing index).
+     * 
+     * @since 1.20.1
+     * 
+     * @see   #DSVALn
+     */
+    nDSREFn(VALUE.STRING, "data subspace table pointer for component"),
+
+    /**
+     * Name for composite long-named keyword (f. CFITSIO HIERARCH) for column <i>n</i>. Also used to de ne array
+     * keywords.
+     * 
+     * @since 1.20.1
+     */
+    DTYPEn(VALUE.STRING, "composite keyword name"),
+
+    /**
+     * Unit for composite long-named keyword for column <i>n</i>.
+     * 
+     * @since 1.20.1
+     */
+    DUNITn(VALUE.STRING, "composite keyword unit"),
+
+    /**
+     * Value for composite long-named keyword for column <i>n</i>.
+     * 
+     * @since 1.20.1
+     */
+    DVALn(VALUE.ANY, "composite keyword value"),
+
+    /**
+     * Gives a name to an HDU. If not present, you should use EXTNAME/EXTVER.
+     * 
+     * @since 1.20.1
+     */
+    HDUNAME(VALUE.STRING, "HDU name"),
+
+    /**
+     * Type of composite column (not yet supported)
+     * 
+     * @since 1.20.1
+     */
+    METYPn(VALUE.STRING, "composite column type"),
+
+    /**
+     * Comma-separated list of column names making up composite col (with {@link #MTYPE}).
+     * 
+     * @since 1.20.1
+     */
+    MFORMk(VALUE.STRING, "column names for composite column"),
+
+    /**
+     * Composite column name (paired with {@link #MFORM}).
+     * 
+     * @since 1.20.1
+     */
+    MTYPEk(VALUE.STRING, "composite column name"),
+
+    /**
+     * Override {@link Standard#TCTYPn} table oordinate axis name.
+     * 
+     * @since 1.20.1
+     */
+    TCNAMn(VALUE.STRING, "column coordinate axis name"),
+
+    /**
+     * Default binning factor for table column
+     * 
+     * @since 1.20.1
+     */
+    TDBINn(VALUE.REAL, "Default binning factor for table column"),
+
+    /**
+     * Floating point <code>null</code> value other than NaN
+     * 
+     * @since 1.20.1
+     */
+    TDNULLn(VALUE.REAL, "designated null value");
+
+    public static final String DATACLAS_OBSERVED = "observed";
+
+    public static final String DATACLAS_SIMULATED = "simulated";
+
+    public static final String OBSMODE_POINTING = "pointing";
+
+    public static final String OBSMODE_SLEWING = "slewing";
+
+    public static final String OBSMODE_GROUND_CAL = "ground cal";
 
     /**
      * Same as {@link CXCStclSharedExt#TIMEREF_GEOCENTRIC}.

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -46,8 +46,9 @@ import nom.tam.fits.header.IFitsHeader;
  * http://cxc.harvard.edu/contrib/arots/fits/content.txt
  * </pre>
  *
- * @author Richard van Nieuwenhoven
+ * @author Richard van Nieuwenhoven and Attila Kovacs
  */
+@SuppressWarnings({"deprecation", "javadoc"})
 public enum CXCExt implements IFitsHeader {
 
     /**
@@ -113,22 +114,22 @@ public enum CXCExt implements IFitsHeader {
     /**
      * Mission specifier, e.g. 'AXAF'
      */
-    MISSION(VALUE.STRING, "Mission"),
+    MISSION(VALUE.STRING, "mission identifier"),
 
     /**
      * Processing version of data
      */
-    REVISION(VALUE.STRING, "Processing version of data"),
+    REVISION(VALUE.STRING, "processing version of data"),
 
     /**
      * Nominal roll angle, deg
      */
-    ROLL_NOM(VALUE.REAL, "[deg] Nominal roll angle"),
+    ROLL_NOM(VALUE.REAL, "[deg] nominal roll angle"),
 
     /**
      * Sequence number
      */
-    SEQ_NUM(VALUE.INTEGER, "Sequence number"),
+    SEQ_NUM(VALUE.INTEGER, "sequence number"),
 
     /**
      * SIM focus pos (mm)
@@ -148,27 +149,27 @@ public enum CXCExt implements IFitsHeader {
     /**
      * Major frame count at start
      */
-    STARTMJF(VALUE.INTEGER, "Major frame count at start"),
+    STARTMJF(VALUE.INTEGER, "major frame count at start"),
 
     /**
      * Minor frame count at start
      */
-    STARTMNF(VALUE.INTEGER, "Minor frame count at start"),
+    STARTMNF(VALUE.INTEGER, "minor frame count at start"),
 
     /**
      * On-Board MET close to STARTMJF and STARTMNF
      */
-    STARTOBT(VALUE.INTEGER, "On-Board MET close to STARTMJF and STARTMNF"),
+    STARTOBT(VALUE.INTEGER, "on-board MET close to STARTMJF and STARTMNF"),
 
     /**
      * Major frame count at stop
      */
-    STOPMJF(VALUE.INTEGER, "Major frame count at stop"),
+    STOPMJF(VALUE.INTEGER, "major frame count at stop"),
 
     /**
      * Minor frame count at stop
      */
-    STOPMNF(VALUE.INTEGER, "Minor frame count at stop"),
+    STOPMNF(VALUE.INTEGER, "minor frame count at stop"),
 
     /**
      * Absolute timing error.
@@ -183,28 +184,119 @@ public enum CXCExt implements IFitsHeader {
     /**
      * Time stamp reference as bin fraction
      */
-    TIMEPIXR(VALUE.REAL, "[bin] Time stamp reference"),
+    TIMEPIXR(VALUE.REAL, "[bin] time stamp reference"),
 
     /**
      * Telemetry revision number (IP&amp;CL)
      */
-    TLMVER(VALUE.STRING, "Telemetry revision number (IP&CL)"),
+    TLMVER(VALUE.STRING, "telemetry revision number (IP&CL)"),
+
+    // Inherited from CXCStscISharedExt ----------------------------------------->
 
     /**
-     * The value field of this keyword shall contain the value of the start time of data acquisition in units of
-     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
-     * keyword.
+     * Same as {@link CXCStclSharedExt#CLOCKAPP}.
+     * 
+     * @since 1.20.1
      */
-    TSTART(VALUE.REAL, "start time of observation"),
+    CLOCKAPP(CXCStclSharedExt.CLOCKAPP),
 
     /**
-     * The value field of this keyword shall contain the value of the stop time of data acquisition in units of
-     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
-     * keyword.
+     * Same as {@link CXCStclSharedExt#MJDREF}.
+     * 
+     * @since 1.20.1
      */
-    TSTOP(VALUE.REAL, "start time of observation");
+    MJDREF(CXCStclSharedExt.MJDREF),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TASSIGN}.
+     * 
+     * @since 1.20.1
+     */
+    TASSIGN(CXCStclSharedExt.TASSIGN),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEDEL}.
+     * 
+     * @since 1.20.1
+     */
+    TIMEDEL(CXCStclSharedExt.TIMEDEL),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF}.
+     * 
+     * @since 1.20.1
+     * 
+     * @see   #TIMEREF_LOCAL
+     * @see   #TIMEREF_GEOCENTRIC
+     * @see   #TIMEREF_HELIOCENTRIC
+     * @see   #TIMEREF_SOLARSYSTEM
+     */
+    TIMEREF(CXCStclSharedExt.TIMEREF),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEUNIT}.
+     * 
+     * @since 1.20.1
+     */
+    TIMEUNIT(CXCStclSharedExt.TIMEUNIT),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMVERSN}.
+     * 
+     * @since 1.20.1
+     */
+    TIMVERSN(CXCStclSharedExt.TIMVERSN),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEZERO}.
+     * 
+     * @since 1.20.1
+     */
+    TIMEZERO(CXCStclSharedExt.TIMEZERO),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TSTART}.
+     */
+    TSTART(CXCStclSharedExt.TSTART),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TSTOP}.
+     */
+    TSTOP(CXCStclSharedExt.TSTOP);
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF_GEOCENTRIC}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_GEOCENTRIC = CXCStclSharedExt.TIMEREF_GEOCENTRIC;
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF_HELIOCENTRIC}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_HELIOCENTRIC = CXCStclSharedExt.TIMEREF_HELIOCENTRIC;
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF_SOLARSYSTEM}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_SOLARSYSTEM = CXCStclSharedExt.TIMEREF_SOLARSYSTEM;
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF_LOCAL}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_LOCAL = CXCStclSharedExt.TIMEREF_LOCAL;
 
     private final FitsKey key;
+
+    CXCExt(IFitsHeader key) {
+        this.key = key.impl();
+    }
 
     CXCExt(VALUE valueType, String comment) {
         key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, valueType, comment);

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.header.extra;
 
+import nom.tam.fits.header.DateTime;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -33,6 +35,7 @@ package nom.tam.fits.header.extra;
 
 import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
+import nom.tam.fits.header.InstrumentDescription;
 
 /**
  * This is the file content.txt that presents a comprehensive compilation of all classes of data products in the Chandra
@@ -48,7 +51,6 @@ import nom.tam.fits.header.IFitsHeader;
  * 
  * @author Attila Kovacs and Richard van Nieuwenhoven
  */
-@SuppressWarnings({"deprecation", "javadoc"})
 public enum CXCExt implements IFitsHeader {
 
     /**
@@ -197,35 +199,28 @@ public enum CXCExt implements IFitsHeader {
     // Inherited from CXCStscISharedExt ----------------------------------------->
 
     /**
-     * Same as {@link CXCStclSharedExt#CLOCKAPP}.
+     * Same as {@link STScIExt#CLOCKAPP}.
      * 
      * @since 1.20.1
      */
-    CLOCKAPP(CXCStclSharedExt.CLOCKAPP),
+    CLOCKAPP(STScIExt.CLOCKAPP),
 
     /**
-     * Same as {@link CXCStclSharedExt#MJDREF}.
+     * Same as {@link STScIExt#TASSIGN}.
      * 
      * @since 1.20.1
      */
-    MJDREF(CXCStclSharedExt.MJDREF),
+    TASSIGN(STScIExt.TASSIGN),
 
     /**
-     * Same as {@link CXCStclSharedExt#TASSIGN}.
+     * Same as {@link DateTime#TIMEDEL}.
      * 
      * @since 1.20.1
      */
-    TASSIGN(CXCStclSharedExt.TASSIGN),
+    TIMEDEL(DateTime.TIMEDEL),
 
     /**
-     * Same as {@link CXCStclSharedExt#TIMEDEL}.
-     * 
-     * @since 1.20.1
-     */
-    TIMEDEL(CXCStclSharedExt.TIMEDEL),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEREF}.
+     * Same as {@link STScIExt#TIMEREF}.
      * 
      * @since 1.20.1
      * 
@@ -234,50 +229,43 @@ public enum CXCExt implements IFitsHeader {
      * @see   #TIMEREF_HELIOCENTRIC
      * @see   #TIMEREF_SOLARSYSTEM
      */
-    TIMEREF(CXCStclSharedExt.TIMEREF),
+    TIMEREF(STScIExt.TIMEREF),
 
     /**
-     * Same as {@link CXCStclSharedExt#TIMEUNIT}.
+     * Same as {@link STScIExt#TIMEUNIT}.
      * 
      * @since 1.20.1
      */
-    TIMEUNIT(CXCStclSharedExt.TIMEUNIT),
+    TIMEUNIT(STScIExt.TIMEUNIT),
 
     /**
-     * Same as {@link CXCStclSharedExt#TIMVERSN}.
+     * Same as {@link STScIExt#TIMVERSN}.
      * 
      * @since 1.20.1
      */
-    TIMVERSN(CXCStclSharedExt.TIMVERSN),
+    TIMVERSN(STScIExt.TIMVERSN),
 
     /**
-     * Same as {@link CXCStclSharedExt#TIMEZERO}.
+     * Same as {@link STScIExt#TIMEZERO}.
      * 
      * @since 1.20.1
      */
-    TIMEZERO(CXCStclSharedExt.TIMEZERO),
+    TIMEZERO(STScIExt.TIMEZERO),
 
     /**
-     * Same as {@link CXCStclSharedExt#TSTART}.
+     * Same as {@link STScIExt#TSTART}.
      */
-    TSTART(CXCStclSharedExt.TSTART),
+    TSTART(STScIExt.TSTART),
 
     /**
-     * Same as {@link CXCStclSharedExt#TSTOP}.
+     * Same as {@link STScIExt#TSTOP}.
      */
-    TSTOP(CXCStclSharedExt.TSTOP),
+    TSTOP(STScIExt.TSTOP),
 
     // ---- Added in 1.20.1 from the CXC Data Model specification ------------>
 
     // Standard header keywords
     // MISSION(VALUE.STRING, "Grouping of related telesopes"),
-
-    /**
-     * Observation ID
-     * 
-     * @since 1.20.1
-     */
-    OBS_ID(VALUE.STRING, "Observation ID"),
 
     // SEQ_NUM(VALUE.INTEGER, "Sequence_number"),
 
@@ -293,24 +281,6 @@ public enum CXCExt implements IFitsHeader {
     // FOC_LEN(VALUE.REAL, "Telessope focal length in mm"),
 
     /**
-     * Observing mode: "pointing", "slewing", or "ground cal".
-     * 
-     * @see   #OBSMODE_POINTING
-     * @see   #OBSMODE_SLEWING
-     * @see   #OBSMODE_GROUND_CAL
-     * 
-     * @since 1.20.1
-     */
-    OBS_MODE(VALUE.STRING, "observing mode"),
-
-    /**
-     * Configuration of on-board processing
-     * 
-     * @since 1.20.1
-     */
-    DATAMODE(VALUE.STRING, "on-board processing config"),
-
-    /**
      * Configuration of instrument
      * 
      * @since 1.20.1
@@ -323,13 +293,6 @@ public enum CXCExt implements IFitsHeader {
     // ONTIME(VALUE.REAL, "Sum of GTIs"),
 
     // DTCOR(VALUE.REAL, "Dead time corretion [0.0:1.0]"),
-
-    /**
-     * {@link #ONTIME} times {@link #DTCOR}
-     * 
-     * @since 1.20.1
-     */
-    LIVETIME(VALUE.REAL, "ONTIME times DTCOR"),
 
     /**
      * CALDB file for gain corretion
@@ -348,7 +311,7 @@ public enum CXCExt implements IFitsHeader {
     // Data model keywords
 
     /**
-     * Override {@link Standard#CTYPEn} image coordinate axis name
+     * Override {@link nom.tam.fits.header.Standard#CTYPEn} image coordinate axis name
      * 
      * @since 1.20.1
      */
@@ -451,21 +414,21 @@ public enum CXCExt implements IFitsHeader {
     METYPn(VALUE.STRING, "composite column type"),
 
     /**
-     * Comma-separated list of column names making up composite col (with {@link #MTYPE}).
+     * Comma-separated list of column names making up composite col (with {@link #MTYPEn}).
      * 
      * @since 1.20.1
      */
-    MFORMk(VALUE.STRING, "column names for composite column"),
+    MFORMn(VALUE.STRING, "column names for composite column"),
 
     /**
-     * Composite column name (paired with {@link #MFORM}).
+     * Composite column name (paired with {@link #MFORMn}).
      * 
      * @since 1.20.1
      */
-    MTYPEk(VALUE.STRING, "composite column name"),
+    MTYPEn(VALUE.STRING, "composite column name"),
 
     /**
-     * Override {@link Standard#TCTYPn} table oordinate axis name.
+     * Override {@link nom.tam.fits.header.WCS#TCTYPn} table oordinate axis name.
      * 
      * @since 1.20.1
      */
@@ -485,43 +448,68 @@ public enum CXCExt implements IFitsHeader {
      */
     TDNULLn(VALUE.REAL, "designated null value");
 
+    /**
+     * Standard {@link #DATACLAS} value 'observed'.
+     * 
+     * @since 1.20.1
+     */
     public static final String DATACLAS_OBSERVED = "observed";
 
+    /**
+     * Standard {@link #DATACLAS} value 'simulated'.
+     * 
+     * @since 1.20.1
+     */
     public static final String DATACLAS_SIMULATED = "simulated";
 
-    public static final String OBSMODE_POINTING = "pointing";
-
-    public static final String OBSMODE_SLEWING = "slewing";
-
-    public static final String OBSMODE_GROUND_CAL = "ground cal";
-
     /**
-     * Same as {@link CXCStclSharedExt#TIMEREF_GEOCENTRIC}.
+     * Standard {@link InstrumentDescription#OBS_MODE} value for pointing observations.
      * 
      * @since 1.20.1
      */
-    public static final String TIMEREF_GEOCENTRIC = CXCStclSharedExt.TIMEREF_GEOCENTRIC;
+    public static final String OBS_MODE_POINTING = "pointing";
 
     /**
-     * Same as {@link CXCStclSharedExt#TIMEREF_HELIOCENTRIC}.
+     * Standard {@link InstrumentDescription#OBS_MODE} value while slewing.
      * 
      * @since 1.20.1
      */
-    public static final String TIMEREF_HELIOCENTRIC = CXCStclSharedExt.TIMEREF_HELIOCENTRIC;
+    public static final String OBS_MODE_SLEWING = "slewing";
 
     /**
-     * Same as {@link CXCStclSharedExt#TIMEREF_SOLARSYSTEM}.
+     * Standard {@link InstrumentDescription#OBS_MODE} value for ground cal observations.
      * 
      * @since 1.20.1
      */
-    public static final String TIMEREF_SOLARSYSTEM = CXCStclSharedExt.TIMEREF_SOLARSYSTEM;
+    public static final String OBS_MODE_GROUND_CAL = "ground cal";
 
     /**
-     * Same as {@link CXCStclSharedExt#TIMEREF_LOCAL}.
+     * Same as {@link STScIExt#TIMEREF_GEOCENTRIC}.
      * 
      * @since 1.20.1
      */
-    public static final String TIMEREF_LOCAL = CXCStclSharedExt.TIMEREF_LOCAL;
+    public static final String TIMEREF_GEOCENTRIC = STScIExt.TIMEREF_GEOCENTRIC;
+
+    /**
+     * Same as {@link STScIExt#TIMEREF_HELIOCENTRIC}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_HELIOCENTRIC = STScIExt.TIMEREF_HELIOCENTRIC;
+
+    /**
+     * Same as {@link STScIExt#TIMEREF_SOLARSYSTEM}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_SOLARSYSTEM = STScIExt.TIMEREF_SOLARSYSTEM;
+
+    /**
+     * Same as {@link STScIExt#TIMEREF_LOCAL}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_LOCAL = STScIExt.TIMEREF_LOCAL;
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -49,135 +49,165 @@ import nom.tam.fits.header.IFitsHeader;
  * @author Richard van Nieuwenhoven
  */
 public enum CXCExt implements IFitsHeader {
+
     /**
      * ASC-DS processing system revision (release)
      */
-    ASCDSVER("ASC-DS processing system revision (release)"),
+    ASCDSVER(VALUE.STRING, "ASC-DS processing system revision (release)"),
+
     /**
      * Correction applied to Basic Time rate (s)
      */
-    BTIMCORR("Correction applied to Basic Time rate (s)"),
+    BTIMCORR(VALUE.REAL, "[s] time rate correction"),
+
     /**
-     * Basic Time clock drift (s / VCDUcount^2)
+     * Basic Time clock drift (s / VCDUcount<sup>2</sup>)
      */
-    BTIMDRFT("Basic Time clock drift (s / VCDUcount^2)"),
+    BTIMDRFT(VALUE.REAL, "'[s/ct**2] clock drift"),
+
     /**
      * Basic Time offset (s)
      */
-    BTIMNULL("Basic Time offset (s)"),
+    BTIMNULL(VALUE.REAL, "[s] time offset"),
+
     /**
      * Basic Time clock rate (s / VCDUcount)
      */
-    BTIMRATE("Basic Time clock rate (s / VCDUcount)"),
+    BTIMRATE(VALUE.REAL, "[s/ct] clock rate"),
 
     /**
-     * Data product identification '########'
+     * Data product identification
      */
-    CONTENT("Data product identification"),
+    CONTENT(VALUE.STRING, "data product identification"),
+
     /**
-     * ???
+     * The format of the CONVERS keyword is 'i.j.k'. if missing, the default value will be '1.0.0'
      */
-    CONVERS("??"),
+    CONVERS(VALUE.STRING, "version info"),
+
     /**
-     * Data class '########'
+     * Data class
      */
-    DATACLAS("Data class"),
+    DATACLAS(VALUE.STRING, "data class"),
+
     /**
-     * Dead time correction
+     * Dead time correction factor
      */
-    DTCOR("Dead time correction"),
+    DTCOR(VALUE.REAL, "[s] dead time correction factor"),
+
     /**
      * Assumed focal length, mm; Level 1 and up
      */
-    FOC_LEN("Assumed focal length, mm; Level 1 and up"),
+    FOC_LEN(VALUE.REAL, "[mm] assumed focal length"),
+
     /**
-     * ICD reference
+     * ICD reference. E.g. 'HRC Level 1 Data Products ICD, Version 1.1'
      */
-    HDUSPEC("ICD reference"),
+    HDUSPEC(VALUE.STRING, "ICD reference"),
+
     /**
      * The OGIP long string convention may be used.
      */
-    LONGSTRN("The OGIP long string convention may be used."),
+    LONGSTRN(VALUE.STRING, "The OGIP long string convention may be used."),
+
     /**
-     * Mission is AXAF
+     * Mission specifier, e.g. 'AXAF'
      */
-    MISSION("Mission is AXAF"),
+    MISSION(VALUE.STRING, "Mission"),
 
     /**
      * Processing version of data
      */
-    REVISION("Processing version of data"),
+    REVISION(VALUE.STRING, "Processing version of data"),
+
     /**
      * Nominal roll angle, deg
      */
-    ROLL_NOM("Nominal roll angle, deg"),
+    ROLL_NOM(VALUE.REAL, "[deg] Nominal roll angle"),
+
     /**
      * Sequence number
      */
-    SEQ_NUM("Sequence number"),
+    SEQ_NUM(VALUE.INTEGER, "Sequence number"),
+
     /**
      * SIM focus pos (mm)
      */
-    SIM_X("SIM focus pos (mm)"),
+    SIM_X(VALUE.REAL, "[mm] SIM focus pos"),
+
     /**
      * SIM orthogonal axis pos (mm)
      */
-    SIM_Y("SIM orthogonal axis pos (mm)"),
+    SIM_Y(VALUE.REAL, "[mm] SIM orthogonal axis pos"),
+
     /**
      * SIM translation stage pos (mm)
      */
-    SIM_Z("SIM translation stage pos (mm)"),
+    SIM_Z(VALUE.REAL, "[mm] SIM translation stage pos"),
+
     /**
      * Major frame count at start
      */
-    STARTMJF("Major frame count at start"),
+    STARTMJF(VALUE.INTEGER, "Major frame count at start"),
+
     /**
      * Minor frame count at start
      */
-    STARTMNF("Minor frame count at start"),
+    STARTMNF(VALUE.INTEGER, "Minor frame count at start"),
+
     /**
      * On-Board MET close to STARTMJF and STARTMNF
      */
-    STARTOBT("On-Board MET close to STARTMJF and STARTMNF"),
+    STARTOBT(VALUE.INTEGER, "On-Board MET close to STARTMJF and STARTMNF"),
+
     /**
      * Major frame count at stop
      */
-    STOPMJF("Major frame count at stop"),
+    STOPMJF(VALUE.INTEGER, "Major frame count at stop"),
+
     /**
      * Minor frame count at stop
      */
-    STOPMNF("Minor frame count at stop"),
+    STOPMNF(VALUE.INTEGER, "Minor frame count at stop"),
+
     /**
-     * Absolute precision of clock correction
+     * Absolute timing error.
      */
-    TIERABSO("Absolute precision of clock correction"),
+    TIERABSO(VALUE.REAL, "[s] absolute timing error"),
+
     /**
-     * Short-term clock stability
+     * Clock rate error
      */
-    TIERRELA("Short-term clock stability"),
+    TIERRELA(VALUE.REAL, "[s/s] clock rate error"),
 
     /**
      * Time stamp reference as bin fraction
      */
-    TIMEPIXR("Time stamp reference as bin fraction"),
+    TIMEPIXR(VALUE.REAL, "[bin] Time stamp reference"),
 
     /**
      * Telemetry revision number (IP&amp;CL)
      */
-    TLMVER("Telemetry revision number (IP&CL)"),
+    TLMVER(VALUE.STRING, "Telemetry revision number (IP&CL)"),
+
     /**
-     * As in the "TIME" column: raw space craft clock;
+     * The value field of this keyword shall contain the value of the start time of data acquisition in units of
+     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
+     * keyword.
      */
-    TSTART("As in the \"TIME\" column: raw space craft clock;"),
+    TSTART(VALUE.REAL, "start time of observation"),
+
     /**
-     * add TIMEZERO and MJDREF for absolute TT
+     * The value field of this keyword shall contain the value of the stop time of data acquisition in units of
+     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
+     * keyword.
      */
-    TSTOP("add TIMEZERO and MJDREF for absolute TT");
+    TSTOP(VALUE.REAL, "start time of observation");
 
     private final FitsKey key;
 
-    CXCExt(String comment) {
-        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
+    CXCExt(VALUE valueType, String comment) {
+        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/CXCExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCExt.java
@@ -315,28 +315,28 @@ public enum CXCExt implements IFitsHeader {
      * 
      * @since 1.20.1
      */
-    CNAMEn(VALUE.STRING, "coordinate axis name"),
+    CNAMEn(VALUE.STRING, HDU.IMAGE, "coordinate axis name"),
 
     /**
      * List of 'preferred cols' for making image from table
      * 
      * @since 1.20.1
      */
-    CPREF(VALUE.STRING, "list of image columns"),
+    CPREF(VALUE.STRING, HDU.TABLE, "list of image columns"),
 
     /**
      * Data Subspace column name for column <i>n</i>.
      * 
      * @since 1.20.1
      */
-    DSTYPn(VALUE.STRING, "data subspace column name"),
+    DSTYPn(VALUE.STRING, HDU.TABLE, "data subspace column name"),
 
     /**
      * Data Subspace data type name (optional) for column <i>n</i>.
      * 
      * @since 1.20.1
      */
-    DSFORMn(VALUE.STRING, "data subspace data type"),
+    DSFORMn(VALUE.STRING, HDU.TABLE, "data subspace data type"),
 
     /**
      * Data Subspace unit name (optional) for column <i>n</i>.
@@ -350,7 +350,7 @@ public enum CXCExt implements IFitsHeader {
      * 
      * @since 1.20.1
      */
-    DSVALn(VALUE.STRING, "data subspace filter list"),
+    DSVALn(VALUE.STRING, HDU.TABLE, "data subspace filter list"),
 
     /**
      * Data Subspace filter list for component <i>i</i> (leading index) and column <i>n</i> (trailing index).
@@ -359,14 +359,14 @@ public enum CXCExt implements IFitsHeader {
      * 
      * @see   #DSVALn
      */
-    nDSVALn(VALUE.STRING, "data subspace filter list for component"),
+    nDSVALn(VALUE.STRING, HDU.TABLE, "data subspace filter list for component"),
 
     /**
      * Data Subspace table pointer for column <i>n</i>.
      * 
      * @since 1.20.1
      */
-    DSREFn(VALUE.STRING, "data subspace table pointer"),
+    DSREFn(VALUE.STRING, HDU.TABLE, "data subspace table pointer"),
 
     /**
      * Data Subspace table pointer for component <i>i</i> (leading index) and column <i>n</i> (trailing index).
@@ -375,7 +375,7 @@ public enum CXCExt implements IFitsHeader {
      * 
      * @see   #DSVALn
      */
-    nDSREFn(VALUE.STRING, "data subspace table pointer for component"),
+    nDSREFn(VALUE.STRING, HDU.TABLE, "data subspace table pointer for component"),
 
     /**
      * Name for composite long-named keyword (f. CFITSIO HIERARCH) for column <i>n</i>. Also used to de ne array
@@ -397,7 +397,7 @@ public enum CXCExt implements IFitsHeader {
      * 
      * @since 1.20.1
      */
-    DVALn(VALUE.ANY, "composite keyword value"),
+    DVALn(VALUE.ANY, HDU.TABLE, "composite keyword value"),
 
     /**
      * Gives a name to an HDU. If not present, you should use EXTNAME/EXTVER.
@@ -411,42 +411,42 @@ public enum CXCExt implements IFitsHeader {
      * 
      * @since 1.20.1
      */
-    METYPn(VALUE.STRING, "composite column type"),
+    METYPn(VALUE.STRING, HDU.TABLE, "composite column type"),
 
     /**
      * Comma-separated list of column names making up composite col (with {@link #MTYPEn}).
      * 
      * @since 1.20.1
      */
-    MFORMn(VALUE.STRING, "column names for composite column"),
+    MFORMn(VALUE.STRING, HDU.TABLE, "column names for composite column"),
 
     /**
      * Composite column name (paired with {@link #MFORMn}).
      * 
      * @since 1.20.1
      */
-    MTYPEn(VALUE.STRING, "composite column name"),
+    MTYPEn(VALUE.STRING, HDU.TABLE, "composite column name"),
 
     /**
      * Override {@link nom.tam.fits.header.WCS#TCTYPn} table oordinate axis name.
      * 
      * @since 1.20.1
      */
-    TCNAMn(VALUE.STRING, "column coordinate axis name"),
+    TCNAMn(VALUE.STRING, HDU.TABLE, "column coordinate axis name"),
 
     /**
      * Default binning factor for table column
      * 
      * @since 1.20.1
      */
-    TDBINn(VALUE.REAL, "Default binning factor for table column"),
+    TDBINn(VALUE.REAL, HDU.TABLE, "Default binning factor for table column"),
 
     /**
      * Floating point <code>null</code> value other than NaN
      * 
      * @since 1.20.1
      */
-    TDNULLn(VALUE.REAL, "designated null value");
+    TDNULLn(VALUE.REAL, HDU.TABLE, "designated null value");
 
     /**
      * Standard {@link #DATACLAS} value 'observed'.
@@ -518,7 +518,11 @@ public enum CXCExt implements IFitsHeader {
     }
 
     CXCExt(VALUE valueType, String comment) {
-        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, valueType, comment);
+        this(valueType, HDU.ANY, comment);
+    }
+
+    CXCExt(VALUE valueType, HDU hduType, String comment) {
+        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, hduType, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -35,17 +35,17 @@ import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
- * This is the file represents the common keywords between CXC and STSclExt. See the ASC keywords at
+ * This is the file represents the common keywords between CXC and STSclExt. See e.g. the ASC keywords at
  * <a href="https://planet4589.org/astro/sds/asc/ps/SDS05.pdf">https://planet4589.org/astro/sds/asc/ps/SDS05.pdf</a> for
  * defititions of these. .
- *
- * @author     Richard van Nieuwenhoven and Attila Kovacs
  * 
  * @deprecated These are available both in the {@link CXCExt} and {@link STScIExt} enums. Visibility may be reduced to
  *                 the package level in the future.
  * 
  * @see        STScIExt
  * @see        CXCExt
+ * 
+ * @author     Attila Kovacs and Richard van Nieuwenhoven
  */
 public enum CXCStclSharedExt implements IFitsHeader {
 

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -39,10 +39,13 @@ import nom.tam.fits.header.IFitsHeader;
  * <a href="https://planet4589.org/astro/sds/asc/ps/SDS05.pdf">https://planet4589.org/astro/sds/asc/ps/SDS05.pdf</a> for
  * defititions of these. .
  *
- * @author Richard van Nieuwenhoven and Attila Kovacs
+ * @author     Richard van Nieuwenhoven and Attila Kovacs
  * 
- * @see    STScIExt
- * @see    CXCExt
+ * @deprecated These are available both in the {@link CXCExt} and {@link STScIExt} enums. Visibility may be reduced to
+ *                 the package level in the future.
+ * 
+ * @see        STScIExt
+ * @see        CXCExt
  */
 public enum CXCStclSharedExt implements IFitsHeader {
 
@@ -52,7 +55,7 @@ public enum CXCStclSharedExt implements IFitsHeader {
      * T
      * </p>
      */
-    CLOCKAPP(VALUE.LOGICAL, "Whether clock correction applied"),
+    CLOCKAPP(VALUE.LOGICAL, "is clock correction applied?"),
 
     /**
      * Reference MJD (TT-based), relative to which time values (e.g. TSTART and TSTOP) are measured.
@@ -77,12 +80,12 @@ public enum CXCStclSharedExt implements IFitsHeader {
      * their usage for ground-based observations. TASSIGN has obviously no meaning when TIMESYS = 'TDB'.
      * </p>
      */
-    TASSIGN(VALUE.STRING, "Source of time measurement"),
+    TASSIGN(VALUE.STRING, "location where time was assigned"),
 
     /**
      * Time resolution of data in {@link #TIMEUNIT}.
      */
-    TIMEDEL(VALUE.REAL, "Time resolution of data"),
+    TIMEDEL(VALUE.REAL, "time resolution of data"),
 
     /**
      * Time reference frame.
@@ -92,12 +95,12 @@ public enum CXCStclSharedExt implements IFitsHeader {
      * @see #TIMEREF_HELIOCENTRIC
      * @see #TIMEREF_SOLARSYSTEM
      */
-    TIMEREF(VALUE.STRING, "Time reference frame"),
+    TIMEREF(VALUE.STRING, "time reference frame"),
 
     /**
      * Units of time, for example 's' for seconds. If absent, assume seconds.
      */
-    TIMEUNIT(VALUE.STRING, "Units of time"),
+    TIMEUNIT(VALUE.STRING, "units of time"),
 
     /**
      * Version of time specification convention.
@@ -107,7 +110,7 @@ public enum CXCStclSharedExt implements IFitsHeader {
     /**
      * Clock correction (if not zero), in {@link #TIMEUNIT}.
      */
-    TIMEZERO(VALUE.REAL, "Clock offset"),
+    TIMEZERO(VALUE.REAL, "clock offset"),
 
     /**
      * The value field of this keyword shall contain the value of the start time of data acquisition in units of

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -35,62 +35,127 @@ import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
- * This is the file represents the common keywords between CXC and STSclExt
+ * This is the file represents the common keywords between CXC and STSclExt. See the ASC keywords at
+ * <a href="https://planet4589.org/astro/sds/asc/ps/SDS05.pdf">https://planet4589.org/astro/sds/asc/ps/SDS05.pdf</a> for
+ * defititions of these. .
  *
- * @author     Richard van Nieuwenhoven
+ * @author Richard van Nieuwenhoven and Attila Kovacs
  * 
- * @deprecated This enum is duplicated by both {@link CXCExt} and {@link STScIExt}, and users would (should) typically
- *                 use one or the other.
+ * @see    STScIExt
+ * @see    CXCExt
  */
 public enum CXCStclSharedExt implements IFitsHeader {
+
     /**
-     * Clock correction applied
+     * Whether clock correction applied (boolean).
      * <p>
      * T
      * </p>
      */
-    CLOCKAPP("Clock correction applied"),
+    CLOCKAPP(VALUE.LOGICAL, "Whether clock correction applied"),
+
     /**
-     * 1998-01-01T00:00:00 (TT) expressed in MJD (TT)
+     * Reference MJD (TT-based), relative to which time values (e.g. TSTART and TSTOP) are measured.
      */
-    MJDREF("1998-01-01T00:00:00 (TT) expressed in MJD"),
+    MJDREF(VALUE.STRING, "[day] MJD reference date"),
+
     /**
-     * Spacecraft clock
+     * <p>
+     * Specifies where the time assignment of the data is done. for example, for EXOSAT time assignment was made at the
+     * Madrid tracking station, so TASSIGN ='Madrid'. Since the document goes on to state that this information is
+     * relevant for barycentric corrections, one assumes that this means what is of interest is not the location of the
+     * computer where time tags where inserted into the telemetry stream, but whether those time tags refer to the
+     * actual photon arrival time or to the time at which the telemetry reached the ground station, etc.
+     * </p>
+     * <p>
+     * For example, for Einstein the time assignment was performed at the ground station but corrected to allow for the
+     * transmission time between satellite and ground, so I presume in this case TASSIGN='SATELLITE'. I believe that for
+     * AXAF, TASSIGN = 'SATELLITE'. OGIP/93-003 also speci es the location for the case of a ground station should be
+     * recorded the keywords GEOLAT, GEOLONG, and ALTITUDE. This is rather unfortunate since it would be nice to reserve
+     * these keywords for the satellite ephemeris position. However, since no ground station is de ned for AXAF, we feel
+     * that we can use GEOLONG, GEOLAT, and ALTITUDE for these purposes, especially since such usage is consistent with
+     * their usage for ground-based observations. TASSIGN has obviously no meaning when TIMESYS = 'TDB'.
+     * </p>
      */
-    TASSIGN("Spacecraft clock"),
+    TASSIGN(VALUE.STRING, "Source of time measurement"),
+
     /**
-     * Time resolution of data (in seconds)
+     * Time resolution of data in {@link #TIMEUNIT}.
      */
-    TIMEDEL("Time resolution of data (in seconds)"),
+    TIMEDEL(VALUE.REAL, "Time resolution of data"),
+
     /**
-     * No pathlength corrections
+     * Time reference frame.
+     * 
+     * @see #TIMEREF_LOCAL
+     * @see #TIMEREF_GEOCENTRIC
+     * @see #TIMEREF_HELIOCENTRIC
+     * @see #TIMEREF_SOLARSYSTEM
      */
-    TIMEREF("No pathlength corrections"),
+    TIMEREF(VALUE.STRING, "Time reference frame"),
+
     /**
-     * Units of time e.g. 's'
+     * Units of time, for example 's' for seconds. If absent, assume seconds.
      */
-    TIMEUNIT("Units of time "),
+    TIMEUNIT(VALUE.STRING, "Units of time"),
+
     /**
-     * AXAF FITS design document
+     * Version of time specification convention.
      */
-    TIMVERSN("AXAF FITS design document"),
+    TIMVERSN(VALUE.STRING, ""),
+
     /**
-     * Clock correction (if not zero)
+     * Clock correction (if not zero), in {@link #TIMEUNIT}.
      */
-    TIMEZERO("Clock correction (if not zero)"),
+    TIMEZERO(VALUE.REAL, "Clock offset"),
+
     /**
-     * As in the "TIME" column: raw space craft clock;
+     * The value field of this keyword shall contain the value of the start time of data acquisition in units of
+     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
+     * keyword.
      */
-    TSTART("As in the \"TIME\" column: raw space craft clock;"),
+    TSTART(VALUE.REAL, "start time of observartion"),
+
     /**
-     * add TIMEZERO and MJDREF for absolute TT
+     * The value field of this keyword shall contain the value of the stop time of data acquisition in units of
+     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
+     * keyword.
      */
-    TSTOP("add TIMEZERO and MJDREF for absolute TT");
+    TSTOP(VALUE.REAL, "stop time of observation");
+
+    /**
+     * Time is reported when detected wavefront passed the center of Earth, a standard value for {@link #TIMEREF}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_GEOCENTRIC = "GEOCENTRIC";
+
+    /**
+     * Time is reported when detected wavefront passed the center of the Sun, a standard value for {@link #TIMEREF}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_HELIOCENTRIC = "HELIOCENTRIC";
+
+    /**
+     * Time is reported when detected wavefront passed the Solar System barycenter, a standard value for
+     * {@link #TIMEREF}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_SOLARSYSTEM = "SOLARSYSTEM";
+
+    /**
+     * Time reported is actual time of detection, a standard value for {@link #TIMEREF}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_LOCAL = "LOCAL";
 
     private final FitsKey key;
 
-    CXCStclSharedExt(String comment) {
-        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
+    CXCStclSharedExt(VALUE valueType, String comment) {
+        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CXCStclSharedExt.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.header.extra;
 
+import nom.tam.fits.header.DateTime;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -39,8 +41,8 @@ import nom.tam.fits.header.IFitsHeader;
  * <a href="https://planet4589.org/astro/sds/asc/ps/SDS05.pdf">https://planet4589.org/astro/sds/asc/ps/SDS05.pdf</a> for
  * defititions of these. .
  * 
- * @deprecated These are available both in the {@link CXCExt} and {@link STScIExt} enums. Visibility may be reduced to
- *                 the package level in the future.
+ * @deprecated These are available both in the {@link CXCExt} and {@link STScIExt} enums. This class may be removed in
+ *                 the future.
  * 
  * @see        STScIExt
  * @see        CXCExt
@@ -50,115 +52,59 @@ import nom.tam.fits.header.IFitsHeader;
 public enum CXCStclSharedExt implements IFitsHeader {
 
     /**
-     * Whether clock correction applied (boolean).
-     * <p>
-     * T
-     * </p>
+     * Same as {@link STScIExt#CLOCKAPP}.
      */
-    CLOCKAPP(VALUE.LOGICAL, "is clock correction applied?"),
+    CLOCKAPP(STScIExt.CLOCKAPP),
 
     /**
-     * Reference MJD (TT-based), relative to which time values (e.g. TSTART and TSTOP) are measured.
+     * Same as {@link STScIExt#MJDREF}.
      */
-    MJDREF(VALUE.STRING, "[day] MJD reference date"),
+    MJDREF(STScIExt.MJDREF),
 
     /**
-     * <p>
-     * Specifies where the time assignment of the data is done. for example, for EXOSAT time assignment was made at the
-     * Madrid tracking station, so TASSIGN ='Madrid'. Since the document goes on to state that this information is
-     * relevant for barycentric corrections, one assumes that this means what is of interest is not the location of the
-     * computer where time tags where inserted into the telemetry stream, but whether those time tags refer to the
-     * actual photon arrival time or to the time at which the telemetry reached the ground station, etc.
-     * </p>
-     * <p>
-     * For example, for Einstein the time assignment was performed at the ground station but corrected to allow for the
-     * transmission time between satellite and ground, so I presume in this case TASSIGN='SATELLITE'. I believe that for
-     * AXAF, TASSIGN = 'SATELLITE'. OGIP/93-003 also speci es the location for the case of a ground station should be
-     * recorded the keywords GEOLAT, GEOLONG, and ALTITUDE. This is rather unfortunate since it would be nice to reserve
-     * these keywords for the satellite ephemeris position. However, since no ground station is de ned for AXAF, we feel
-     * that we can use GEOLONG, GEOLAT, and ALTITUDE for these purposes, especially since such usage is consistent with
-     * their usage for ground-based observations. TASSIGN has obviously no meaning when TIMESYS = 'TDB'.
-     * </p>
+     * Same as {@link STScIExt#TASSIGN}.
      */
-    TASSIGN(VALUE.STRING, "location where time was assigned"),
+    TASSIGN(STScIExt.TASSIGN),
 
     /**
-     * Time resolution of data in {@link #TIMEUNIT}.
+     * Same as {@link DateTime#TIMEDEL}.
      */
-    TIMEDEL(VALUE.REAL, "time resolution of data"),
+    TIMEDEL(DateTime.TIMEDEL),
 
     /**
-     * Time reference frame.
-     * 
-     * @see #TIMEREF_LOCAL
-     * @see #TIMEREF_GEOCENTRIC
-     * @see #TIMEREF_HELIOCENTRIC
-     * @see #TIMEREF_SOLARSYSTEM
+     * Same as {@link STScIExt#TIMEREF}.
      */
-    TIMEREF(VALUE.STRING, "time reference frame"),
+    TIMEREF(STScIExt.TIMEREF),
 
     /**
-     * Units of time, for example 's' for seconds. If absent, assume seconds.
+     * Same as {@link STScIExt#TIMEUNIT}.
      */
-    TIMEUNIT(VALUE.STRING, "units of time"),
+    TIMEUNIT(STScIExt.TIMEUNIT),
 
     /**
-     * Version of time specification convention.
+     * Same as {@link STScIExt#TIMVERSN}.
      */
-    TIMVERSN(VALUE.STRING, ""),
+    TIMVERSN(STScIExt.TIMVERSN),
 
     /**
-     * Clock correction (if not zero), in {@link #TIMEUNIT}.
+     * Same as {@link STScIExt#TIMEZERO}.
      */
-    TIMEZERO(VALUE.REAL, "clock offset"),
+    TIMEZERO(STScIExt.TIMEZERO),
 
     /**
-     * The value field of this keyword shall contain the value of the start time of data acquisition in units of
-     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
-     * keyword.
+     * Same as {@link STScIExt#TSTART}.
      */
-    TSTART(VALUE.REAL, "start time of observartion"),
+    TSTART(STScIExt.TSTART),
 
     /**
-     * The value field of this keyword shall contain the value of the stop time of data acquisition in units of
-     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
-     * keyword.
+     * Same as {@link CXCStclSharedExt#TSTOP}.
      */
-    TSTOP(VALUE.REAL, "stop time of observation");
-
-    /**
-     * Time is reported when detected wavefront passed the center of Earth, a standard value for {@link #TIMEREF}.
-     * 
-     * @since 1.20.1
-     */
-    public static final String TIMEREF_GEOCENTRIC = "GEOCENTRIC";
-
-    /**
-     * Time is reported when detected wavefront passed the center of the Sun, a standard value for {@link #TIMEREF}.
-     * 
-     * @since 1.20.1
-     */
-    public static final String TIMEREF_HELIOCENTRIC = "HELIOCENTRIC";
-
-    /**
-     * Time is reported when detected wavefront passed the Solar System barycenter, a standard value for
-     * {@link #TIMEREF}.
-     * 
-     * @since 1.20.1
-     */
-    public static final String TIMEREF_SOLARSYSTEM = "SOLARSYSTEM";
-
-    /**
-     * Time reported is actual time of detection, a standard value for {@link #TIMEREF}.
-     * 
-     * @since 1.20.1
-     */
-    public static final String TIMEREF_LOCAL = "LOCAL";
+    TSTOP(STScIExt.TSTOP);
 
     private final FitsKey key;
 
-    CXCStclSharedExt(VALUE valueType, String comment) {
-        key = new FitsKey(name(), IFitsHeader.SOURCE.CXC, HDU.ANY, valueType, comment);
+    CXCStclSharedExt(IFitsHeader orig) {
+        key = orig.impl();
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -92,7 +92,7 @@ public enum CommonExt implements IFitsHeader {
      */
     DATA_MODE(VALUE.STRING, SOURCE.HEASARC, "pre-processor data mode"),
 
-    /** Local time of observation (ISO timestamp), e..g "2017-01-03T02:41:24" or "2024-02-24T22:23:33.054" */
+    /** Local time of observation (ISO timestamp), e.g. "2017-01-03T02:41:24" or "2024-02-24T22:23:33.054" */
     DATE_LOC("DATE-LOC", VALUE.STRING, "Local time of observation"),
 
     /**
@@ -220,7 +220,7 @@ public enum CommonExt implements IFitsHeader {
 
     /**
      * Camera gain / amplification. Often used the same as {@link #GAINRAW}. There may be many different conventions on
-     * using this keyword. For example itmay represent a multiplicative gain factor or gain defined as decibels, or
+     * using this keyword. For example it may represent a multiplicative gain factor or gain defined as decibels, or
      * strings such as 'HI'/'LO', or even as a boolean T/F. Therefore, this definition does not restrict the type of
      * value this keyword can be used with. It is up to the user to ensure they follow the convention that makes most
      * sense to their application, and for the tools they intend to use.

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -47,26 +47,11 @@ import nom.tam.fits.header.IFitsHeader;
  */
 public enum CommonExt implements IFitsHeader {
 
-    /**
-     * The value field shall contain a floating point number giving the air mass during the observation by a ground
-     * based telescope. The value of the airmass is often approximated by the secant of the elevation angle and has a
-     * value of 1.0 at the zenith and increases towards the horizon. This value is assumed to correspond to the start of
-     * the observation unless another interpretation is clearly explained in the comment field.
-     */
-    AIRMASS(VALUE.REAL, SOURCE.NOAO, "air mass in line of sight"),
-
     /** Ambient air temperature in degrees Celsius */
     AMBTEMP(VALUE.REAL, "[C] ambient air temperature"),
 
     /** Synonym of {@link #OBJCTROT}. */
     ANGLE(VALUE.REAL, "[deg] image rotation angle"),
-
-    /**
-     * The value field shall contain a character string which gives the name of the instrumental aperture though which
-     * the observation was made. This keyword is typically used in instruments which have a selection of apertures which
-     * restrict the field of view of the detector.
-     */
-    APERTURE(VALUE.STRING, SOURCE.HEASARC, "name of field of view aperture"),
 
     /** X axis binning factor. Synonym for {@link SBFitsExt#XBINNING} */
     CCDXBIN(VALUE.INTEGER, "X axis binning factor"),
@@ -77,125 +62,11 @@ public enum CommonExt implements IFitsHeader {
     /** Cloud cover as percentage */
     CLOUDCVR(VALUE.REAL, "[%] cloud cover"),
 
-    /**
-     * The value field shall contain a character string that uniquely defines the configuration state, or version, of
-     * the the software processing system that generated the data contained in the HDU. This keyword differs from the
-     * CREATOR keyword in that it give the name and version of the overall processing system and not just the name and
-     * version of a single program.
-     */
-    CONFIGUR(VALUE.STRING, SOURCE.HEASARC, "processing software configuration"),
-
-    /**
-     * The value field shall contain a character string which identifies the configuration or mode of the pre-processing
-     * software that operated on the raw instrumental data to generate the data that is recorded in the FITS file.
-     * Example: some X-ray satellite data may be recorded in 'BRIGHT', 'FAINT', or 'FAST' data mode.
-     */
-    DATA_MODE(VALUE.STRING, SOURCE.HEASARC, "pre-processor data mode"),
-
     /** Local time of observation (ISO timestamp), e.g. "2017-01-03T02:41:24" or "2024-02-24T22:23:33.054" */
     DATE_LOC("DATE-LOC", VALUE.STRING, "Local time of observation"),
 
-    /**
-     * The value field gives the declination of the observation. It may be expressed either as a floating point number
-     * in units of decimal degrees, or as a character string in 'dd:mm:ss.sss' format where the decimal point and number
-     * of fractional digits are optional. The coordinate reference frame is given by the RADECSYS keyword, and the
-     * coordinate epoch is given by the EQUINOX keyword. Example: -47.25944 or '-47:15:34.00'.
-     */
-    DEC(VALUE.ANY, SOURCE.NOAO, "declination"),
-
-    /**
-     * The value field shall contain a floating point number giving the nominal declination of the pointing direction in
-     * units of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate
-     * epoch is given by the EQUINOX keyword. The precise definition of this keyword is instrument-specific, but
-     * typically the nominal direction corresponds to the direction to which the instrument was requested to point. The
-     * DEC_PNT keyword should be used to give the actual pointed direction.
-     */
-    DEC_NOM(VALUE.REAL, SOURCE.HEASARC, "[deg] nominal declination of the observation"),
-
-    /**
-     * The value field shall contain a floating point number giving the declination of the observed object in units of
-     * decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate epoch is
-     * given by the EQUINOX keyword.
-     */
-    DEC_OBJ(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of observed object"),
-
-    /**
-     * The value field shall contain a floating point number giving the declination of the pointing direction in units
-     * of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate epoch is
-     * given by the EQUINOX keyword. The precise definition of this keyword is instrument-specific, but typically the
-     * pointed direction corresponds to the optical axis of the instrument. This keyword gives a mean value in cases
-     * where the pointing axis was not fixed during the entire observation.
-     */
-    DEC_PNT(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of the pointed direction"),
-
-    /**
-     * The value field shall contain a floating point number giving the declination of the space craft (or telescope
-     * platform) X axis during the observation in decimal degrees. The coordinate reference frame is given by the
-     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
-     * cases where the axis was not fixed during the entire observation.
-     */
-    DEC_SCX(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of the X spacecraft axis"),
-
-    /**
-     * The value field shall contain a floating point number giving the declination of the space craft (or telescope
-     * platform) Y axis during the observation in decimal degrees. The coordinate reference frame is given by the
-     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
-     * cases where the axis was not fixed during the entire observation.
-     */
-    DEC_SCY(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of the Y spacecraft axis"),
-
-    /**
-     * The value field shall contain a floating point number giving the declination of the space craft (or telescope
-     * platform) Z axis during the observation in decimal degrees. The coordinate reference frame is given by the
-     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
-     * cases where the axis was not fixed during the entire observation.
-     */
-    DEC_SCZ(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of the Z spacecraft axis"),
-
-    /**
-     * The value field shall contain a character string giving the name of the detector within the instrument that was
-     * used to make the observation. Example: 'CCD1'
-     */
-    DETNAM(VALUE.STRING, SOURCE.HEASARC, "detector used"),
-
     /** Dew point in degrees Celsius. */
     DEWPOINT(VALUE.REAL, "[C] dew point"),
-
-    /**
-     * The value field shall contain a floating point number giving the difference between the stop and start times of
-     * the observation in units of seconds. This keyword is synonymous with the {@link #TELAPSE} keyword.
-     */
-    ELAPTIME(VALUE.REAL, SOURCE.UCOLICK, "elapsed time of the observation"),
-
-    /**
-     * The value field shall contain a character string giving the the host file name used to record the original data.
-     */
-    FILENAME(VALUE.STRING, SOURCE.NOAO, "original file name"),
-
-    /**
-     * The value field shall contain a character string giving the file type suffix of the host file name. The full file
-     * name typically consists of the root name (see ROOTNAME) followed by a file type suffix, separated by the period
-     * ('.') character.
-     */
-    FILETYPE(VALUE.REAL, "file type"),
-
-    /**
-     * The value field shall contain a character string which gives the name of the filter that was used during the
-     * observation to select or modify the radiation that was transmitted to the detector. More than 1 filter may be
-     * listed by using the FILTERn indexed keyword. The value 'none' or 'NONE' indicates that no filter was used.
-     * 
-     * @see #FILTER_NONE
-     */
-    FILTER(VALUE.STRING, SOURCE.HEASARC, "filter name/ID"),
-
-    /**
-     * The value field of this indexed keyword shall contain a character string which gives the name of one of multiple
-     * filters that were used during the observation to select or modify the radiation that was transmitted to the
-     * detector. The value 'none' or 'NONE' indicates that no filter was used.
-     * 
-     * @see #FILTER_NONE
-     */
-    FILTERn(VALUE.STRING, SOURCE.HEASARC, "filter name/ID n"),
 
     /** Whether or not the image is flipped */
     FLIPPED(VALUE.LOGICAL, "is image flipped"),
@@ -233,84 +104,14 @@ public enum CommonExt implements IFitsHeader {
     /** Amplifier gain. Synonym of {@link MaxImDLExt#ISOSPEED} */
     GAINRAW(VALUE.REAL, "gain factor"),
 
-    /**
-     * The value field shall contain a character string which gives the name of the defraction grating that was used
-     * during the observation. More than 1 grating may be listed by using the GRATINGn indexed keyword. The value 'none'
-     * or 'NONE' indicates that no grating was used.
-     * 
-     * @see #GRATING_NONE
-     */
-    GRATING(VALUE.STRING, SOURCE.HEASARC, "grating name/ID"),
-
-    /**
-     * name of gratings used during the observation. DEFINITION: The value field of this indexed keyword shall contain a
-     * character string which gives the name of one of multiple defraction gratings that were used during the
-     * observation. The value 'none' or 'NONE' indicates that no grating was used.
-     * 
-     * @see #GRATING_NONE
-     */
-    GRATINGn(VALUE.STRING, SOURCE.HEASARC, "grating name/ID n"),
-
     /** Relative humidity as percentage */
     HUMIDITY(VALUE.REAL, "[%] relative humidity"),
-
-    /**
-     * The value field shall contain a floating point number giving the geographic latitude from which the observation
-     * was made in units of degrees.
-     */
-    LATITUDE(VALUE.REAL, SOURCE.UCOLICK, "[deg] geographic latitude"),
-
-    /**
-     * The value field shall contain a floating point number giving the angle between the direction of the observation
-     * (e.g., the optical axis of the telescope or the position of the target) and the moon, measured in degrees.
-     */
-    MOONANGL(VALUE.REAL, SOURCE.STScI, "[deg] angular distance to Moon"),
-
-    /**
-     * The value field shall contain an integer giving the number of standard extensions contained in the FITS file.
-     * This keyword may only be used in the primary array header.
-     */
-    NEXTEND(VALUE.INTEGER, SOURCE.STScI, HDU.PRIMARY, "number of extensions contained"),
 
     /** Image rotation angle in degrees. **/
     OBJCTROT(VALUE.REAL, "[deg] image rotation angle"),
 
-    /**
-     * The value field shall contain a character string which uniquely identifies the dataset contained in the FITS
-     * file. This is typically a sequence number that can contain a mixture of numerical and character values. Example:
-     * '10315-01-01-30A'
-     */
-    OBS_ID(VALUE.STRING, SOURCE.HEASARC, "observation ID"),
-
-    /**
-     * The value field shall contain a character string which gives the observing mode of the observation. This is used
-     * in cases where the instrument or detector can be configured to operate in different modes which significantly
-     * affect the resulting data. Examples: 'SLEW', 'RASTER', or 'POINTING'
-     */
-    OBS_MODE(VALUE.STRING, SOURCE.HEASARC, "observation mode"),
-
     /** Camera offset setting. Very common since CMOS cameras became popular */
     OFFSET(VALUE.INTEGER, "camera offset setting"),
-
-    /**
-     * The value field shall contain a floating point number giving the position angle of the y axis of the detector
-     * projected on the sky, in degrees east of north. This keyword is synonymous with the CROTA2 WCS keyword.
-     */
-    ORIENTAT(VALUE.REAL, SOURCE.STScI, "[deg] position angle of image y axis (E of N)"),
-
-    /**
-     * The value field shall contain a floating point number giving the position angle of the relevant aspect of
-     * telescope pointing axis and/or instrument on the sky in units of degrees east of north. It commonly applies to
-     * the orientation of a slit mask.
-     */
-    PA_PNT(VALUE.REAL, SOURCE.UCOLICK, "[deg] position angle of pointing (E of N)"),
-
-    /**
-     * The value field shall contain a character string giving the name, and optionally, the version of the program that
-     * originally created the current FITS HDU. This keyword is synonymous with the CREATOR keyword. Example: 'TASKNAME
-     * V1.2.3'
-     */
-    PROGRAM(VALUE.STRING, SOURCE.UCOLICK, "software that created original FITS file"),
 
     /**
      * Image scale in arcsec/pixel. Redundant with {@link nom.tam.fits.header.Standard#CDELTn}.
@@ -319,77 +120,6 @@ public enum CommonExt implements IFitsHeader {
 
     /** Air pressure in hPa. */
     PRESSURE(VALUE.REAL, "[hPa] air pressure"),
-
-    /**
-     * The value field gives the Right Ascension of the observation. It may be expressed either as a floating point
-     * number in units of decimal degrees, or as a character string in 'HH:MM:SS.sss' format where the decimal point and
-     * number of fractional digits are optional. The coordinate reference frame is given by the RADECSYS keyword, and
-     * the coordinate epoch is given by the EQUINOX keyword. Example: 180.6904 or '12:02:45.7'.
-     */
-    RA(VALUE.ANY, SOURCE.NOAO, "right ascension"),
-
-    /**
-     * The value field shall contain a floating point number giving\ the nominal Right Ascension of the pointing
-     * direction in units of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the
-     * coordinate epoch is given by the EQUINOX keyword. The precise definition of this keyword is instrument-specific,
-     * but typically the nominal direction corresponds to the direction to which the instrument was requested to point.
-     * The RA_PNT keyword should be used to give the actual pointed direction.
-     */
-    RA_NOM(VALUE.REAL, SOURCE.HEASARC, "[deg] nominal right ascension"),
-
-    /**
-     * The value field shall contain a floating point number giving\ the Right Ascension of the observed object in units
-     * of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate epoch is
-     * given by the EQUINOX keyword.
-     */
-    RA_OBJ(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of observed object"),
-
-    /**
-     * The value field shall contain a floating point number giving the Right Ascension of the pointing direction in
-     * units of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate
-     * epoch is given by the EQUINOX keyword. The precise definition of this keyword is instrument-specific, but
-     * typically the pointed direction corresponds to the optical axis of the instrument. This keyword gives a mean
-     * value in cases where the pointing axis was not fixed during the entire observation.
-     */
-    RA_PNT(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of pointing direction"),
-
-    /**
-     * The value field shall contain a floating point number giving the Right Ascension of the space craft (or telescope
-     * platform) X axis during the observation in decimal degrees. The coordinate reference frame is given by the
-     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
-     * cases where the axis was not fixed during the entire observation.
-     */
-    RA_SCX(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of the X spacecraft axis"),
-
-    /**
-     * The value field shall contain a floating point number giving the Right Ascension of the space craft (or telescope
-     * platform) Y axis during the observation in decimal degrees. The coordinate reference frame is given by the
-     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
-     * cases where the axis was not fixed during the entire observation.
-     */
-    RA_SCY(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of the Y spacecraft axis"),
-
-    /**
-     * The value field shall contain a floating point number giving the Right Ascension of the space craft (or telescope
-     * platform) Z axis during the observation in decimal degrees. The coordinate reference frame is given by the
-     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
-     * cases where the axis was not fixed during the entire observation.
-     */
-    RA_SCZ(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of the Z spacecraft axis"),
-
-    /**
-     * The value field shall contain a character string giving the root of the host file name. The full file name
-     * typically consists of the root name followed by a file type suffix (see FILETYPE), separated by the period ('.')
-     * character.
-     */
-    ROOTNAME(VALUE.STRING, "root of host file name"),
-
-    /**
-     * The value field shall contain an integer giving the data value at which the detector becomes saturated. This
-     * keyword value may differ from the maximum value implied by the BITPIX in that more bits may be allocated in the
-     * FITS pixel values than the detector can accommodate.
-     */
-    SATURATE(VALUE.INTEGER, SOURCE.STScI, ""),
 
     /**
      * Image scale in arcsec / pixel. Synonym of {@link #PIXSCALE}, and redundant with
@@ -403,58 +133,11 @@ public enum CommonExt implements IFitsHeader {
     /** Observatory site, e.g. "Maunakea" */
     SITENAME(VALUE.STRING, "observatory site"),
 
-    /**
-     * The value field shall contain a floating point number giving the angle between the direction of the observation
-     * (e.g., the optical axis of the telescope or the position of the target) and the sun, measured in degrees.
-     */
-    SUNANGLE(VALUE.REAL, SOURCE.STScI, "[deg] distance to Sun"),
-
-    /**
-     * The value field of this indexed keyword shall contain a floating point number specifying the suggested bin size
-     * when producing a histogram of the values in column n. This keyword is typically used in conjunction the TLMINn
-     * and TLMAXn keywords when constructing a histogram of the values in column n, such that the histogram ranges from
-     * TLMINn to TLMAXn with the histogram bin size given by TDBINn. This keyword may only be used in 'TABLE' or
-     * 'BINTABLE' extensions.
-     */
-    TDBINn(VALUE.REAL, SOURCE.CXC, "suggested column bin size"),
-
-    /**
-     * The value field shall contain a floating point number giving the difference between the stop and start times of
-     * the observation in units of seconds. This keyword is synonymous with the {@link #ELAPTIME} keyword.
-     */
-    TELAPSE(VALUE.REAL, SOURCE.HEASARC, "[s] elapsed time of observation"),
-
-    /**
-     * The value field shall contain a character string giving a title that is suitable for display purposes, e.g., for
-     * annotation on images or plots of the data contained in the HDU.
-     */
-    TITLE(VALUE.STRING, SOURCE.ROSAT, "display title"),
-
-    /**
-     * The value field shall contain a character string that defines the order in which the rows in the current FITS
-     * ASCII or binary table extension have been sorted. The character string lists the name (as given by the TTYPEn
-     * keyword) of the primary sort column, optionally followed by the names of any secondary sort column(s). The
-     * presence of this keyword indicates that the rows in the table have been sorted first by the values in the primary
-     * sort column; any rows that have the same value in the primary column have been further sorted by the values in
-     * the secondary sort column and so on for all the specified columns. If more than one column is specified by
-     * TSORTKEY then the names must be separated by a comma. One or more spaces are also allowed between the comma and
-     * the following column name. By default, columns are sorted in ascending order, but a minus sign may precede the
-     * column name to indicate that the rows are sorted in descending order. This keyword may only be used in 'TABLE' or
-     * 'BINTABLE' extensions. Example: TSORTKEY = 'TIME, RA, DEC'.
-     */
-    TSORTKEY(VALUE.STRING, SOURCE.HEASARC, "table sort order"),
-
     /** Wind direction clockwise from North [0:360] */
     WINDDIR(VALUE.REAL, "[deg] wind direction: 0=N, 90=E, 180=S, 270=W"),
 
     /** Average wind speed in km/h */
     WINDSPD(VALUE.REAL, "[km/h] wind speed");
-
-    /** Standard {@link #FILTER} name when no filter was used. */
-    public static final String FILTER_NONE = "NONE";
-
-    /** Standard {@link #GRATING} name when no filter was used. */
-    public static final String GRATING_NONE = "NONE";
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -141,24 +141,12 @@ public enum CommonExt implements IFitsHeader {
 
     private final FitsKey key;
 
-    CommonExt(IFitsHeader key) {
-        this.key = key.impl();
-    }
-
     CommonExt(VALUE valueType, String comment) {
         this(null, valueType, comment);
     }
 
-    CommonExt(VALUE valueType, SOURCE source, String comment) {
-        this(null, valueType, source, HDU.ANY, comment);
-    }
-
     CommonExt(String key, VALUE valueType, String comment) {
         this(key, valueType, SOURCE.UNKNOWN, HDU.ANY, comment);
-    }
-
-    CommonExt(VALUE valueType, SOURCE source, HDU hduType, String comment) {
-        this(null, valueType, source, hduType, comment);
     }
 
     CommonExt(String key, VALUE valueType, SOURCE source, HDU hduType, String comment) {

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -49,8 +49,8 @@ public enum CommonExt implements IFitsHeader {
     /** Ambient air temperature in degrees Celsius */
     AMBTEMP(VALUE.REAL, "[C] ambient air temperature"),
 
-    /** Image angle in degrees */
-    ANGLE(VALUE.REAL, "[deg] image angle"),
+    /** Synonym of {@link #ANGLE}. */
+    ANGLE(VALUE.REAL, "[deg] image rotation angle"),
 
     /** X axis binning factor. Synonym for {@link SBFitsExt#XBINNING} */
     CCDXBIN(VALUE.INTEGER, "X axis binning factor"),
@@ -100,14 +100,14 @@ public enum CommonExt implements IFitsHeader {
     /** Synonym of {@link MaxImDLExt#EGAIN} */
     GAINADU(VALUE.REAL, "[ct/adu] amplifier gain electrons / ADU"),
 
-    /** Amplifier gain. */
+    /** Amplifier gain. Synonym of {@link MaxImDLExt#ISOSPEED} */
     GAINRAW(VALUE.REAL, "gain factor"),
 
     /** Relative humidity as percentage */
     HUMIDITY(VALUE.REAL, "[%] relative humidity"),
 
-    /** Synonym of {@link #ANGLE}. **/
-    OBJCTROT(VALUE.REAL, "[deg] image angle"),
+    /** Image rotation angle in degrees. **/
+    OBJCTROT(VALUE.REAL, "[deg] image rotation angle"),
 
     /** Camera offset setting. Very common since CMOS cameras became popular */
     OFFSET(VALUE.INTEGER, "camera offset setting"),

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -36,9 +36,7 @@ import nom.tam.fits.header.IFitsHeader;
 
 /**
  * <p>
- * A Set of commonly used keywords in the astronomy community. Many of these are semi-officially recognised by HEASARC
- * and listed in the <a href="https://heasarc.gsfc.nasa.gov/docs/fcg/common_dict.html">Dictionary of Commonly Used FITS
- * Keywords</a>, while others are commonly used in the amateur astronomy community.
+ * A Set of commonly used keywords in the amateur astronomy community.
  * </p>
  *
  * @author John Murphy and Attila Kovacs
@@ -51,7 +49,7 @@ public enum CommonExt implements IFitsHeader {
     AMBTEMP(VALUE.REAL, "[C] ambient air temperature"),
 
     /** Synonym of {@link #OBJCTROT}. */
-    ANGLE(VALUE.REAL, "[deg] image rotation angle"),
+    ANGLE(VALUE.REAL, HDU.IMAGE, "[deg] image rotation angle"),
 
     /** X axis binning factor. Synonym for {@link SBFitsExt#XBINNING} */
     CCDXBIN(VALUE.INTEGER, "X axis binning factor"),
@@ -69,7 +67,7 @@ public enum CommonExt implements IFitsHeader {
     DEWPOINT(VALUE.REAL, "[C] dew point"),
 
     /** Whether or not the image is flipped */
-    FLIPPED(VALUE.LOGICAL, "is image flipped"),
+    FLIPPED(VALUE.LOGICAL, HDU.IMAGE, "is image flipped"),
 
     /** Name of focuser. Synonym of {@link #FOCUSER} */
     FOCNAME(VALUE.STRING, "focuser name"),
@@ -108,7 +106,7 @@ public enum CommonExt implements IFitsHeader {
     HUMIDITY(VALUE.REAL, "[%] relative humidity"),
 
     /** Image rotation angle in degrees. **/
-    OBJCTROT(VALUE.REAL, "[deg] image rotation angle"),
+    OBJCTROT(VALUE.REAL, HDU.IMAGE, "[deg] image rotation angle"),
 
     /** Camera offset setting. Very common since CMOS cameras became popular */
     OFFSET(VALUE.INTEGER, "camera offset setting"),
@@ -116,7 +114,7 @@ public enum CommonExt implements IFitsHeader {
     /**
      * Image scale in arcsec/pixel. Redundant with {@link nom.tam.fits.header.Standard#CDELTn}.
      */
-    PIXSCALE(VALUE.REAL, "[arcsec/pixel] image scale"),
+    PIXSCALE(VALUE.REAL, HDU.IMAGE, "[arcsec/pixel] image scale"),
 
     /** Air pressure in hPa. */
     PRESSURE(VALUE.REAL, "[hPa] air pressure"),
@@ -125,7 +123,7 @@ public enum CommonExt implements IFitsHeader {
      * Image scale in arcsec / pixel. Synonym of {@link #PIXSCALE}, and redundant with
      * {@link nom.tam.fits.header.Standard#CDELTn}.
      */
-    SCALE(VALUE.REAL, "[arcsec/pixel] image scale"),
+    SCALE(VALUE.REAL, HDU.IMAGE, "[arcsec/pixel] image scale"),
 
     /** Elevation of observing site above sea level in meters */
     SITEELEV(VALUE.REAL, "[m] elevation at observing site"),
@@ -145,12 +143,16 @@ public enum CommonExt implements IFitsHeader {
         this(null, valueType, comment);
     }
 
-    CommonExt(String key, VALUE valueType, String comment) {
-        this(key, valueType, SOURCE.UNKNOWN, HDU.ANY, comment);
+    CommonExt(VALUE valueType, HDU hduType, String comment) {
+        this(null, valueType, hduType, comment);
     }
 
-    CommonExt(String key, VALUE valueType, SOURCE source, HDU hduType, String comment) {
-        this.key = new FitsKey(key == null ? name() : key, source, hduType, valueType, comment);
+    CommonExt(String key, VALUE valueType, String comment) {
+        this(key, valueType, HDU.ANY, comment);
+    }
+
+    CommonExt(String key, VALUE valueType, HDU hduType, String comment) {
+        this.key = new FitsKey(key == null ? name() : key, SOURCE.UNKNOWN, hduType, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -84,8 +84,8 @@ public enum CommonExt implements IFitsHeader {
     /** Focus temperature in degrees Celsius. Synonymous to {@link MaxImDLExt#FOCUSTEM}. */
     FOCTEMP(VALUE.REAL, "[C] focuser temperature readout"),
 
-    /** Filter wheel position */
-    FWHEEL(VALUE.STRING, "filter wheel position"),
+    /** Filter wheel name */
+    FWHEEL(VALUE.STRING, "filter wheel name"),
 
     /**
      * Camera gain / amplification. Often used the same as {@link #GAINRAW}. There may be many different conventions on

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -36,8 +36,9 @@ import nom.tam.fits.header.IFitsHeader;
 
 /**
  * <p>
- * A Set of commonly used keywords in the astronomy community, such as for describing cameras used by amateur
- * astronomers.
+ * A Set of commonly used keywords in the astronomy community. Many of these are semi-officially recognised by HEASARC
+ * and listed in the <a href="https://heasarc.gsfc.nasa.gov/docs/fcg/common_dict.html">Dictionary of Commonly Used FITS
+ * Keywords</a>, while other are commonly used by amateur astronomers.
  * </p>
  *
  * @author John Murphy and Attila Kovacs
@@ -46,11 +47,26 @@ import nom.tam.fits.header.IFitsHeader;
  */
 public enum CommonExt implements IFitsHeader {
 
+    /**
+     * The value field shall contain a floating point number giving the air mass during the observation by a ground
+     * based telescope. The value of the airmass is often approximated by the secant of the elevation angle and has a
+     * value of 1.0 at the zenith and increases towards the horizon. This value is assumed to correspond to the start of
+     * the observation unless another interpretation is clearly explained in the comment field.
+     */
+    AIRMASS(VALUE.REAL, SOURCE.NOAO, "air mass in line of sight"),
+
     /** Ambient air temperature in degrees Celsius */
     AMBTEMP(VALUE.REAL, "[C] ambient air temperature"),
 
-    /** Synonym of {@link #ANGLE}. */
+    /** Synonym of {@link #OBJCTROT}. */
     ANGLE(VALUE.REAL, "[deg] image rotation angle"),
+
+    /**
+     * The value field shall contain a character string which gives the name of the instrumental aperture though which
+     * the observation was made. This keyword is typically used in instruments which have a selection of apertures which
+     * restrict the field of view of the detector.
+     */
+    APERTURE(VALUE.STRING, SOURCE.HEASARC, "name of field of view aperture"),
 
     /** X axis binning factor. Synonym for {@link SBFitsExt#XBINNING} */
     CCDXBIN(VALUE.INTEGER, "X axis binning factor"),
@@ -61,11 +77,125 @@ public enum CommonExt implements IFitsHeader {
     /** Cloud cover as percentage */
     CLOUDCVR(VALUE.REAL, "[%] cloud cover"),
 
+    /**
+     * The value field shall contain a character string that uniquely defines the configuration state, or version, of
+     * the the software processing system that generated the data contained in the HDU. This keyword differs from the
+     * CREATOR keyword in that it give the name and version of the overall processing system and not just the name and
+     * version of a single program.
+     */
+    CONFIGUR(VALUE.STRING, SOURCE.HEASARC, "processing software configuration"),
+
+    /**
+     * The value field shall contain a character string which identifies the configuration or mode of the pre-processing
+     * software that operated on the raw instrumental data to generate the data that is recorded in the FITS file.
+     * Example: some X-ray satellite data may be recorded in 'BRIGHT', 'FAINT', or 'FAST' data mode.
+     */
+    DATA_MODE(VALUE.STRING, SOURCE.HEASARC, "pre-processor data mode"),
+
     /** Local time of observation (ISO timestamp), e..g "2017-01-03T02:41:24" or "2024-02-24T22:23:33.054" */
     DATE_LOC("DATE-LOC", VALUE.STRING, "Local time of observation"),
 
+    /**
+     * The value field gives the declination of the observation. It may be expressed either as a floating point number
+     * in units of decimal degrees, or as a character string in 'dd:mm:ss.sss' format where the decimal point and number
+     * of fractional digits are optional. The coordinate reference frame is given by the RADECSYS keyword, and the
+     * coordinate epoch is given by the EQUINOX keyword. Example: -47.25944 or '-47:15:34.00'.
+     */
+    DEC(VALUE.ANY, SOURCE.NOAO, "declination"),
+
+    /**
+     * The value field shall contain a floating point number giving the nominal declination of the pointing direction in
+     * units of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate
+     * epoch is given by the EQUINOX keyword. The precise definition of this keyword is instrument-specific, but
+     * typically the nominal direction corresponds to the direction to which the instrument was requested to point. The
+     * DEC_PNT keyword should be used to give the actual pointed direction.
+     */
+    DEC_NOM(VALUE.REAL, SOURCE.HEASARC, "[deg] nominal declination of the observation"),
+
+    /**
+     * The value field shall contain a floating point number giving the declination of the observed object in units of
+     * decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate epoch is
+     * given by the EQUINOX keyword.
+     */
+    DEC_OBJ(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of observed object"),
+
+    /**
+     * The value field shall contain a floating point number giving the declination of the pointing direction in units
+     * of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate epoch is
+     * given by the EQUINOX keyword. The precise definition of this keyword is instrument-specific, but typically the
+     * pointed direction corresponds to the optical axis of the instrument. This keyword gives a mean value in cases
+     * where the pointing axis was not fixed during the entire observation.
+     */
+    DEC_PNT(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of the pointed direction"),
+
+    /**
+     * The value field shall contain a floating point number giving the declination of the space craft (or telescope
+     * platform) X axis during the observation in decimal degrees. The coordinate reference frame is given by the
+     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
+     * cases where the axis was not fixed during the entire observation.
+     */
+    DEC_SCX(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of the X spacecraft axis"),
+
+    /**
+     * The value field shall contain a floating point number giving the declination of the space craft (or telescope
+     * platform) Y axis during the observation in decimal degrees. The coordinate reference frame is given by the
+     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
+     * cases where the axis was not fixed during the entire observation.
+     */
+    DEC_SCY(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of the Y spacecraft axis"),
+
+    /**
+     * The value field shall contain a floating point number giving the declination of the space craft (or telescope
+     * platform) Z axis during the observation in decimal degrees. The coordinate reference frame is given by the
+     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
+     * cases where the axis was not fixed during the entire observation.
+     */
+    DEC_SCZ(VALUE.REAL, SOURCE.HEASARC, "[deg] declination of the Z spacecraft axis"),
+
+    /**
+     * The value field shall contain a character string giving the name of the detector within the instrument that was
+     * used to make the observation. Example: 'CCD1'
+     */
+    DETNAM(VALUE.STRING, SOURCE.HEASARC, "detector used"),
+
     /** Dew point in degrees Celsius. */
     DEWPOINT(VALUE.REAL, "[C] dew point"),
+
+    /**
+     * The value field shall contain a floating point number giving the difference between the stop and start times of
+     * the observation in units of seconds. This keyword is synonymous with the {@link #TELAPSE} keyword.
+     */
+    ELAPTIME(VALUE.REAL, SOURCE.UCOLICK, "elapsed time of the observation"),
+
+    /**
+     * The value field shall contain a character string giving the the host file name used to record the original data.
+     */
+    FILENAME(VALUE.STRING, SOURCE.NOAO, "original file name"),
+
+    /**
+     * The value field shall contain a character string giving the file type suffix of the host file name. The full file
+     * name typically consists of the root name (see ROOTNAME) followed by a file type suffix, separated by the period
+     * ('.') character.
+     */
+    FILETYPE(VALUE.REAL, "file type"),
+
+    /**
+     * The value field shall contain a character string which gives the name of the filter that was used during the
+     * observation to select or modify the radiation that was transmitted to the detector. More than 1 filter may be
+     * listed by using the FILTERn indexed keyword. The value 'none' or 'NONE' indicates that no filter was used.
+     * 
+     * @see #FILTER_NONE
+     */
+    FILTER(VALUE.STRING, SOURCE.HEASARC, "filter name/ID"),
+
+    /**
+     * The value field of this indexed keyword shall contain a character string which gives the name of one of multiple
+     * filters that were used during the observation to select or modify the radiation that was transmitted to the
+     * detector. The value 'none' or 'NONE' indicates that no filter was used.
+     * 
+     * @see #FILTER_NONE
+     */
+    FILTERn(VALUE.STRING, SOURCE.HEASARC, "filter name/ID n"),
 
     /** Whether or not the image is flipped */
     FLIPPED(VALUE.LOGICAL, "is image flipped"),
@@ -103,14 +233,84 @@ public enum CommonExt implements IFitsHeader {
     /** Amplifier gain. Synonym of {@link MaxImDLExt#ISOSPEED} */
     GAINRAW(VALUE.REAL, "gain factor"),
 
+    /**
+     * The value field shall contain a character string which gives the name of the defraction grating that was used
+     * during the observation. More than 1 grating may be listed by using the GRATINGn indexed keyword. The value 'none'
+     * or 'NONE' indicates that no grating was used.
+     * 
+     * @see #GRATING_NONE
+     */
+    GRATING(VALUE.STRING, SOURCE.HEASARC, "grating name/ID"),
+
+    /**
+     * name of gratings used during the observation. DEFINITION: The value field of this indexed keyword shall contain a
+     * character string which gives the name of one of multiple defraction gratings that were used during the
+     * observation. The value 'none' or 'NONE' indicates that no grating was used.
+     * 
+     * @see #GRATING_NONE
+     */
+    GRATINGn(VALUE.STRING, SOURCE.HEASARC, "grating name/ID n"),
+
     /** Relative humidity as percentage */
     HUMIDITY(VALUE.REAL, "[%] relative humidity"),
+
+    /**
+     * The value field shall contain a floating point number giving the geographic latitude from which the observation
+     * was made in units of degrees.
+     */
+    LATITUDE(VALUE.REAL, SOURCE.UCOLICK, "[deg] geographic latitude"),
+
+    /**
+     * The value field shall contain a floating point number giving the angle between the direction of the observation
+     * (e.g., the optical axis of the telescope or the position of the target) and the moon, measured in degrees.
+     */
+    MOONANGL(VALUE.REAL, SOURCE.STScI, "[deg] angular distance to Moon"),
+
+    /**
+     * The value field shall contain an integer giving the number of standard extensions contained in the FITS file.
+     * This keyword may only be used in the primary array header.
+     */
+    NEXTEND(VALUE.INTEGER, SOURCE.STScI, HDU.PRIMARY, "number of extensions contained"),
 
     /** Image rotation angle in degrees. **/
     OBJCTROT(VALUE.REAL, "[deg] image rotation angle"),
 
+    /**
+     * The value field shall contain a character string which uniquely identifies the dataset contained in the FITS
+     * file. This is typically a sequence number that can contain a mixture of numerical and character values. Example:
+     * '10315-01-01-30A'
+     */
+    OBS_ID(VALUE.STRING, SOURCE.HEASARC, "observation ID"),
+
+    /**
+     * The value field shall contain a character string which gives the observing mode of the observation. This is used
+     * in cases where the instrument or detector can be configured to operate in different modes which significantly
+     * affect the resulting data. Examples: 'SLEW', 'RASTER', or 'POINTING'
+     */
+    OBS_MODE(VALUE.STRING, SOURCE.HEASARC, "observation mode"),
+
     /** Camera offset setting. Very common since CMOS cameras became popular */
     OFFSET(VALUE.INTEGER, "camera offset setting"),
+
+    /**
+     * The value field shall contain a floating point number giving the position angle of the y axis of the detector
+     * projected on the sky, in degrees east of north. This keyword is synonymous with the CROTA2 WCS keyword.
+     */
+    ORIENTAT(VALUE.REAL, SOURCE.STScI, "[deg] position angle of image y axis (E of N)"),
+
+    /**
+     * The value field shall contain a floating point number giving the position angle of the relevant aspect of
+     * telescope pointing axis and/or instrument on the sky in units of degrees east of north. It commonly applies to
+     * the orientation of a slit mask.
+     */
+    PA_PNT(VALUE.REAL, SOURCE.UCOLICK, "[deg] position angle of pointing (E of N)"),
+
+    /**
+     * The value field shall contain a character string giving the name, and optionally, the version of the program that
+     * originally created the current FITS HDU. This keyword is synonymous with the CREATOR keyword. Example: 'TASKNAME
+     * V1.2.3'
+     */
+    PROGRAM(VALUE.STRING, SOURCE.UCOLICK, "software that created original FITS file"),
 
     /**
      * Image scale in arcsec/pixel. Redundant with {@link nom.tam.fits.header.Standard#CDELTn}.
@@ -119,6 +319,77 @@ public enum CommonExt implements IFitsHeader {
 
     /** Air pressure in hPa. */
     PRESSURE(VALUE.REAL, "[hPa] air pressure"),
+
+    /**
+     * The value field gives the Right Ascension of the observation. It may be expressed either as a floating point
+     * number in units of decimal degrees, or as a character string in 'HH:MM:SS.sss' format where the decimal point and
+     * number of fractional digits are optional. The coordinate reference frame is given by the RADECSYS keyword, and
+     * the coordinate epoch is given by the EQUINOX keyword. Example: 180.6904 or '12:02:45.7'.
+     */
+    RA(VALUE.ANY, SOURCE.NOAO, "right ascension"),
+
+    /**
+     * The value field shall contain a floating point number giving\ the nominal Right Ascension of the pointing
+     * direction in units of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the
+     * coordinate epoch is given by the EQUINOX keyword. The precise definition of this keyword is instrument-specific,
+     * but typically the nominal direction corresponds to the direction to which the instrument was requested to point.
+     * The RA_PNT keyword should be used to give the actual pointed direction.
+     */
+    RA_NOM(VALUE.REAL, SOURCE.HEASARC, "[deg] nominal right ascension"),
+
+    /**
+     * The value field shall contain a floating point number giving\ the Right Ascension of the observed object in units
+     * of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate epoch is
+     * given by the EQUINOX keyword.
+     */
+    RA_OBJ(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of observed object"),
+
+    /**
+     * The value field shall contain a floating point number giving the Right Ascension of the pointing direction in
+     * units of decimal degrees. The coordinate reference frame is given by the RADECSYS keyword, and the coordinate
+     * epoch is given by the EQUINOX keyword. The precise definition of this keyword is instrument-specific, but
+     * typically the pointed direction corresponds to the optical axis of the instrument. This keyword gives a mean
+     * value in cases where the pointing axis was not fixed during the entire observation.
+     */
+    RA_PNT(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of pointing direction"),
+
+    /**
+     * The value field shall contain a floating point number giving the Right Ascension of the space craft (or telescope
+     * platform) X axis during the observation in decimal degrees. The coordinate reference frame is given by the
+     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
+     * cases where the axis was not fixed during the entire observation.
+     */
+    RA_SCX(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of the X spacecraft axis"),
+
+    /**
+     * The value field shall contain a floating point number giving the Right Ascension of the space craft (or telescope
+     * platform) Y axis during the observation in decimal degrees. The coordinate reference frame is given by the
+     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
+     * cases where the axis was not fixed during the entire observation.
+     */
+    RA_SCY(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of the Y spacecraft axis"),
+
+    /**
+     * The value field shall contain a floating point number giving the Right Ascension of the space craft (or telescope
+     * platform) Z axis during the observation in decimal degrees. The coordinate reference frame is given by the
+     * RADECSYS keyword, and the coordinate epoch is given by the EQUINOX keyword. This keyword gives a mean value in
+     * cases where the axis was not fixed during the entire observation.
+     */
+    RA_SCZ(VALUE.REAL, SOURCE.HEASARC, "[deg] R.A. of the Z spacecraft axis"),
+
+    /**
+     * The value field shall contain a character string giving the root of the host file name. The full file name
+     * typically consists of the root name followed by a file type suffix (see FILETYPE), separated by the period ('.')
+     * character.
+     */
+    ROOTNAME(VALUE.STRING, "root of host file name"),
+
+    /**
+     * The value field shall contain an integer giving the data value at which the detector becomes saturated. This
+     * keyword value may differ from the maximum value implied by the BITPIX in that more bits may be allocated in the
+     * FITS pixel values than the detector can accommodate.
+     */
+    SATURATE(VALUE.INTEGER, SOURCE.STScI, ""),
 
     /**
      * Image scale in arcsec / pixel. Synonym of {@link #PIXSCALE}, and redundant with
@@ -132,11 +403,58 @@ public enum CommonExt implements IFitsHeader {
     /** Observatory site, e.g. "Maunakea" */
     SITENAME(VALUE.STRING, "observatory site"),
 
+    /**
+     * The value field shall contain a floating point number giving the angle between the direction of the observation
+     * (e.g., the optical axis of the telescope or the position of the target) and the sun, measured in degrees.
+     */
+    SUNANGLE(VALUE.REAL, SOURCE.STScI, "[deg] distance to Sun"),
+
+    /**
+     * The value field of this indexed keyword shall contain a floating point number specifying the suggested bin size
+     * when producing a histogram of the values in column n. This keyword is typically used in conjunction the TLMINn
+     * and TLMAXn keywords when constructing a histogram of the values in column n, such that the histogram ranges from
+     * TLMINn to TLMAXn with the histogram bin size given by TDBINn. This keyword may only be used in 'TABLE' or
+     * 'BINTABLE' extensions.
+     */
+    TDBINn(VALUE.REAL, SOURCE.CXC, "suggested column bin size"),
+
+    /**
+     * The value field shall contain a floating point number giving the difference between the stop and start times of
+     * the observation in units of seconds. This keyword is synonymous with the {@link #ELAPTIME} keyword.
+     */
+    TELAPSE(VALUE.REAL, SOURCE.HEASARC, "[s] elapsed time of observation"),
+
+    /**
+     * The value field shall contain a character string giving a title that is suitable for display purposes, e.g., for
+     * annotation on images or plots of the data contained in the HDU.
+     */
+    TITLE(VALUE.STRING, SOURCE.ROSAT, "display title"),
+
+    /**
+     * The value field shall contain a character string that defines the order in which the rows in the current FITS
+     * ASCII or binary table extension have been sorted. The character string lists the name (as given by the TTYPEn
+     * keyword) of the primary sort column, optionally followed by the names of any secondary sort column(s). The
+     * presence of this keyword indicates that the rows in the table have been sorted first by the values in the primary
+     * sort column; any rows that have the same value in the primary column have been further sorted by the values in
+     * the secondary sort column and so on for all the specified columns. If more than one column is specified by
+     * TSORTKEY then the names must be separated by a comma. One or more spaces are also allowed between the comma and
+     * the following column name. By default, columns are sorted in ascending order, but a minus sign may precede the
+     * column name to indicate that the rows are sorted in descending order. This keyword may only be used in 'TABLE' or
+     * 'BINTABLE' extensions. Example: TSORTKEY = 'TIME, RA, DEC'.
+     */
+    TSORTKEY(VALUE.STRING, SOURCE.HEASARC, "table sort order"),
+
     /** Wind direction clockwise from North [0:360] */
     WINDDIR(VALUE.REAL, "[deg] wind direction: 0=N, 90=E, 180=S, 270=W"),
 
     /** Average wind speed in km/h */
     WINDSPD(VALUE.REAL, "[km/h] wind speed");
+
+    /** Standard {@link #FILTER} name when no filter was used. */
+    public static final String FILTER_NONE = "NONE";
+
+    /** Standard {@link #GRATING} name when no filter was used. */
+    public static final String GRATING_NONE = "NONE";
 
     private final FitsKey key;
 
@@ -148,8 +466,20 @@ public enum CommonExt implements IFitsHeader {
         this(null, valueType, comment);
     }
 
+    CommonExt(VALUE valueType, SOURCE source, String comment) {
+        this(null, valueType, source, HDU.ANY, comment);
+    }
+
     CommonExt(String key, VALUE valueType, String comment) {
-        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.UNKNOWN, HDU.ANY, valueType, comment);
+        this(key, valueType, SOURCE.UNKNOWN, HDU.ANY, comment);
+    }
+
+    CommonExt(VALUE valueType, SOURCE source, HDU hduType, String comment) {
+        this(null, valueType, source, hduType, comment);
+    }
+
+    CommonExt(String key, VALUE valueType, SOURCE source, HDU hduType, String comment) {
+        this.key = new FitsKey(key == null ? name() : key, source, hduType, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -92,7 +92,41 @@ public enum CommonExt implements IFitsHeader {
     WINDDIR(VALUE.REAL, "[deg] wind direction: 0=N, 90=E, 180=S, 270=W"),
 
     /** Air pressure in hPa. */
-    PRESSURE(VALUE.REAL, "[hPa] air pressure");
+    PRESSURE(VALUE.REAL, "[hPa] air pressure"),
+
+    /** Observatory site, e.g. "Maunakea" */
+    SITENAME(VALUE.STRING, "observatory site"),
+
+    /** Elevation of observing site above sea level in meters */
+    SITEELEV(VALUE.REAL, "[m] elevation at observing site"),
+
+    /** Name of focuser */
+    FOCUSER(VALUE.STRING, "focuser name"),
+
+    /** Name of focuser. Synonym of {@link #FOCUSER} */
+    FOCNAME(VALUE.STRING, "focuser name"),
+
+    /** Filter wheel position */
+    FWHEEL(VALUE.STRING, "filter wheel position"),
+
+    /**
+     * Plate scale in arcsec / pixel. It may be different from the image scale described by the
+     * {@link nom.tam.fits.header.Standard#CDELTn} keywords, if physical pixels were binned or interpolated for a
+     * different image pixelization.
+     */
+    PIXSCALE(VALUE.REAL, "[arcsec/pixel] plate scale"),
+
+    /** Plate scale in arcsec / pixel. Synonym of {@link #PIXSCALE} */
+    SCALE(VALUE.REAL, "[arcsec/pixel] plate scale"),
+
+    /** Synonym of {@link #ANGLE}. **/
+    OBJCTROT(VALUE.REAL, "[deg] image angle"),
+
+    /** Amplifier gain */
+    GAINRAW(VALUE.REAL, "amplifier gain"),
+
+    /** Synonym of {@link MaxImDLExt#EGAIN} */
+    GAINADU(VALUE.REAL, "[ct/adu] amplifier gain electrons / ADU");
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -46,20 +46,11 @@ import nom.tam.fits.header.IFitsHeader;
  */
 public enum CommonExt implements IFitsHeader {
 
+    /** Ambient air temperature in degrees Celsius */
+    AMBTEMP(VALUE.REAL, "[C] ambient air temperature"),
+
     /** Image angle in degrees */
     ANGLE(VALUE.REAL, "[deg] image angle"),
-
-    /** Local time of observation (ISO timestamp), e..g "2017-01-03T02:41:24" or "2024-02-24T22:23:33.054" */
-    DATE_LOC("DATE-LOC", VALUE.STRING, "Local time of observation"),
-
-    /** Whether or not the image is flipped */
-    FLIPPED(VALUE.LOGICAL, "is image flipped"),
-
-    /** Focal ratio */
-    FOCRATIO(VALUE.REAL, "focal ratio"),
-
-    /** Camera offset setting. Very common since CMOS cameras became popular */
-    OFFSET(VALUE.INTEGER, "camera offset setting"),
 
     /** X axis binning factor. Synonym for {@link SBFitsExt#XBINNING} */
     CCDXBIN(VALUE.INTEGER, "X axis binning factor"),
@@ -67,66 +58,79 @@ public enum CommonExt implements IFitsHeader {
     /** Y axis binning factor. Synonym for {@link SBFitsExt#YBINNING} */
     CCDYBIN(VALUE.INTEGER, "Y axis binning factor"),
 
-    /** Focuser position in steps. Usually an integer, but not always. Synonymous to {@link MaxImDLExt#FOCUSPOS} */
-    FOCPOS(VALUE.REAL, "[ct] focuser position in steps"),
-
-    /** Focus temperature in degrees Celsius. Synonymous to {@link MaxImDLExt#FOCUSTEM}. */
-    FOCTEMP(VALUE.REAL, "[C] focuser temperature readout"),
-
     /** Cloud cover as percentage */
     CLOUDCVR(VALUE.REAL, "[%] cloud cover"),
 
-    /** Relative humidity as percentage */
-    HUMIDITY(VALUE.REAL, "[%] relative humidity"),
+    /** Local time of observation (ISO timestamp), e..g "2017-01-03T02:41:24" or "2024-02-24T22:23:33.054" */
+    DATE_LOC("DATE-LOC", VALUE.STRING, "Local time of observation"),
 
     /** Dew point in degrees Celsius. */
     DEWPOINT(VALUE.REAL, "[C] dew point"),
 
-    /** Ambient air temperature in degrees Celsius */
-    AMBTEMP(VALUE.REAL, "[C] ambient air temperature"),
-
-    /** Average wind speed in km/h */
-    WINDSPD(VALUE.REAL, "[km/h] wind speed"),
-
-    /** Wind direction clockwise from North [0:360] */
-    WINDDIR(VALUE.REAL, "[deg] wind direction: 0=N, 90=E, 180=S, 270=W"),
-
-    /** Air pressure in hPa. */
-    PRESSURE(VALUE.REAL, "[hPa] air pressure"),
-
-    /** Observatory site, e.g. "Maunakea" */
-    SITENAME(VALUE.STRING, "observatory site"),
-
-    /** Elevation of observing site above sea level in meters */
-    SITEELEV(VALUE.REAL, "[m] elevation at observing site"),
-
-    /** Name of focuser */
-    FOCUSER(VALUE.STRING, "focuser name"),
+    /** Whether or not the image is flipped */
+    FLIPPED(VALUE.LOGICAL, "is image flipped"),
 
     /** Name of focuser. Synonym of {@link #FOCUSER} */
     FOCNAME(VALUE.STRING, "focuser name"),
 
+    /** Focuser position in steps. Usually an integer, but not always. Synonymous to {@link MaxImDLExt#FOCUSPOS} */
+    FOCPOS(VALUE.REAL, "[ct] focuser position in steps"),
+
+    /** Focal ratio */
+    FOCRATIO(VALUE.REAL, "focal ratio"),
+
+    /** Name of focuser */
+    FOCUSER(VALUE.STRING, "focuser name"),
+
+    /** Focus temperature in degrees Celsius. Synonymous to {@link MaxImDLExt#FOCUSTEM}. */
+    FOCTEMP(VALUE.REAL, "[C] focuser temperature readout"),
+
     /** Filter wheel position */
     FWHEEL(VALUE.STRING, "filter wheel position"),
 
-    /**
-     * Plate scale in arcsec / pixel. It may be different from the image scale described by the
-     * {@link nom.tam.fits.header.Standard#CDELTn} keywords, if physical pixels were binned or interpolated for a
-     * different image pixelization.
-     */
-    PIXSCALE(VALUE.REAL, "[arcsec/pixel] plate scale"),
+    /** Camera gain / amplification. Often used the same as {@link #GAINRAW} */
+    GAIN(VALUE.REAL, "camera gain factor"),
 
-    /** Plate scale in arcsec / pixel. Synonym of {@link #PIXSCALE} */
-    SCALE(VALUE.REAL, "[arcsec/pixel] plate scale"),
+    /** Synonym of {@link MaxImDLExt#EGAIN} */
+    GAINADU(VALUE.REAL, "[ct/adu] amplifier gain electrons / ADU"),
+
+    /** Amplifier gain. */
+    GAINRAW(VALUE.REAL, "gain factor"),
+
+    /** Relative humidity as percentage */
+    HUMIDITY(VALUE.REAL, "[%] relative humidity"),
 
     /** Synonym of {@link #ANGLE}. **/
     OBJCTROT(VALUE.REAL, "[deg] image angle"),
 
-    /** Amplifier gain */
-    GAINRAW(VALUE.REAL, "amplifier gain"),
+    /** Camera offset setting. Very common since CMOS cameras became popular */
+    OFFSET(VALUE.INTEGER, "camera offset setting"),
 
-    /** Synonym of {@link MaxImDLExt#EGAIN} */
-    GAINADU(VALUE.REAL, "[ct/adu] amplifier gain electrons / ADU");
+    /**
+     * Image scale in arcsec/pixel. Redundant with {@link nom.tam.fits.header.Standard#CDELTn}.
+     */
+    PIXSCALE(VALUE.REAL, "[arcsec/pixel] image scale"),
+
+    /** Air pressure in hPa. */
+    PRESSURE(VALUE.REAL, "[hPa] air pressure"),
+
+    /**
+     * Image scale in arcsec / pixel. Synonym of {@link #PIXSCALE}, and redundant with
+     * {@link nom.tam.fits.header.Standard#CDELTn}.
+     */
+    SCALE(VALUE.REAL, "[arcsec/pixel] image scale"),
+
+    /** Elevation of observing site above sea level in meters */
+    SITEELEV(VALUE.REAL, "[m] elevation at observing site"),
+
+    /** Observatory site, e.g. "Maunakea" */
+    SITENAME(VALUE.STRING, "observatory site"),
+
+    /** Wind direction clockwise from North [0:360] */
+    WINDDIR(VALUE.REAL, "[deg] wind direction: 0=N, 90=E, 180=S, 270=W"),
+
+    /** Average wind speed in km/h */
+    WINDSPD(VALUE.REAL, "[km/h] wind speed");
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -38,7 +38,7 @@ import nom.tam.fits.header.IFitsHeader;
  * <p>
  * A Set of commonly used keywords in the astronomy community. Many of these are semi-officially recognised by HEASARC
  * and listed in the <a href="https://heasarc.gsfc.nasa.gov/docs/fcg/common_dict.html">Dictionary of Commonly Used FITS
- * Keywords</a>, while other are commonly used by amateur astronomers.
+ * Keywords</a>, while others are commonly used in the amateur astronomy community.
  * </p>
  *
  * @author John Murphy and Attila Kovacs

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -88,8 +88,14 @@ public enum CommonExt implements IFitsHeader {
     /** Filter wheel position */
     FWHEEL(VALUE.STRING, "filter wheel position"),
 
-    /** Camera gain / amplification. Often used the same as {@link #GAINRAW} */
-    GAIN(VALUE.REAL, "camera gain factor"),
+    /**
+     * Camera gain / amplification. Often used the same as {@link #GAINRAW}. There may be many different conventions on
+     * using this keyword. For example itmay represent a multiplicative gain factor or gain defined as decibels, or
+     * strings such as 'HI'/'LO', or even as a boolean T/F. Therefore, this definition does not restrict the type of
+     * value this keyword can be used with. It is up to the user to ensure they follow the convention that makes most
+     * sense to their application, and for the tools they intend to use.
+     */
+    GAIN(VALUE.ANY, "camera gain"),
 
     /** Synonym of {@link MaxImDLExt#EGAIN} */
     GAINADU(VALUE.REAL, "[ct/adu] amplifier gain electrons / ADU"),

--- a/src/main/java/nom/tam/fits/header/extra/CommonExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/CommonExt.java
@@ -1,0 +1,116 @@
+package nom.tam.fits.header.extra;
+
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import nom.tam.fits.header.FitsKey;
+import nom.tam.fits.header.IFitsHeader;
+
+/**
+ * <p>
+ * A Set of commonly used keywords in the astronomy community, such as for describing cameras used by amateur
+ * astronomers.
+ * </p>
+ *
+ * @author John Murphy and Attila Kovacs
+ * 
+ * @since  1.20.1
+ */
+public enum CommonExt implements IFitsHeader {
+
+    /** Image angle in degrees */
+    ANGLE(VALUE.REAL, "[deg] image angle"),
+
+    /** Local time of observation (ISO timestamp), e..g "2017-01-03T02:41:24" or "2024-02-24T22:23:33.054" */
+    DATE_LOC("DATE-LOC", VALUE.STRING, "Local time of observation"),
+
+    /** Whether or not the image is flipped */
+    FLIPPED(VALUE.LOGICAL, "is image flipped"),
+
+    /** Focal ratio */
+    FOCRATIO(VALUE.REAL, "focal ratio"),
+
+    /** Camera offset setting. Very common since CMOS cameras became popular */
+    OFFSET(VALUE.INTEGER, "camera offset setting"),
+
+    /** X axis binning factor. Synonym for {@link SBFitsExt#XBINNING} */
+    CCDXBIN(VALUE.INTEGER, "X axis binning factor"),
+
+    /** Y axis binning factor. Synonym for {@link SBFitsExt#YBINNING} */
+    CCDYBIN(VALUE.INTEGER, "Y axis binning factor"),
+
+    /** Focuser position in steps. Usually an integer, but not always. Synonymous to {@link MaxImDLExt#FOCUSPOS} */
+    FOCPOS(VALUE.REAL, "[ct] focuser position in steps"),
+
+    /** Focus temperature in degrees Celsius. Synonymous to {@link MaxImDLExt#FOCUSTEM}. */
+    FOCTEMP(VALUE.REAL, "[C] focuser temperature readout"),
+
+    /** Cloud cover as percentage */
+    CLOUDCVR(VALUE.REAL, "[%] cloud cover"),
+
+    /** Relative humidity as percentage */
+    HUMIDITY(VALUE.REAL, "[%] relative humidity"),
+
+    /** Dew point in degrees Celsius. */
+    DEWPOINT(VALUE.REAL, "[C] dew point"),
+
+    /** Ambient air temperature in degrees Celsius */
+    AMBTEMP(VALUE.REAL, "[C] ambient air temperature"),
+
+    /** Average wind speed in km/h */
+    WINDSPD(VALUE.REAL, "[km/h] wind speed"),
+
+    /** Wind direction clockwise from North [0:360] */
+    WINDDIR(VALUE.REAL, "[deg] wind direction: 0=N, 90=E, 180=S, 270=W"),
+
+    /** Air pressure in hPa. */
+    PRESSURE(VALUE.REAL, "[hPa] air pressure");
+
+    private final FitsKey key;
+
+    CommonExt(IFitsHeader key) {
+        this.key = key.impl();
+    }
+
+    CommonExt(VALUE valueType, String comment) {
+        this(null, valueType, comment);
+    }
+
+    CommonExt(String key, VALUE valueType, String comment) {
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.UNKNOWN, HDU.ANY, valueType, comment);
+    }
+
+    @Override
+    public final FitsKey impl() {
+        return key;
+    }
+
+}

--- a/src/main/java/nom/tam/fits/header/extra/ESOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/ESOExt.java
@@ -106,7 +106,7 @@ public enum ESOExt implements IFitsHeader {
     }
 
     ESOExt(String name, VALUE valueType, String comment) {
-        key = new FitsKey(name, IFitsHeader.SOURCE.ESO, HDU.ANY, valueType, comment);
+        this.key = new FitsKey(name == null ? name() : name, IFitsHeader.SOURCE.ESO, HDU.ANY, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/ESOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/ESOExt.java
@@ -1,0 +1,85 @@
+package nom.tam.fits.header.extra;
+
+import nom.tam.fits.header.FitsKey;
+import nom.tam.fits.header.IFitsHeader;
+
+/**
+ * <p>
+ * Standard ESO FITS keywords, based on ESO's
+ * <a href="https://archive.eso.org/cms/tools-documentation/dicb/ESO-044156_7_DataInterfaceControlDocument.pdf">Data
+ * Interface Control Document</a>. Only ESO specific keyword, beyond those defined in the standard or in
+ * {@link CommonExt} are listed.
+ * </p>
+ * <p>
+ * HIERARCH-type keywords are not currently included in this enumeration.
+ * </p>
+ * 
+ * @author Attila Kovacs
+ *
+ * @see    CommonExt
+ * 
+ * @since  1.20.1
+ */
+public enum ESOExt implements IFitsHeader {
+
+    /**
+     * Provides the name under which the file is stored in the archive
+     */
+    ARCFILE(VALUE.STRING, "archive file name"),
+
+    /**
+     * If applicable, the string containing the designation of the dispersing element (grating, grism) used during the
+     * observation
+     */
+    DISPELEM(VALUE.STRING, "Dispersing element used"),
+
+    /**
+     * Modification timestamp. Imay be added to files downloaded for the ESO archive by the delivery software. It shall
+     * be present in the primary HDU of the delivered file if the metadata of the frame have been updated/modified after
+     * the ingestion (an example of such modification is reassigning of the file to a different programme/run or a
+     * correction of erroneous metadata). If present, it contains the modification timetag, in restricted ISO 8601
+     * format, YYYY-MM-DDThh:mm:ss.sss. If it is not present in the frame, it indicates that there have been no metadata
+     * modifications. HDRVER must not be present in files ingested into archive. In particular, HDRVER must be actively
+     * removed prior to ingestion from the headers of products.
+     */
+    HDRVER(VALUE.STRING, "modification timestamp"),
+
+    /**
+     * UTC seconds since midnight.
+     */
+    LST(VALUE.REAL, "[s] Local Sidereal Time"),
+
+    /**
+     * Records the original file name, as assigned at the instrument workstation.
+     */
+    ORIGFILE(VALUE.STRING, "original file name"),
+
+    /**
+     * The PI or Co-I’s initials followed by their surname. The primary keyword should repeat the value OBS.PI-COI.NAME.
+     */
+    PI_COI("PI-COI", VALUE.STRING, "PI and CoIs"),
+
+    /**
+     * UTC seconds since midnight.
+     */
+    UTC(VALUE.REAL, "[s] UTC time of day");
+
+    private final FitsKey key;
+
+    ESOExt(IFitsHeader key) {
+        this.key = key.impl();
+    }
+
+    ESOExt(VALUE valueType, String comment) {
+        this(null, valueType, comment);
+    }
+
+    ESOExt(String name, VALUE valueType, String comment) {
+        key = new FitsKey(name, IFitsHeader.SOURCE.ESO, HDU.ANY, valueType, comment);
+    }
+
+    @Override
+    public final FitsKey impl() {
+        return key;
+    }
+}

--- a/src/main/java/nom/tam/fits/header/extra/ESOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/ESOExt.java
@@ -97,10 +97,6 @@ public enum ESOExt implements IFitsHeader {
 
     private final FitsKey key;
 
-    ESOExt(IFitsHeader key) {
-        this.key = key.impl();
-    }
-
     ESOExt(VALUE valueType, String comment) {
         this(null, valueType, comment);
     }

--- a/src/main/java/nom/tam/fits/header/extra/ESOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/ESOExt.java
@@ -42,7 +42,7 @@ public enum ESOExt implements IFitsHeader {
      * modifications. HDRVER must not be present in files ingested into archive. In particular, HDRVER must be actively
      * removed prior to ingestion from the headers of products.
      */
-    HDRVER(VALUE.STRING, "modification timestamp"),
+    HDRVER(VALUE.STRING, "header modification timestamp"),
 
     /**
      * UTC seconds since midnight.

--- a/src/main/java/nom/tam/fits/header/extra/ESOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/ESOExt.java
@@ -1,5 +1,36 @@
 package nom.tam.fits.header.extra;
 
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
 import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -46,7 +46,7 @@ import nom.tam.fits.header.IFitsHeader;
  * http://www.cyanogen.com/help/maximdl/FITS_File_Header_Definitions.htm
  * </pre>
  *
- * @author Richard van Nieuwenhoven and Attila Kovacs
+ * @author Richard van Nieuwenhoven, Attila Kovacs, and John Murphy
  * 
  * @see    SBFitsExt
  */
@@ -331,7 +331,8 @@ public enum MaxImDLExt implements IFitsHeader {
     AOCFWHM(VALUE.REAL, "[arcsec] seeing FWHM"),
 
     /**
-     * if present the image has a valid Bayer color pattern.
+     * if present the image has a valid Bayer color pattern. For example, "RGGB", "GRBG", "GBRG", "BGGR", "RGBG",
+     * "GRGB", "GBGR", or "BGRG"
      */
     BAYERPAT(VALUE.STRING, "Bayer color pattern"),
 
@@ -452,7 +453,7 @@ public enum MaxImDLExt implements IFitsHeader {
     DAVWINDD(VALUE.REAL, "[deg] wind direction"),
 
     /**
-     * status of pier flip for German Equatorial mounts.
+     * Status of pier flip for German Equatorial mounts.
      */
     FLIPSTAT(VALUE.STRING, "status of pier flip"),
 
@@ -527,12 +528,19 @@ public enum MaxImDLExt implements IFitsHeader {
     OBJCTHA(VALUE.REAL, "[h] nominal hour angle of center of image"),
 
     /**
-     * indicates side-of-pier status when connected to a German Equatorial mount.
+     * Indicates side-of-pier status when connected to a German Equatorial mount. Usually 'East' or 'West'.
+     * 
+     * @see #PIERSIDE_EAST
+     * @see #PIERSIDE_WEST
      */
     PIERSIDE(VALUE.STRING, "side-of-pier status"),
 
     /**
-     * records the selected Readout Mode (if any) for the camera.
+     * Records the selected Readout Mode (if any) for the camera. We define constants for some commonly used readout
+     * modes, but other modes beyond these may be valid and can be used also.
+     * 
+     * @see #READOUTM_RAW
+     * @see #READOUTM_LONG_EXPOSURE_MODE
      */
     READOUTM(VALUE.STRING, "readout Mode for the camera"),
 
@@ -633,6 +641,34 @@ public enum MaxImDLExt implements IFitsHeader {
      * @since 1.20.1
      */
     public static final String IMAGETYP_TRICOLOR_IMAGE = "Tricolor Image";
+
+    /**
+     * Standard {@link #PIERSIDE} value for East side of mount.
+     * 
+     * @since 1.20.1
+     */
+    public static final String PIERSIDE_EAST = "East";
+
+    /**
+     * Standard {@link #PIERSIDE} value for West side of mount.
+     * 
+     * @since 1.20.1
+     */
+    public static final String PIERSIDE_WEST = "West";
+
+    /**
+     * Standard {@link #READOUTM} value for raw readout mode.
+     * 
+     * @since 1.20.1
+     */
+    public static final String READOUTM_RAW = "Raw";
+
+    /**
+     * Standard {@link #READOUTM} value for long exposure mode.
+     * 
+     * @since 1.20.1
+     */
+    public static final String READOUTM_LONG_EXPOSURE_MODE = "Long Exposure Mode";
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -495,7 +495,7 @@ public enum MaxImDLExt implements IFitsHeader {
     /**
      * Focuser step size in microns, if available.
      */
-    FOCUSSZ(VALUE.REAL, "[um] focuser step size"),
+    FOCUSSSZ(VALUE.REAL, "[um] focuser step size"),
 
     /**
      * Focuser temperature readout in degrees C, if available.

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -35,177 +35,522 @@ import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
 
 /**
- * The Fits extension as defined by Maxim DL.Extension keywords that may be added or read by MaxIm DL, depending on the
- * current equipment and software configuration.
+ * The Fits extension keywords that may be added or read by MaxIm DL, depending on the current equipment and software
+ * configuration.
  * <p>
- * This standard extends the @see {@link SBFitsExt} all that fields are included.
+ * This standard extends the @see {@link SBFitsExt}. As of version 1.20.1, this enum explicitly includes all keywords of
+ * the SBIG proposal also.
  * </p>
  *
  * <pre>
  * http://www.cyanogen.com/help/maximdl/FITS_File_Header_Definitions.htm
  * </pre>
  *
- * @author Richard van Nieuwenhoven
+ * @author Richard van Nieuwenhoven and Attila Kovacs
+ * 
+ * @see    SBFitsExt
  */
 public enum MaxImDLExt implements IFitsHeader {
+
+    // ------------------------------------------------------------------------
+    // The MaxIm DL keywords, which are based on the SBIG proposal:
+    // ------------------------------------------------------------------------
+
+    /**
+     * Aperture Area of the Telescope used in square millimeters. Note that we are specifying the area as well as the
+     * diameter because we want to be able to correct for any central obstruction.
+     */
+    APTAREA(VALUE.REAL, "[mm**2] telescope aperture area"),
+
+    /**
+     * Aperture Diameter of the Telescope used in millimeters.
+     */
+    APTDIA(VALUE.REAL, "[mm] telescope aperture diameter"),
+
+    /**
+     * Upon initial display of this image use this ADU level for the Black level.
+     */
+    CBLACK(VALUE.REAL, "[adu] black level counts"),
+
+    /**
+     * Temperature of CCD when exposure taken.
+     */
+    CCD_TEMP("CCD-TEMP", VALUE.REAL, "[C] temperature of CCD"),
+
+    /**
+     * Altitude of the center of the image in +DDD MM SS.SSS format.
+     */
+    CENTALT(VALUE.STRING, "DMS altitude of the center of the image"),
+
+    /**
+     * Azimuth of the center of the image in +DDD MM SS.SSS format.
+     */
+    CENTAZ(VALUE.STRING, "DMS azimuth of the center of the image"),
+
+    /**
+     * Upon initial display of this image use this ADU level as the White level. For the SBIG method of displaying
+     * images using Background and Range the following conversions would be used: Background = CBLACK Range = CWHITE -
+     * CBLACK.
+     */
+    CWHITE(VALUE.REAL, "[adu] white level counts"),
+
+    /**
+     * Total dark time of the observation. This is the total time during which dark current is collected by the
+     * detector. If the times in the extension are different the primary HDU gives one of the extension times.
+     * <p>
+     * units = UNITTIME
+     * </p>
+     * <p>
+     * default value = EXPTIME
+     * </p>
+     * <p>
+     * index = none
+     * </p>
+     */
+    DARKTIME(VALUE.REAL, "[s] dark time"),
+
+    /**
+     * Electronic gain in e-/ADU.
+     */
+    EGAIN(VALUE.REAL, "[ct/adu] electronic gain in electrons/ADU"),
+
+    /*
+     * Optional Keywords <p> The following Keywords are not defined in the FITS Standard but are defined in this
+     * Standard. They may or may not be included by AIP Software Packages adhering to this Standard. Any of these
+     * keywords read by an AIP Package must be preserved in files written. </p>
+     */
+
+    /**
+     * Focal Length of the Telescope used in millimeters.
+     */
+    FOCALLEN(VALUE.REAL, "[mm] focal length of telescope"),
+
+    /**
+     * This indicates the type of image and should be one of the following: 'Light Frame', 'Dark Frame', 'Bias Frame',
+     * 'Flat Field', or 'Tricolor Image'.
+     * 
+     * @see #IMAGETYP_LIGHT_FRAME
+     * @see #IMAGETYP_DARK_FRAME
+     * @see #IMAGETYP_FLAT_FRAME
+     * @see #IMAGETYP_BIAS_FRAME
+     * @see #IMAGETYP_TRICOLOR_IMAGE
+     */
+    IMAGETYP(VALUE.STRING, "type of image"),
+
+    /**
+     * This is the Declination of the center of the image in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. North is + and
+     * South is -.
+     */
+    OBJCTDEC(VALUE.STRING, "DMS declination of image center"),
+
+    /**
+     * This is the Right Ascension of the center of the image in HH MM SS.SSS format. E.g. ’12 24 23.123’.
+     */
+    OBJCTRA(VALUE.STRING, "HMS right ascension of image center"),
+
+    /**
+     * Add this ADU count to each pixel value to get to a zero-based ADU. For example in SBIG images we add 100 ADU to
+     * each pixel to stop underflow at Zero ADU from noise. We would set PEDESTAL to -100 in this case.
+     */
+    PEDESTAL(VALUE.REAL, "[adu] zero level counts"),
+
+    /**
+     * This string indicates the version of this standard that the image was created to ie ‘SBFITSEXT Version 1.0’.
+     */
+    SBSTDVER(VALUE.STRING, "version of this standard"),
+
+    /**
+     * This is the setpoint of the cooling in degrees Celsius. If it is not specified the setpoint is assumed to be the
+     */
+    SET_TEMP("SET-TEMP", VALUE.REAL, "[C] setpoint of the cooling"),
+
+    /**
+     * Latitude of the imaging location in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. North is + and South is -.
+     */
+    SITELAT(VALUE.STRING, "DMS latitude of the imaging location"),
+
+    /**
+     * Longitude of the imaging location in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. East is + and West is -.
+     */
+    SITELONG(VALUE.STRING, "DMS longitude of the imaging location"),
+
+    /**
+     * Number of images combined to make this image as in track and accumulate or coadded images.
+     */
+    SNAPSHOT(VALUE.INTEGER, "number of images combined"),
+
+    /**
+     * This indicates the name and version of the Software that initially created this file ie ‘SBIGs CCDOps Version
+     * 5.10’.
+     */
+    SWCREATE(VALUE.STRING, "software name and version that created file"),
+
+    /**
+     * This indicates the name and version of the Software that modified this file ie ‘SBIGs CCDOps Version 5.10’ and
+     * the re can be multiple copies of this keyword. Only add this keyword if you actually modified the image and we
+     * suggest placing this above the HISTORY keywords corresponding to the modifications made to the image.
+     */
+    SWMODIFY(VALUE.STRING, "list of software that modified file"),
+
+    /**
+     * If the image was auto-guided this is the exposure time in seconds of the tracker used to acquire this image. If
+     * this keyword is not present then the image was unguided or hand guided.
+     */
+    TRAKTIME(VALUE.REAL, "[s] exposure time of the tracker"),
+
+    /**
+     * Binning factor in width.
+     */
+    XBINNING(VALUE.INTEGER, "binning factor in width"),
+
+    /**
+     * Sub frame X position of upper left pixel relative to whole frame in binned pixel units.
+     */
+    XORGSUBF(VALUE.INTEGER, "[pix] sub frame X position"),
+
+    /**
+     * Pixel width in microns (after binning).
+     */
+    XPIXSZ(VALUE.REAL, "[um] pixel width"),
+
+    /**
+     * Binning factor in height.
+     */
+    YBINNING(VALUE.INTEGER, "binning factor in height"),
+
+    /**
+     * Sub frame Y position of upper left pixel relative to whole frame in binned pixel units.
+     */
+    YORGSUBF(VALUE.INTEGER, "[pix] sub frame Y position"),
+
+    /**
+     * Pixel height in microns (after binning).
+     */
+    YPIXSZ(VALUE.REAL, "[um] pixel height"),
+
+    // ------------------------------------------------------------------------
+    // Additional MaxIm DL keywords, beyong the SBIG proposal
+    // ------------------------------------------------------------------------
+
+    /**
+     * ASCOM Observatory Conditions -- relative optical path length through atmosphere
+     * 
+     * @since 1.20.1
+     */
+    AIRMASS(VALUE.REAL, "relative optical path length through atmosphere"),
+
+    /**
+     * ASCOM Observatory Conditions -- ambient temperature in degrees Celsius
+     * 
+     * @since 1.20.1
+     */
+    AOCAMBT(VALUE.REAL, "[C] ambient temperature"),
+
+    /**
+     * ASCOM Observatory Conditions -- dew point in degrees Celsius
+     * 
+     * @since 1.20.1
+     */
+    AOCDEW(VALUE.REAL, "[C] dew point"),
+
+    /**
+     * ASCOM Observatory Conditions -- rain rate in mm/hour
+     * 
+     * @since 1.20.1
+     */
+    AOCRAIN(VALUE.REAL, "[mm/h] rain rate"),
+
+    /**
+     * ASCOM Observatory Conditions -- humidity in percent
+     * 
+     * @since 1.20.1
+     */
+    AOCHUM(VALUE.REAL, "[%] humidity"),
+
+    /**
+     * ASCOM Observatory Conditions -- wind speed in m/s
+     * 
+     * @since 1.20.1
+     */
+    AOCWIND(VALUE.REAL, "[m/s] wind speed"),
+
+    /**
+     * ASCOM Observatory Conditions -- wind direction in degrees [0:360]
+     * 
+     * @since 1.20.1
+     */
+    AOCWINDD(VALUE.REAL, "[deg] wind direction"),
+
+    /**
+     * ASCOM Observatory Conditions -- wind gusts in m/s
+     * 
+     * @since 1.20.1
+     */
+    AOCWINDG(VALUE.REAL, "[m/s] wind gust"),
+
+    /**
+     * ASCOM Observatory Conditions -- barometric pressure in hPa
+     * 
+     * @since 1.20.1
+     */
+    AOCBAROM(VALUE.REAL, "[hPa] barometric pressure"),
+
+    /**
+     * ASCOM Observatory Conditions -- cloud coverage in percent
+     * 
+     * @since 1.20.1
+     */
+    AOCCLOUD(VALUE.REAL, "[%] cloud coverage"),
+
+    /**
+     * ASCOM Observatory Conditions -- sky brightness in lux
+     * 
+     * @since 1.20.1
+     */
+
+    AOCSKYBR(VALUE.REAL, "[lx] sky brightness"),
+    /**
+     * ASCOM Observatory Conditions -- Sky quality in magnitudes / sq-arcsec
+     * 
+     * @since 1.20.1
+     */
+
+    AOCSKYQU(VALUE.REAL, "[mag/arcsec**2] sky quality"),
+    /**
+     * ASCOM Observatory Conditions -- sky temperature in degrees Celsius
+     * 
+     * @since 1.20.1
+     */
+
+    AOCSKYT(VALUE.REAL, "[C] sky temperature"),
+    /**
+     * ASCOM Observatory Conditions -- seeing FWHM in arcsec
+     * 
+     * @since 1.20.1
+     */
+    AOCFWHM(VALUE.REAL, "[arcsec] seeing FWHM"),
+
     /**
      * if present the image has a valid Bayer color pattern.
      */
-    BAYERPAT(VALUE.REAL, "image Bayer color pattern"),
+    BAYERPAT(VALUE.STRING, "Bayer color pattern"),
+
     /**
      * Boltwood Cloud Sensor ambient temperature in degrees C.
      */
-    BOLTAMBT(VALUE.REAL, "ambient temperature in degrees C"),
+    BOLTAMBT(VALUE.REAL, "[C] ambient temperature"),
+
     /**
      * Boltwood Cloud Sensor cloud condition.
      */
-    BOLTCLOU(VALUE.REAL, "Boltwood Cloud Sensor cloud condition."),
+    BOLTCLOU(VALUE.STRING, "cloud condition"),
 
     /**
-     * Boltwood Cloud Sensor daylight level.
+     * Boltwood Cloud Sensor daylight level (arbitrary units).
      */
-    BOLTDAY(VALUE.REAL, "Boltwood Cloud Sensor daylight level."),
+    BOLTDAY(VALUE.REAL, "daylight level"),
+
     /**
      * Boltwood Cloud Sensor dewpoint in degrees C.
      */
-    BOLTDEW(VALUE.REAL, "Boltwood Cloud Sensor dewpoint in degrees C."),
+    BOLTDEW(VALUE.REAL, "[C] dew point"),
+
     /**
      * Boltwood Cloud Sensor humidity in percent.
      */
-    BOLTHUM(VALUE.REAL, "Boltwood Cloud Sensor humidity in percent."),
+    BOLTHUM(VALUE.REAL, "[%] humidity"),
+
     /**
      * Boltwood Cloud Sensor rain condition.
      */
-    BOLTRAIN(VALUE.REAL, "Boltwood Cloud Sensor rain condition."),
+    BOLTRAIN(VALUE.STRING, "rain condition"),
+
     /**
      * Boltwood Cloud Sensor sky minus ambient temperature in degrees C.
      */
-    BOLTSKYT(VALUE.REAL, "Boltwood Cloud Sensor sky minus ambient temperature in degrees C."),
+    BOLTSKYT(VALUE.REAL, "[C] sky minus ambient temperature"),
+
     /**
      * Boltwood Cloud Sensor wind speed in km/h.
      */
-    BOLTWIND(VALUE.REAL, "Boltwood Cloud Sensor wind speed in km/h."),
+    BOLTWIND(VALUE.REAL, "[km/h] wind speed"),
+
     /**
      * indicates calibration state of the image; B indicates bias corrected, D indicates dark corrected, F indicates
      * flat corrected.
+     * 
+     * @see #CALSTAT_BIAS_CORRECTED
+     * @see #CALSTAT_DARK_CORRECTED
+     * @see #CALSTAT_FLAT_CORRECTED
      */
-    CALSTAT(VALUE.REAL, "calibration state of the image"),
+    CALSTAT(VALUE.STRING, "calibration state of the image"),
+
+    /**
+     * initial display screen stretch mode
+     */
+    CSTRETCH(VALUE.STRING, "initial display screen stretch mode"),
+
     /**
      * type of color sensor Bayer array or zero for monochrome.
      */
-    COLORTYP(VALUE.REAL, "type of color sensor"),
-    /**
-     * initial display screen stretch mode.
-     */
-    CSTRETCH(VALUE.REAL, "initial display screen stretch mode"),
-    /**
-     * dark current integration time, if recorded. May be longer than exposure time.
-     */
-    DARKTIME(VALUE.REAL, "dark current integration time"),
+    COLORTYP(VALUE.ANY, "type of color sensor"),
+
     /**
      * Davis Instruments Weather Station ambient temperature in deg C
+     * 
+     * @deprecated Not part of the current MaxIm DL specification
      */
-    DAVAMBT(VALUE.REAL, "ambient temperature"),
+    DAVAMBT(VALUE.REAL, "[C] ambient temperature"),
+
     /**
      * Davis Instruments Weather Station barometric pressure in hPa
+     * 
+     * @deprecated Not part of the current MaxIm DL specification
      */
-    DAVBAROM(VALUE.REAL, "barometric pressure"),
+    DAVBAROM(VALUE.REAL, "[hPa] barometric pressure"),
+
     /**
      * Davis Instruments Weather Station dewpoint in deg C
+     * 
+     * @deprecated Not part of the current MaxIm DL specification
      */
-    DAVDEW(VALUE.REAL, "dewpoint in deg C"),
+    DAVDEW(VALUE.REAL, "[C] dew point"),
+
     /**
      * Davis Instruments Weather Station humidity in percent
+     * 
+     * @deprecated Not part of the current MaxIm DL specification
      */
-    DAVHUM(VALUE.REAL, "humidity in percent"),
+    DAVHUM(VALUE.REAL, "[%] humidity"),
+
     /**
      * Davis Instruments Weather Station solar radiation in W/m^2
+     * 
+     * @deprecated Not part of the current MaxIm DL specification
      */
-    DAVRAD(VALUE.REAL, "solar radiation"),
+    DAVRAD(VALUE.REAL, "[W/m**2] solar radiation"),
+
     /**
      * Davis Instruments Weather Station accumulated rainfall in mm/day
+     * 
+     * @deprecated Not part of the current MaxIm DL specification
      */
-    DAVRAIN(VALUE.REAL, "accumulated rainfall"),
+    DAVRAIN(VALUE.REAL, "[mm/day] accumulated rainfall"),
+
     /**
      * Davis Instruments Weather Station wind speed in km/h
+     * 
+     * @deprecated Not part of the current MaxIm DL specification
      */
-    DAVWIND(VALUE.REAL, "wind speed"),
+    DAVWIND(VALUE.REAL, "[km/h] wind speed"),
+
     /**
      * Davis Instruments Weather Station wind direction in deg
+     * 
+     * @deprecated Not part of the current MaxIm DL specification
      */
-    DAVWINDD(VALUE.REAL, "wind direction"),
+    DAVWINDD(VALUE.REAL, "[deg] wind direction"),
+
     /**
      * status of pier flip for German Equatorial mounts.
      */
-    FLIPSTAT(VALUE.REAL, "status of pier flip"),
+    FLIPSTAT(VALUE.STRING, "status of pier flip"),
+
     /**
      * Focuser position in steps, if focuser is connected.
      */
-    FOCUSPOS(VALUE.REAL, "Focuser position in steps"),
+    FOCUSPOS(VALUE.REAL, "[ct] focuser position in steps"),
+
     /**
      * Focuser step size in microns, if available.
      */
-    FOCUSSZ(VALUE.REAL, "Focuser step size in microns"),
+    FOCUSSZ(VALUE.REAL, "[um] focuser step size"),
+
     /**
      * Focuser temperature readout in degrees C, if available.
      */
-    FOCUSTEM(VALUE.REAL, "Focuser temperature readout"),
+    FOCUSTEM(VALUE.REAL, "[C] focuser temperature readout"),
+
     /**
      * format of file from which image was read.
      */
-    INPUTFMT(VALUE.REAL, "format of file"),
+    INPUTFMT(VALUE.STRING, "format of file from which image was read"),
+
     /**
      * ISO camera setting, if camera uses ISO speeds.
      */
     ISOSPEED(VALUE.REAL, "ISO camera setting"),
+
     /**
      * records the geocentric Julian Day of the start of exposure.
      */
-    JD(VALUE.REAL, "geocentric Julian Day"),
+    JD(VALUE.REAL, "[day] Geocentric Julian Date"),
+
     /**
      * records the geocentric Julian Day of the start of exposure.
      */
-    JD_GEO(VALUE.REAL, "geocentric Julian Da"),
+    JD_GEO(VALUE.REAL, "[day] Geocentric Julian Date"),
+
     /**
      * records the Heliocentric Julian Date at the exposure midpoint.
      */
-    JD_HELIO(VALUE.REAL, "Heliocentric Julian Date"),
+    JD_HELIO(VALUE.REAL, "[day] Heliocentric Julian Date"),
+
     /**
      * records the Heliocentric Julian Date at the exposure midpoint.
      */
-    JD_HELIO2("JD-HELIO", VALUE.REAL, "Heliocentric Julian Date"),
+    JD_HELIO2("JD-HELIO", VALUE.REAL, "[day] Heliocentric Julian Date"),
+
     /**
-     * UT of midpoint of exposure.
+     * UT of midpoint of exposure (ISO timestamp).
      */
-    MIDPOINT(VALUE.REAL, "midpoint of exposure"),
+    MIDPOINT(VALUE.STRING, "midpoint of exposure"),
+
     /**
      * user-entered information; free-form notes.
      */
-    NOTES(VALUE.REAL, "free-form note"),
+    NOTES(VALUE.STRING, "free-form note"),
+
     /**
      * nominal altitude of center of image
      */
-    OBJCTALT(VALUE.REAL, "altitude of center of image"),
+    OBJCTALT(VALUE.REAL, "[deg] altitude of center of image"),
+
     /**
      * nominal azimuth of center of image
      */
-    OBJCTAZ(VALUE.REAL, "nominal azimuth of center of image"),
+    OBJCTAZ(VALUE.REAL, "[deg] nominal azimuth of center of image"),
+
     /**
      * nominal hour angle of center of image
      */
-    OBJCTHA(VALUE.REAL, "nominal hour angle of center of image"),
+    OBJCTHA(VALUE.REAL, "[h] nominal hour angle of center of image"),
+
     /**
      * indicates side-of-pier status when connected to a German Equatorial mount.
      */
-    PIERSIDE(VALUE.REAL, "side-of-pier status"),
+    PIERSIDE(VALUE.STRING, "side-of-pier status"),
+
     /**
      * records the selected Readout Mode (if any) for the camera.
      */
-    READOUTM(VALUE.REAL, "Readout Mode for the camera"),
+    READOUTM(VALUE.STRING, "readout Mode for the camera"),
+
     /**
      * Rotator angle in degrees, if focal plane rotator is connected.
      */
-    ROTATANG(VALUE.REAL, "Rotator angle in degrees"),
+    ROTATANG(VALUE.REAL, "[deg] rotator angle in degrees"),
+
+    /**
+     * Images taken by MaxIm DL are always TOP-DOWN.
+     * 
+     * @see   #ROWORDER_TOP_DOWN
+     * @see   #ROWORDER_BOTTOM_UP
+     * 
+     * @since 1.20.1
+     */
+    ROWORDER(VALUE.STRING, "pixel row readout order"),
+
     /**
      * indicates tile position within a mosaic.
      */
@@ -219,11 +564,80 @@ public enum MaxImDLExt implements IFitsHeader {
      */
     YBAYROFF(VALUE.REAL, "Y offset of Bayer array");
 
+    /**
+     * Value for {@link #CALSTAT} indicating a bias corrected calibration state.
+     * 
+     * @since 1.20.1
+     */
+    public static final String CALSTAT_BIAS_CORRECTED = "B";
+
+    /**
+     * Value for {@link #CALSTAT} indicating a dark corrected calibration state.
+     * 
+     * @since 1.20.1
+     */
+    public static final String CALSTAT_DARK_CORRECTED = "D";
+
+    /**
+     * Value for {@link #CALSTAT} indicating a flat corrected calibration state.
+     * 
+     * @since 1.20.1
+     */
+    public static final String CALSTAT_FLAT_CORRECTED = "F";
+
+    /**
+     * Value for {@link #ROWORDER} indicating top-down ordering. MaxIm DL images are always this type
+     * 
+     * @since 1.20.1
+     */
+    public static final String ROWORDER_TOP_DOWN = "TOP-DOWN";
+
+    /**
+     * Value for {@link #ROWORDER} indicating bottom-up ordering.
+     * 
+     * @since 1.20.1
+     */
+    public static final String ROWORDER_BOTTOM_UP = "BOTTOM-UP";
+
+    /**
+     * Standard {@link #IMAGETYP} value for a light frame.
+     * 
+     * @since 1.20.1
+     */
+    public static final String IMAGETYP_LIGHT_FRAME = "Light Frame";
+
+    /**
+     * Standard {@link #IMAGETYP} value for a bias frame.
+     * 
+     * @since 1.20.1
+     */
+    public static final String IMAGETYP_BIAS_FRAME = "Bias Frame";
+
+    /**
+     * Standard {@link #IMAGETYP} value for a dark frame.
+     * 
+     * @since 1.20.1
+     */
+    public static final String IMAGETYP_DARK_FRAME = "Dark Frame";
+
+    /**
+     * Standard {@link #IMAGETYP} value for a flat frame.
+     * 
+     * @since 1.20.1
+     */
+    public static final String IMAGETYP_FLAT_FRAME = "Flat Frame";
+
+    /**
+     * Standard {@link #IMAGETYP} value for a tricolor image.
+     * 
+     * @since 1.20.1
+     */
+    public static final String IMAGETYP_TRICOLOR_IMAGE = "Tricolor Image";
+
     private final FitsKey key;
 
     MaxImDLExt(String key, VALUE valueType, String comment) {
-        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType,
-                comment);
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType, comment);
     }
 
     MaxImDLExt(VALUE valueType, String comment) {

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -57,179 +57,209 @@ public enum MaxImDLExt implements IFitsHeader {
     // ------------------------------------------------------------------------
 
     /**
-     * Aperture Area of the Telescope used in square millimeters. Note that we are specifying the area as well as the
-     * diameter because we want to be able to correct for any central obstruction.
-     */
-    APTAREA(VALUE.REAL, "[mm**2] telescope aperture area"),
-
-    /**
-     * Aperture Diameter of the Telescope used in millimeters.
-     */
-    APTDIA(VALUE.REAL, "[mm] telescope aperture diameter"),
-
-    /**
-     * Upon initial display of this image use this ADU level for the Black level.
-     */
-    CBLACK(VALUE.REAL, "[adu] black level counts"),
-
-    /**
-     * Temperature of CCD when exposure taken.
-     */
-    CCD_TEMP("CCD-TEMP", VALUE.REAL, "[C] temperature of CCD"),
-
-    /**
-     * Altitude of the center of the image in +DDD MM SS.SSS format.
-     */
-    CENTALT(VALUE.STRING, "DMS altitude of the center of the image"),
-
-    /**
-     * Azimuth of the center of the image in +DDD MM SS.SSS format.
-     */
-    CENTAZ(VALUE.STRING, "DMS azimuth of the center of the image"),
-
-    /**
-     * Upon initial display of this image use this ADU level as the White level. For the SBIG method of displaying
-     * images using Background and Range the following conversions would be used: Background = CBLACK Range = CWHITE -
-     * CBLACK.
-     */
-    CWHITE(VALUE.REAL, "[adu] white level counts"),
-
-    /**
-     * Total dark time of the observation. This is the total time during which dark current is collected by the
-     * detector. If the times in the extension are different the primary HDU gives one of the extension times.
-     * <p>
-     * units = UNITTIME
-     * </p>
-     * <p>
-     * default value = EXPTIME
-     * </p>
-     * <p>
-     * index = none
-     * </p>
-     */
-    DARKTIME(VALUE.REAL, "[s] dark time"),
-
-    /**
-     * Electronic gain in e-/ADU.
-     */
-    EGAIN(VALUE.REAL, "[ct/adu] electronic gain in electrons/ADU"),
-
-    /*
-     * Optional Keywords <p> The following Keywords are not defined in the FITS Standard but are defined in this
-     * Standard. They may or may not be included by AIP Software Packages adhering to this Standard. Any of these
-     * keywords read by an AIP Package must be preserved in files written. </p>
-     */
-
-    /**
-     * Focal Length of the Telescope used in millimeters.
-     */
-    FOCALLEN(VALUE.REAL, "[mm] focal length of telescope"),
-
-    /**
-     * This indicates the type of image and should be one of the following: 'Light Frame', 'Dark Frame', 'Bias Frame',
-     * 'Flat Field', or 'Tricolor Image'.
+     * Same as {@link SBFitsExt#APTAREA}.
      * 
-     * @see #IMAGETYP_LIGHT_FRAME
-     * @see #IMAGETYP_DARK_FRAME
-     * @see #IMAGETYP_FLAT_FRAME
-     * @see #IMAGETYP_BIAS_FRAME
-     * @see #IMAGETYP_TRICOLOR_IMAGE
+     * @since 1.20.1
      */
-    IMAGETYP(VALUE.STRING, "type of image"),
+    APTAREA(SBFitsExt.APTAREA),
 
     /**
-     * This is the Declination of the center of the image in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. North is + and
-     * South is -.
+     * Same as {@link SBFitsExt#APTDIA}.
+     * 
+     * @since 1.20.1
      */
-    OBJCTDEC(VALUE.STRING, "DMS declination of image center"),
+    APTDIA(SBFitsExt.APTDIA),
 
     /**
-     * This is the Right Ascension of the center of the image in HH MM SS.SSS format. E.g. ’12 24 23.123’.
+     * Same as {@link SBFitsExt#CBLACK}.
+     * 
+     * @since 1.20.1
      */
-    OBJCTRA(VALUE.STRING, "HMS right ascension of image center"),
+    CBLACK(SBFitsExt.CBLACK),
 
     /**
-     * Add this ADU count to each pixel value to get to a zero-based ADU. For example in SBIG images we add 100 ADU to
-     * each pixel to stop underflow at Zero ADU from noise. We would set PEDESTAL to -100 in this case.
+     * Same as {@link SBFitsExt#CCD_TEMP}.
+     * 
+     * @since 1.20.1
      */
-    PEDESTAL(VALUE.REAL, "[adu] zero level counts"),
+    CCD_TEMP(SBFitsExt.CCD_TEMP),
 
     /**
-     * This string indicates the version of this standard that the image was created to ie ‘SBFITSEXT Version 1.0’.
+     * Same as {@link SBFitsExt#CENTALT}.
+     * 
+     * @since 1.20.1
      */
-    SBSTDVER(VALUE.STRING, "version of this standard"),
+    CENTALT(SBFitsExt.CENTALT),
 
     /**
-     * This is the setpoint of the cooling in degrees Celsius. If it is not specified the setpoint is assumed to be the
+     * Same as {@link SBFitsExt#CENTAZ}.
+     * 
+     * @since 1.20.1
      */
-    SET_TEMP("SET-TEMP", VALUE.REAL, "[C] setpoint of the cooling"),
+    CENTAZ(SBFitsExt.CENTAZ),
 
     /**
-     * Latitude of the imaging location in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. North is + and South is -.
+     * Same as {@link SBFitsExt#CWHITE}.
+     * 
+     * @since 1.20.1
      */
-    SITELAT(VALUE.STRING, "DMS latitude of the imaging location"),
+    CWHITE(SBFitsExt.CWHITE),
 
     /**
-     * Longitude of the imaging location in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. East is + and West is -.
+     * Same as {@link SBFitsExt#DARKTIME}.
+     * 
+     * @since 1.20.1
      */
-    SITELONG(VALUE.STRING, "DMS longitude of the imaging location"),
+    DARKTIME(SBFitsExt.DARKTIME),
 
     /**
-     * Number of images combined to make this image as in track and accumulate or coadded images.
+     * Same as {@link SBFitsExt#EGAIN}.
+     * 
+     * @since 1.20.1
      */
-    SNAPSHOT(VALUE.INTEGER, "number of images combined"),
+    EGAIN(SBFitsExt.EGAIN),
 
     /**
-     * This indicates the name and version of the Software that initially created this file ie ‘SBIGs CCDOps Version
-     * 5.10’.
+     * Same as {@link SBFitsExt#FOCALLEN}.
+     * 
+     * @since 1.20.1
      */
-    SWCREATE(VALUE.STRING, "software name and version that created file"),
+    FOCALLEN(SBFitsExt.FOCALLEN),
 
     /**
-     * This indicates the name and version of the Software that modified this file ie ‘SBIGs CCDOps Version 5.10’ and
-     * the re can be multiple copies of this keyword. Only add this keyword if you actually modified the image and we
-     * suggest placing this above the HISTORY keywords corresponding to the modifications made to the image.
+     * Same as {@link SBFitsExt#IMAGETYP}.
+     * 
+     * @since 1.20.1
+     * 
+     * @see   #IMAGETYP_LIGHT_FRAME
+     * @see   #IMAGETYP_DARK_FRAME
+     * @see   #IMAGETYP_FLAT_FRAME
+     * @see   #IMAGETYP_BIAS_FRAME
+     * @see   #IMAGETYP_TRICOLOR_IMAGE
      */
-    SWMODIFY(VALUE.STRING, "list of software that modified file"),
+    IMAGETYP(SBFitsExt.IMAGETYP),
 
     /**
-     * If the image was auto-guided this is the exposure time in seconds of the tracker used to acquire this image. If
-     * this keyword is not present then the image was unguided or hand guided.
+     * Same as {@link SBFitsExt#OBJCTDEC}.
+     * 
+     * @since 1.20.1
      */
-    TRAKTIME(VALUE.REAL, "[s] exposure time of the tracker"),
+    OBJCTDEC(SBFitsExt.OBJCTDEC),
 
     /**
-     * Binning factor in width.
+     * Same as {@link SBFitsExt#OBJCTRA}.
+     * 
+     * @since 1.20.1
      */
-    XBINNING(VALUE.INTEGER, "binning factor in width"),
+    OBJCTRA(SBFitsExt.OBJCTRA),
 
     /**
-     * Sub frame X position of upper left pixel relative to whole frame in binned pixel units.
+     * Same as {@link SBFitsExt#PEDESTAL}.
+     * 
+     * @since 1.20.1
      */
-    XORGSUBF(VALUE.INTEGER, "[pix] sub frame X position"),
+    PEDESTAL(SBFitsExt.PEDESTAL),
 
     /**
-     * Pixel width in microns (after binning).
+     * Same as {@link SBFitsExt#SBSTDVER}.
+     * 
+     * @since 1.20.1
      */
-    XPIXSZ(VALUE.REAL, "[um] pixel width"),
+    SBSTDVER(SBFitsExt.SBSTDVER),
 
     /**
-     * Binning factor in height.
+     * Same as {@link SBFitsExt#SET_TEMP}.
+     * 
+     * @since 1.20.1
      */
-    YBINNING(VALUE.INTEGER, "binning factor in height"),
+    SET_TEMP(SBFitsExt.SET_TEMP),
 
     /**
-     * Sub frame Y position of upper left pixel relative to whole frame in binned pixel units.
+     * Same as {@link SBFitsExt#SITELAT}.
+     * 
+     * @since 1.20.1
      */
-    YORGSUBF(VALUE.INTEGER, "[pix] sub frame Y position"),
+    SITELAT(SBFitsExt.SITELAT),
 
     /**
-     * Pixel height in microns (after binning).
+     * Same as {@link SBFitsExt#SITELONG}.
+     * 
+     * @since 1.20.1
      */
-    YPIXSZ(VALUE.REAL, "[um] pixel height"),
+    SITELONG(SBFitsExt.SITELONG),
+
+    /**
+     * Same as {@link SBFitsExt#SNAPSHOT}.
+     * 
+     * @since 1.20.1
+     */
+    SNAPSHOT(SBFitsExt.SNAPSHOT),
+
+    /**
+     * Same as {@link SBFitsExt#SWCREATE}.
+     * 
+     * @since 1.20.1
+     */
+    SWCREATE(SBFitsExt.SWCREATE),
+
+    /**
+     * Same as {@link SBFitsExt#SWMODIFY}.
+     * 
+     * @since 1.20.1
+     */
+    SWMODIFY(SBFitsExt.SWMODIFY),
+
+    /**
+     * Same as {@link SBFitsExt#TRAKTIME}.
+     * 
+     * @since 1.20.1
+     */
+    TRAKTIME(SBFitsExt.TRAKTIME),
+
+    /**
+     * Same as {@link SBFitsExt#XBINNING}.
+     * 
+     * @since 1.20.1
+     */
+    XBINNING(SBFitsExt.XBINNING),
+
+    /**
+     * Same as {@link SBFitsExt#XORGSUBF}.
+     * 
+     * @since 1.20.1
+     */
+    XORGSUBF(SBFitsExt.XORGSUBF),
+
+    /**
+     * Same as {@link SBFitsExt#XPIXSZ}.
+     * 
+     * @since 1.20.1
+     */
+    XPIXSZ(SBFitsExt.XPIXSZ),
+
+    /**
+     * Same as {@link SBFitsExt#YBINNING}.
+     * 
+     * @since 1.20.1
+     */
+    YBINNING(SBFitsExt.YBINNING),
+
+    /**
+     * Same as {@link SBFitsExt#YORGSUBF}.
+     * 
+     * @since 1.20.1
+     */
+    YORGSUBF(SBFitsExt.YORGSUBF),
+
+    /**
+     * Same as {@link SBFitsExt#YPIXSZ}.
+     * 
+     * @since 1.20.1
+     */
+    YPIXSZ(SBFitsExt.YPIXSZ),
 
     // ------------------------------------------------------------------------
-    // Additional MaxIm DL keywords, beyong the SBIG proposal
+    // Additional MaxIm DL keywords, beyond the SBIG proposal
     // ------------------------------------------------------------------------
 
     /**
@@ -608,32 +638,32 @@ public enum MaxImDLExt implements IFitsHeader {
     public static final String ROWORDER_BOTTOM_UP = "BOTTOM-UP";
 
     /**
-     * Standard {@link #IMAGETYP} value for a light frame.
+     * Same as {@link SBFitsExt#IMAGETYP_LIGHT_FRAME}.
      * 
      * @since 1.20.1
      */
-    public static final String IMAGETYP_LIGHT_FRAME = "Light Frame";
+    public static final String IMAGETYP_LIGHT_FRAME = SBFitsExt.IMAGETYP_LIGHT_FRAME;
 
     /**
-     * Standard {@link #IMAGETYP} value for a bias frame.
+     * Same as {@link SBFitsExt#IMAGETYP_BIAS_FRAME}.
      * 
      * @since 1.20.1
      */
-    public static final String IMAGETYP_BIAS_FRAME = "Bias Frame";
+    public static final String IMAGETYP_BIAS_FRAME = SBFitsExt.IMAGETYP_BIAS_FRAME;
 
     /**
-     * Standard {@link #IMAGETYP} value for a dark frame.
+     * Same as {@link SBFitsExt#IMAGETYP_DARK_FRAME}.
      * 
      * @since 1.20.1
      */
-    public static final String IMAGETYP_DARK_FRAME = "Dark Frame";
+    public static final String IMAGETYP_DARK_FRAME = SBFitsExt.IMAGETYP_DARK_FRAME;
 
     /**
-     * Standard {@link #IMAGETYP} value for a flat frame.
+     * Same as {@link SBFitsExt#IMAGETYP_FLAT_FRAME}.
      * 
      * @since 1.20.1
      */
-    public static final String IMAGETYP_FLAT_FRAME = "Flat Frame";
+    public static final String IMAGETYP_FLAT_FRAME = SBFitsExt.IMAGETYP_FLAT_FRAME;
 
     /**
      * Standard {@link #IMAGETYP} value for a tricolor image.
@@ -671,6 +701,10 @@ public enum MaxImDLExt implements IFitsHeader {
     public static final String READOUTM_LONG_EXPOSURE_MODE = "Long Exposure Mode";
 
     private final FitsKey key;
+
+    MaxImDLExt(IFitsHeader key) {
+        this.key = key.impl();
+    }
 
     MaxImDLExt(String key, VALUE valueType, String comment) {
         this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.MaxImDL, HDU.IMAGE, valueType, comment);

--- a/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/MaxImDLExt.java
@@ -46,7 +46,7 @@ import nom.tam.fits.header.IFitsHeader;
  * http://www.cyanogen.com/help/maximdl/FITS_File_Header_Definitions.htm
  * </pre>
  *
- * @author Richard van Nieuwenhoven, Attila Kovacs, and John Murphy
+ * @author Attila Kovacs, John Murphy, and Richard van Nieuwenhoven
  * 
  * @see    SBFitsExt
  */

--- a/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/NOAOExt.java
@@ -7474,6 +7474,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITENER(HDU.PRIMARY, VALUE.STRING, "Energy unit"),
+
     /**
      * Event unit.
      * <p>
@@ -7484,6 +7485,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITEVNT(HDU.PRIMARY, VALUE.STRING, "Event unit"),
+
     /**
      * Flux unit.
      * <p>
@@ -7494,6 +7496,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITFLUX(HDU.PRIMARY, VALUE.STRING, "Flux unit"),
+
     /**
      * Force unit.
      * <p>
@@ -7504,6 +7507,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITFORC(HDU.PRIMARY, VALUE.STRING, "Force unit"),
+
     /**
      * Frequency unit.
      * <p>
@@ -7514,6 +7518,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITFREQ(HDU.PRIMARY, VALUE.STRING, "Frequency unit"),
+
     /**
      * Time of day unit.
      * <p>
@@ -7524,6 +7529,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITHOUR(HDU.PRIMARY, VALUE.STRING, "Time of day unit"),
+
     /**
      * Illuminance unit.
      * <p>
@@ -7534,6 +7540,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITILLU(HDU.PRIMARY, VALUE.STRING, "Illuminance unit"),
+
     /**
      * Inductance unit.
      * <p>
@@ -7544,6 +7551,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITINDU(HDU.PRIMARY, VALUE.STRING, "Inductance unit"),
+
     /**
      * Latitude unit.
      * <p>
@@ -7554,6 +7562,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITLAT(HDU.PRIMARY, VALUE.STRING, "Latitude unit"),
+
     /**
      * Length unit. A wavelength unit is also provided so this unit is primarily used to instrumental descriptions.
      * <p>
@@ -7564,6 +7573,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITLEN(HDU.PRIMARY, VALUE.STRING, "Length unit"),
+
     /**
      * Luminous flux unit.
      * <p>
@@ -7574,6 +7584,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITLFLX(HDU.PRIMARY, VALUE.STRING, "Luminous flux unit"),
+
     /**
      * Luminous intensity unit.
      * <p>
@@ -7584,6 +7595,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITLINT(HDU.PRIMARY, VALUE.STRING, "Luminous intensity unit"),
+
     /**
      * Longitude unit.
      * <p>
@@ -7594,6 +7606,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITLONG(HDU.PRIMARY, VALUE.STRING, "Longitude unit"),
+
     /**
      * Mass unit.
      * <p>
@@ -7604,6 +7617,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITMASS(HDU.PRIMARY, VALUE.STRING, "Mass unit"),
+
     /**
      * Magnetic density unit.
      * <p>
@@ -7614,6 +7628,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITMDEN(HDU.PRIMARY, VALUE.STRING, "Magnetic density unit"),
+
     /**
      * Magnetic field unit.
      * <p>
@@ -7624,6 +7639,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITMFLD(HDU.PRIMARY, VALUE.STRING, "Magnetic field unit"),
+
     /**
      * Magnetic flux unit.
      * <p>
@@ -7634,6 +7650,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITMFLX(HDU.PRIMARY, VALUE.STRING, "Magnetic flux unit"),
+
     /**
      * Position angle unit.
      * <p>
@@ -7644,6 +7661,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITPA(HDU.PRIMARY, VALUE.STRING, "Position angle unit"),
+
     /**
      * Power unit.
      * <p>
@@ -7654,6 +7672,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITPOW(HDU.PRIMARY, VALUE.STRING, "Wavelength unit"),
+
     /**
      * Pressure unit.
      * <p>
@@ -7664,6 +7683,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITPRES(HDU.PRIMARY, VALUE.STRING, "Pressure unit"),
+
     /**
      * Right ascension unit.
      * <p>
@@ -7674,6 +7694,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITRA(HDU.PRIMARY, VALUE.STRING, "Right ascension unit"),
+
     /**
      * Celestial rate of motion.
      * <p>
@@ -7683,7 +7704,8 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    UNITRATE(HDU.PRIMARY, VALUE.STRING, "Celestial rate of motion"),
+    UNITRATE(HDU.PRIMARY, VALUE.STRING, "Celestial rate of motion unit"),
+
     /**
      * Resistance unit.
      * <p>
@@ -7694,6 +7716,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITRES(HDU.PRIMARY, VALUE.STRING, "Resistance unit"),
+
     /**
      * Solid angle unit.
      * <p>
@@ -7704,6 +7727,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITSANG(HDU.PRIMARY, VALUE.STRING, "Solid angle unit"),
+
     /**
      * Celestial separation unit.
      * <p>
@@ -7713,7 +7737,8 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    UNITSEP(HDU.PRIMARY, VALUE.STRING, "Separation unit"),
+    UNITSEP(HDU.PRIMARY, VALUE.STRING, "Angular separation unit"),
+
     /**
      * Temperature unit.
      * <p>
@@ -7724,6 +7749,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITTEMP(HDU.PRIMARY, VALUE.STRING, "Temperature unit"),
+
     /**
      * Time unit.
      * <p>
@@ -7734,6 +7760,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITTIME(HDU.PRIMARY, VALUE.STRING, "Time unit"),
+
     /**
      * Velocity unit.
      * <p>
@@ -7744,6 +7771,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITVEL(HDU.PRIMARY, VALUE.STRING, "Velocity unit"),
+
     /**
      * Voltage unit.
      * <p>
@@ -7754,6 +7782,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UNITVOLT(HDU.PRIMARY, VALUE.STRING, "Voltage unit"),
+
     /**
      * UTC time at the start of the exposure.
      * <p>
@@ -7767,6 +7796,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UTC_OBS("UTC-OBS", HDU.ANY, VALUE.STRING, "UTC of exposure start"),
+
     /**
      * UTC at the end of the exposure.
      * <p>
@@ -7780,6 +7810,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UTCEND(HDU.ANY, VALUE.STRING, "UTC at end of exposure"),
+
     /**
      * UTC of header creation.
      * <p>
@@ -7793,6 +7824,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     UTCHDR(HDU.ANY, VALUE.STRING, "UTC of header creation"),
+
     /**
      * Default UTC time for the observation. This keyword is generally not used and is UTC-OBS keyword for the start of
      * the exposure on the detector is used.
@@ -7817,6 +7849,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     WAT_nnn(HDU.ANY, VALUE.STRING, ""),
+
     /**
      * IRAF WCS attribute strings. These are defined by the IRAF WCS system.
      * <p>
@@ -7827,6 +7860,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     WATn_nnn(HDU.ANY, VALUE.STRING, ""),
+
     /**
      * Descriptive string identifying the source of the astrometry used to derive the WCS. One example is the exposure
      * used to derive a WCS apart from the reference coordinate.
@@ -7838,6 +7872,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     WCSAnnn(HDU.ANY, VALUE.STRING, "WCS Source"),
+
     /**
      * Descriptive string identifying the source of the astrometry used to derive the WCS. One example is the exposure
      * used to derive a WCS apart from the reference coordinate.
@@ -7849,6 +7884,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     WCSASTRM(HDU.ANY, VALUE.STRING, "WCS Source"),
+
     /**
      * Dimensionality of the WCS physical system. In IRAF a WCS can have a higher dimensionality than the image.
      * <p>
@@ -7859,6 +7895,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     WCSDIM(HDU.ANY, VALUE.INTEGER, "WCS dimensionality"),
+
     /**
      * Epoch of the coordinates used in the world coordinate system.
      * <p>
@@ -7871,7 +7908,8 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    WCSEnnn(HDU.ANY, VALUE.REAL, "WCS coordinate epoch"),
+    WCSEnnn(HDU.ANY, VALUE.REAL, "[yr] WCS coordinate epoch"),
+
     /**
      * Equinox when equatorial coordinates are used in the world coordinate system. A value before 1984 is Besselian
      * otherwise it is Julian.
@@ -7885,7 +7923,8 @@ public enum NOAOExt implements IFitsHeader {
      * index = none 1-9999
      * </p>
      */
-    WCSEPOCH(HDU.ANY, VALUE.REAL, "WCS coordinate epoch"),
+    WCSEPOCH(HDU.ANY, VALUE.REAL, "[yr] WCS coordinate epoch"),
+
     /**
      * Coordinate system type when equatorial coordinates are used in the world coordinate system.
      * <p>
@@ -7896,6 +7935,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     WCSRADEC(HDU.ANY, VALUE.STRING, "WCS coordinate system"),
+
     /**
      * Coordinate system type when equatorial coordinates are used in the world coordinate system.
      * <p>
@@ -7906,6 +7946,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     WCSRnnn(HDU.ANY, VALUE.STRING, "WCS coordinate system"),
+
     /**
      * Weather condition description. Generally this would be either 'clear' or 'partly cloudy'.
      * <p>
@@ -7916,6 +7957,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     WEATHER(HDU.PRIMARY, VALUE.STRING, "Weather conditions"),
+
     /**
      * Zenith distance of telescope pointing at TELMJD.
      * <p>
@@ -7929,6 +7971,7 @@ public enum NOAOExt implements IFitsHeader {
      * </p>
      */
     ZD(HDU.PRIMARY, VALUE.REAL, "Zenith distance"),
+
     /**
      * Modified Julian date at the start of the exposure. The fractional part of the date is given to better than a
      * second of time.
@@ -7942,7 +7985,7 @@ public enum NOAOExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    MJD_OBS("MJD-OBS", HDU.ANY, VALUE.REAL, "MJD of exposure start");
+    MJD_OBS("MJD-OBS", HDU.ANY, VALUE.REAL, "[day] MJD of exposure start");
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -158,6 +158,7 @@ public enum SBFitsExt implements IFitsHeader {
 
     /**
      * This is the setpoint of the cooling in degrees Celsius. If it is not specified the setpoint is assumed to be the
+     * ambient temperature.
      */
     SET_TEMP("SET-TEMP", VALUE.REAL, "[C] setpoint of the cooling"),
 

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -47,40 +47,50 @@ import nom.tam.fits.header.IFitsHeader;
  * https://diffractionlimited.com/wp-content/uploads/2016/11/sbfitsext_1r0.pdf</a>
  * </p>
  *
- * @author Richard van Nieuwenhoven.
+ * @author Richard van Nieuwenhoven and Attila Kovacs
+ * 
+ * @see    MaxImDLExt
  */
 public enum SBFitsExt implements IFitsHeader {
+
     /**
      * Aperture Area of the Telescope used in square millimeters. Note that we are specifying the area as well as the
      * diameter because we want to be able to correct for any central obstruction.
      */
-    APTAREA(VALUE.REAL, "Aperture Area of the Telescope"),
+    APTAREA(VALUE.REAL, "[mm**2] telescope aperture area"),
+
     /**
      * Aperture Diameter of the Telescope used in millimeters.
      */
-    APTDIA(VALUE.REAL, "Aperture Diameter of the Telescope"),
+    APTDIA(VALUE.REAL, "[mm] telescope aperture diameter"),
+
     /**
      * Upon initial display of this image use this ADU level for the Black level.
      */
-    CBLACK(VALUE.INTEGER, "use this ADU level for the Black"),
+    CBLACK(VALUE.REAL, "[adu] black level counts"),
+
     /**
      * Temperature of CCD when exposure taken.
      */
-    CCD_TEMP("CCD-TEMP", VALUE.REAL, "Temperature of CCD"),
+    CCD_TEMP("CCD-TEMP", VALUE.REAL, "[C] temperature of CCD"),
+
     /**
-     * Altitude in degrees of the center of the image in degrees. Format is the same as the OBJCTDEC keyword.
+     * Altitude of the center of the image in +DDD MM SS.SSS format.
      */
-    CENTALT(VALUE.STRING, "Altitude of the center of the image"),
+    CENTALT(VALUE.STRING, "DMS altitude of the center of the image"),
+
     /**
-     * Azimuth in degrees of the center of the image in degrees. Format is the same as the OBJCTDEC keyword.
+     * Azimuth of the center of the image in +DDD MM SS.SSS format.
      */
-    CENTAZ(VALUE.STRING, "Azimuth of the center of the image"),
+    CENTAZ(VALUE.STRING, "DMS azimuth of the center of the image"),
+
     /**
      * Upon initial display of this image use this ADU level as the White level. For the SBIG method of displaying
      * images using Background and Range the following conversions would be used: Background = CBLACK Range = CWHITE -
      * CBLACK.
      */
-    CWHITE(VALUE.INTEGER, "use this ADU level for the White"),
+    CWHITE(VALUE.REAL, "[adu] white level counts"),
+
     /**
      * Total dark time of the observation. This is the total time during which dark current is collected by the
      * detector. If the times in the extension are different the primary HDU gives one of the extension times.
@@ -94,104 +104,141 @@ public enum SBFitsExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    DARKTIME(VALUE.REAL, "Dark time"),
+    DARKTIME(VALUE.REAL, "[s] dark time"),
+
     /**
      * Electronic gain in e-/ADU.
      */
-    EGAIN(VALUE.REAL, "Electronic gain in e-/ADU"),
+    EGAIN(VALUE.REAL, "[ct/adu] electronic gain in electrons/ADU"),
+
     /*
      * Optional Keywords <p> The following Keywords are not defined in the FITS Standard but are defined in this
      * Standard. They may or may not be included by AIP Software Packages adhering to this Standard. Any of these
      * keywords read by an AIP Package must be preserved in files written. </p>
      */
+
     /**
      * Focal Length of the Telescope used in millimeters.
      */
-    FOCALLEN(VALUE.REAL, "Focal Length of the Telescope"),
+    FOCALLEN(VALUE.REAL, "[mm] focal length of telescope"),
+
     /**
-     * This indicates the type of image and should be one of the following: Light Frame Dark Frame Bias Frame Flat
-     * Field.
+     * This indicates the type of image and should be one of the following: 'Light Frame', 'Dark Frame', 'Bias Frame',
+     * 'Flat Field', or 'Tricolor Image'.
+     * 
+     * @see #IMAGETYP_LIGHT_FRAME
+     * @see #IMAGETYP_DARK_FRAME
+     * @see #IMAGETYP_FLAT_FRAME
+     * @see #IMAGETYP_BIAS_FRAME
+     * @see #IMAGETYP_TRICOLOR_IMAGE
      */
     IMAGETYP(VALUE.STRING, "type of image"),
+
     /**
-     * This is the Declination of the center of the image in degrees. The format for this is ‘+25 12 34.111’ (SDD MM
-     * SS.SSS) using a space as the separator. For the sign, North is + and South is -.
+     * This is the Declination of the center of the image in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. North is + and
+     * South is -.
      */
-    OBJCTDEC(VALUE.STRING, "Declination of the center of the image"),
+    OBJCTDEC(VALUE.STRING, "DMS declination of image center"),
+
     /**
-     * This is the Right Ascension of the center of the image in hours, minutes and secon ds. The format for this is ’12
-     * 24 23.123’ (HH MM SS.SSS) using a space as the separator.
+     * This is the Right Ascension of the center of the image in HH MM SS.SSS format. E.g. ’12 24 23.123’.
      */
-    OBJCTRA(VALUE.STRING, "Right Ascension of the center of the image"),
+    OBJCTRA(VALUE.STRING, "HMS right ascension of image center"),
+
     /**
-     * Add this ADU count to each pixel value to get to a zero - based ADU. For example in SBIG images we add 100 ADU to
-     * each pixel to stop underflow at Zero ADU from noise. We would set PEDESTAL to - 100 in this case.
+     * Add this ADU count to each pixel value to get to a zero-based ADU. For example in SBIG images we add 100 ADU to
+     * each pixel to stop underflow at Zero ADU from noise. We would set PEDESTAL to -100 in this case.
      */
-    PEDESTAL(VALUE.INTEGER, "ADU count to each pixel value to get to a zero"),
+    PEDESTAL(VALUE.REAL, "[adu] zero level counts"),
+
     /**
      * This string indicates the version of this standard that the image was created to ie ‘SBFITSEXT Version 1.0’.
      */
     SBSTDVER(VALUE.STRING, "version of this standard"),
-    /**
-     * This is the setpoint of the cooling in degrees C. If it is not specified the setpoint is assumed to be the
-     */
-    SET_TEMP("SET-TEMP", VALUE.REAL, "setpoint of the cooling in degrees C"),
-    /**
-     * Latitude of the imaging location in degrees. Format is the same as the OBJCTDEC key word.
-     */
-    SITELAT(VALUE.STRING, "Latitude of the imaging location"),
 
     /**
-     * Longitude of the imaging location in degrees. Format is the same as the OBJCTDEC keyword.
+     * This is the setpoint of the cooling in degrees Celsius. If it is not specified the setpoint is assumed to be the
      */
-    SITELONG(VALUE.STRING, "Longitude of the imaging location"),
+    SET_TEMP("SET-TEMP", VALUE.REAL, "[C] setpoint of the cooling"),
+
     /**
-     * Number of images combined to make this image as in Track and Accumulate or Co - Added images.
+     * Latitude of the imaging location in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. North is + and South is -.
      */
-    SNAPSHOT(VALUE.INTEGER, "Number of images combined"),
+    SITELAT(VALUE.STRING, "DMS latitude of the imaging location"),
+
+    /**
+     * Longitude of the imaging location in +DDD MM SS.SSS format. E.g. ‘+25 12 34.111’. East is + and West is -.
+     */
+    SITELONG(VALUE.STRING, "DMS longitude of the imaging location"),
+
+    /**
+     * Number of images combined to make this image as in track and accumulate or coadded images.
+     */
+    SNAPSHOT(VALUE.INTEGER, "number of images combined"),
+
     /**
      * This indicates the name and version of the Software that initially created this file ie ‘SBIGs CCDOps Version
      * 5.10’.
      */
-    SWCREATE(VALUE.STRING, "created version of the Software"),
+    SWCREATE(VALUE.STRING, "software name and version that created file"),
+
     /**
      * This indicates the name and version of the Software that modified this file ie ‘SBIGs CCDOps Version 5.10’ and
      * the re can be multiple copies of this keyword. Only add this keyword if you actually modified the image and we
      * suggest placing this above the HISTORY keywords corresponding to the modifications made to the image.
      */
-    SWMODIFY(VALUE.STRING, "modified version of the Software"),
+    SWMODIFY(VALUE.STRING, "list of software that modified file"),
 
     /**
      * If the image was auto-guided this is the exposure time in seconds of the tracker used to acquire this image. If
      * this keyword is not present then the image was unguided or hand guided.
      */
-    TRAKTIME(VALUE.REAL, "exposure time in seconds of the tracker"),
+    TRAKTIME(VALUE.REAL, "[s] exposure time of the tracker"),
 
     /**
      * Binning factor in width.
      */
-    XBINNING(VALUE.INTEGER, "Binning factor in width"),
+    XBINNING(VALUE.INTEGER, "binning factor in width"),
+
     /**
      * Sub frame X position of upper left pixel relative to whole frame in binned pixel units.
      */
-    XORGSUBF(VALUE.INTEGER, "Sub frame X position"),
+    XORGSUBF(VALUE.INTEGER, "[pix] sub frame X position"),
 
     /**
      * Pixel width in microns (after binning).
      */
-    XPIXSZ(VALUE.REAL, "Pixel width in microns"),
+    XPIXSZ(VALUE.REAL, "[um] pixel width"),
+
     /**
      * Binning factor in height.
      */
-    YBINNING(VALUE.INTEGER, "Binning factor in height"),
+    YBINNING(VALUE.INTEGER, "binning factor in height"),
+
     /**
      * Sub frame Y position of upper left pixel relative to whole frame in binned pixel units.
      */
-    YORGSUBF(VALUE.INTEGER, "Sub frame Y position"),
+    YORGSUBF(VALUE.INTEGER, "[pix] sub frame Y position"),
+
     /**
      * Pixel height in microns (after binning).
      */
-    YPIXSZ(VALUE.REAL, "Pixel height in microns");
+    YPIXSZ(VALUE.REAL, "[um] pixel height");
+
+    /** Standard IMAETYP value for a light frame. */
+    public static final String IMAGETYP_LIGHT_FRAME = "Light Frame";
+
+    /** Standard IMAETYP value for a bias frame. */
+    public static final String IMAGETYP_BIAS_FRAME = "Bias Frame";
+
+    /** Standard IMAETYP value for a dark frame. */
+    public static final String IMAGETYP_DARK_FRAME = "Dark Frame";
+
+    /** Standard IMAETYP value for a flat frame. */
+    public static final String IMAGETYP_FLAT_FRAME = "Flat Frame";
+
+    /** Standard IMAETYP value for a tricolor image. */
+    public static final String IMAGETYP_TRICOLOR_IMAGE = "Tricolor Image";
 
     private final FitsKey key;
 

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -225,19 +225,19 @@ public enum SBFitsExt implements IFitsHeader {
      */
     YPIXSZ(VALUE.REAL, "[um] pixel height");
 
-    /** Standard IMAETYP value for a light frame. */
+    /** Standard {@link #IMAGETYP} value for a light frame. */
     public static final String IMAGETYP_LIGHT_FRAME = "Light Frame";
 
-    /** Standard IMAETYP value for a bias frame. */
+    /** Standard {@link #IMAGETYP} value for a bias frame. */
     public static final String IMAGETYP_BIAS_FRAME = "Bias Frame";
 
-    /** Standard IMAETYP value for a dark frame. */
+    /** Standard {@link #IMAGETYP} value for a dark frame. */
     public static final String IMAGETYP_DARK_FRAME = "Dark Frame";
 
-    /** Standard IMAETYP value for a flat frame. */
+    /** Standard {@link #IMAGETYP} value for a flat frame. */
     public static final String IMAGETYP_FLAT_FRAME = "Flat Frame";
 
-    /** Standard IMAETYP value for a tricolor image. */
+    /** Standard {@link #IMAGETYP} value for a tricolor image. */
     public static final String IMAGETYP_TRICOLOR_IMAGE = "Tricolor Image";
 
     private final FitsKey key;

--- a/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/SBFitsExt.java
@@ -47,7 +47,7 @@ import nom.tam.fits.header.IFitsHeader;
  * https://diffractionlimited.com/wp-content/uploads/2016/11/sbfitsext_1r0.pdf</a>
  * </p>
  *
- * @author Richard van Nieuwenhoven and Attila Kovacs
+ * @author Attila Kovacs and Richard van Nieuwenhoven
  * 
  * @see    MaxImDLExt
  */

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -40,10 +40,12 @@ import nom.tam.fits.header.IFitsHeader;
  * </p>
  * <p>
  * See <a href=
- * "http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html">http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html</a>
+ * "http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html">http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html</a>.
+ * Additional keywords added in 1.20.1 based on the
+ * <a href="https://outerspace.stsci.edu/display/MASTDOCS/Required+Metadata">HLSP Contributor Guide</a>
  * </p>
  *
- * @author Richard van Nieuwenhoven and Attila Kovacs
+ * @author Attila Kovacs and Richard van Nieuwenhoven
  */
 @SuppressWarnings({"deprecation", "javadoc"})
 public enum STScIExt implements IFitsHeader {
@@ -63,12 +65,12 @@ public enum STScIExt implements IFitsHeader {
      * 
      * @see nom.tam.fits.header.DateTime#DATE_BEG
      */
-    DATE_BEG("DATE-BEG", VALUE.STRING, "date of initial data represented."),
+    DATE_BEG("DATE-BEG", VALUE.STRING, HDU.ANY, "date of initial data represented."),
 
     /**
      * Date of original file creation (yy/mm/dd)
      */
-    DATE_MAP("DATE-MAP", VALUE.STRING, "date of original file creation"),
+    DATE_MAP("DATE-MAP", VALUE.STRING, HDU.ANY, "date of original file creation"),
 
     /**
      * Pointing error in declination (degrees; 1-sigma)
@@ -90,27 +92,27 @@ public enum STScIExt implements IFitsHeader {
      *                 keywords. If possible, avoid using it since it may result in FITS that is not readable by some
      *                 software.
      */
-    IPPS_B_P("IPPS-B/P", VALUE.INTEGER, "[bits/pixel] of IPPS raster."),
+    IPPS_B_P("IPPS-B/P", VALUE.INTEGER, HDU.ANY, "[bits/pixel] of IPPS raster."),
 
     /**
      * IPPS identification, such as target name, possibly including IPPS configuration
      */
-    IPPS_ID("IPPS-ID", VALUE.STRING, "IPPS ID"),
+    IPPS_ID("IPPS-ID", VALUE.STRING, HDU.ANY, "IPPS ID"),
 
     /**
      * Maximum value in raster
      */
-    IPPS_MAX("IPPS-MAX", VALUE.REAL, "maximum value in raster"),
+    IPPS_MAX("IPPS-MAX", VALUE.REAL, HDU.ANY, "maximum value in raster"),
 
     /**
      * Minimum value in raster
      */
-    IPPS_MIN("IPPS-MIN", VALUE.REAL, "minimum value in raster"),
+    IPPS_MIN("IPPS-MIN", VALUE.REAL, HDU.ANY, "minimum value in raster"),
 
     /**
      * Raster LFN / raster ordinal
      */
-    IPPS_RF("IPPS-RF", VALUE.STRING, "raster LFN / raster ordinal"),
+    IPPS_RF("IPPS-RF", VALUE.STRING, HDU.ANY, "raster LFN / raster ordinal"),
 
     /**
      * ?
@@ -130,7 +132,7 @@ public enum STScIExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    MJD_OBS("MJD-OBS", VALUE.REAL, "[day] MJD of exposure start"),
+    MJD_OBS("MJD-OBS", VALUE.REAL, HDU.ANY, "[day] MJD of exposure start"),
 
     /**
      * Fractional portion of ephemeris MJD
@@ -317,8 +319,202 @@ public enum STScIExt implements IFitsHeader {
     /**
      * Same as {@link CXCStclSharedExt#TSTOP}.
      */
-    TSTOP(CXCStclSharedExt.TSTOP);
+    TSTOP(CXCStclSharedExt.TSTOP),
 
+    // ------------------------------------------------------------->
+    // from https://outerspace.stsci.edu/display/MASTDOCS/Common+Metadata
+
+    /**
+     * Digital Object Identifier for the HLSP data collection
+     * 
+     * @since 1.20.1
+     */
+    DOI(VALUE.STRING, HDU.PRIMARY, "DOI of HLSP data collection"),
+
+    /**
+     * The identifier (acronym) for this HLSP collection.
+     * 
+     * @since 1.20.1
+     */
+    HLSPID(VALUE.STRING, HDU.PRIMARY, "HLSP collection ID"),
+
+    /**
+     * Full name of HLSP project lead
+     * 
+     * @since 1.20.1
+     */
+    HLSPLEAD(VALUE.STRING, HDU.PRIMARY, "HLSP project lead"),
+
+    /**
+     * Title for HLSP project, long form
+     * 
+     * @since 1.20.1
+     */
+    HLSPNAME(VALUE.STRING, HDU.PRIMARY, "HLSP project title"),
+
+    /**
+     * Designation of the target(s) or field(s) for this HLSP
+     * 
+     * @since 1.20.1
+     */
+    HLSPTARG(VALUE.STRING, HDU.PRIMARY, "HLSP target fields"),
+
+    /**
+     * Version identifier for this HLSP product
+     * 
+     * @since 1.20.1
+     */
+    HLSPVER(VALUE.STRING, HDU.PRIMARY, "HLSP product version"),
+
+    /**
+     * License for use of these data, with the value 'CC BY 4.0'
+     * 
+     * @see   #LICENURL
+     * 
+     * @since 1.20.1
+     */
+    LICENSE(VALUE.STRING, HDU.PRIMARY, "data license"),
+
+    /**
+     * Data license URL, with the value 'https://creativecommons.org/licenses/by/4.0/'
+     * 
+     * @see   #LICENSE
+     * 
+     * @since 1.20.1
+     */
+    LICENURL(VALUE.STRING, HDU.PRIMARY, "data license URL"),
+
+    /**
+     * Observatory program/proposal identifier, if applicable
+     * 
+     * @since 1.20.1
+     */
+    PROPOSID(VALUE.STRING, HDU.PRIMARY, "program/proposal ID"),
+
+    /**
+     * Duration of exposure, exclusive of dead time, in seconds.
+     */
+    XPOSURE(VALUE.REAL, "[s] exposure time excl. dead time"),
+
+    // ------------------------------------------------------------->
+    // https://outerspace.stsci.edu/display/MASTDOCS/Image+Metadata
+
+    /**
+     * Name of aperture used for exposure (if any)
+     * 
+     * @since 1.20.1
+     */
+    APERTURE(VALUE.STRING, "aperture name"),
+
+    /**
+     * ID of detector used for exposure
+     * 
+     * @since 1.20.1
+     */
+    DETECTOR(VALUE.STRING, "ID of detector used for exposure"),
+
+    /**
+     * Name of filter used, or 'MULTI' if more than one defined the passband
+     * 
+     * @see   #FILTER_MULTI
+     * 
+     * @since 1.20.1
+     */
+    FILTER(VALUE.STRING, "Filer/passband name"),
+
+    /**
+     * Name(s) of filter(s) used to define the passband, if more than one was used, with nn incrementing from 1 (and
+     * zero-pad if nn >9). As such for a passband index of 4, you might use <code>FILTERnn.n(0).n(4)<code> to construct
+     * 'FILTER04'.
+     * 
+     * @since 1.20.1
+     */
+    FILTERnn(VALUE.STRING, "filter of passband n"),
+
+    /**
+     * Declination coordinate of the target or field, in degrees
+     * 
+     * @since 1.20.1
+     */
+    DEC_TARG(VALUE.REAL, "[deg] target/field declination"),
+
+    /**
+     * Typical spatial extent of the point-spread function, in pix
+     * 
+     * @since 1.20.1
+     */
+    PSFSIZE(VALUE.REAL, "[pix] Width of point-spread function"),
+
+    /**
+     * Right Ascension coordinate of the target or field, in degrees
+     * 
+     * @since 1.20.1
+     */
+    RA_TARG(VALUE.REAL, "[deg] target/field right ascension"),
+
+    // ------------------------------------------------------------->
+    // https://outerspace.stsci.edu/display/MASTDOCS/Spectral+Metadata
+
+    /**
+     * Name of dispersive element used, or 'MULTI' if more than one defined the passband.
+     * 
+     * @see   #DISPRSR_MULTI
+     * 
+     * @since 1.20.1
+     */
+    DISPRSR(VALUE.STRING, "dispersive element used"),
+
+    /**
+     * Name(s) of dispersive element(s) used for exposure if more than one was used, with nn (zero-padded) incrementing
+     * from 1. Note that this information can alternatively be represented in a PROVENANCE extension. See Provenance
+     * Metadata for details. As such for a passband index of 4, you might use <code>DISPRnn.n(0).n(4)<code> to construct
+     * 'DISPR04'.
+     * 
+     * @since 1.20.1
+     */
+    DISPRnn(VALUE.STRING, "dispersive element n"),
+
+    // ------------------------------------------------------------->
+    // https://outerspace.stsci.edu/display/MASTDOCS/Provenance+Metadata
+
+    /**
+     * File name or observatory-unique identifier of the contributing observation. For products from MAST missions,
+     * provide the Observation ID so that the contributing data may be linked within MAST.
+     * 
+     * @since 1.20.1
+     */
+    FILE_ID(VALUE.STRING, "File name or obervation UID");
+
+    /**
+     * Standard {@link #FILTER} value if multiple passbands are used.
+     */
+    public static final String FILTER_MULTI = "MULTI";
+
+    /**
+     * Standard {@link #DISPRSR} value if multiple passbands are used.
+     */
+    public static final String DISPRSR_MULTI = "MULTI";
+
+    /**
+     * Data quality (binary) flags, with zero indicating no anthologies
+     */
+    public static final String COLNAME_FLAGS = "FLAGS";
+
+    /**
+     * Could also be called "FLUX_DENSITY" or something similar, depending upon the quantity stored. Flux(es) for the
+     * associated wavelength(s), in units of the value of the TUNIT keyword for this column.
+     */
+    public static final String COLNAME_FLUX = "FLUX";
+
+    /**
+     * Variance in the flux(es) at the associated wavelength(s)
+     */
+    public static final String COLNAME_VARIANCE = "VARIANCE";
+
+    /**
+     * Wavelength(s) for the associated flux(es), in units of the TUNIT keyword for this column.
+     */
+    public static final String COLNAME_WAVELENGTH = "WAVELENGTH";
     /**
      * Same as {@link CXCStclSharedExt#TIMEREF_GEOCENTRIC}.
      * 
@@ -354,11 +550,15 @@ public enum STScIExt implements IFitsHeader {
     }
 
     STScIExt(VALUE valueType, String comment) {
-        this(null, valueType, comment);
+        this(null, valueType, HDU.ANY, comment);
     }
 
-    STScIExt(String key, VALUE valueType, String comment) {
-        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.STScI, HDU.ANY, valueType, comment);
+    STScIExt(VALUE valueType, HDU hduType, String comment) {
+        this(null, valueType, hduType, comment);
+    }
+
+    STScIExt(String key, VALUE valueType, HDU hduType, String comment) {
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.STScI, hduType, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -86,10 +86,12 @@ public enum STScIExt implements IFitsHeader {
      * Pointing error in declination (degrees; 1-sigma)
      */
     DEC_PNTE(VALUE.REAL, "[deg] declination pointing error "),
+
     /**
      * Detector X field of view (mm)
      */
     FOV_X_MM(VALUE.REAL, "[mm] detector X field of view"),
+
     /**
      * Detector X field of view (mm)
      */

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -71,7 +71,7 @@ public enum STScIExt implements IFitsHeader {
     DATE_MAP("DATE-MAP", VALUE.STRING, "date of original file creation"),
 
     /**
-     * Pointing error DEC (degrees; 1-sigma)
+     * Pointing error in declination (degrees; 1-sigma)
      */
     DEC_PNTE(VALUE.REAL, "[deg] declination pointing error "),
     /**
@@ -156,10 +156,12 @@ public enum STScIExt implements IFitsHeader {
      * beginning orbit number
      */
     ORBITBEG(VALUE.INTEGER, "beginning orbit number"),
+
     /**
      * ending orbit number
      */
     ORBITEND(VALUE.INTEGER, "ending orbit number"),
+
     /**
      * Pointing error in position angle (degrees; 1-sigma)
      */
@@ -181,7 +183,7 @@ public enum STScIExt implements IFitsHeader {
     PRODUCT(VALUE.STRING, ""),
 
     /**
-     * Pointing error in RA (degrees, 1-sigma)
+     * Pointing error in right ascension (degrees, 1-sigma)
      */
     RA_PNTE(VALUE.REAL, "R.A. pointing error"),
 

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -43,8 +43,9 @@ import nom.tam.fits.header.IFitsHeader;
  * "http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html">http://tucana.noao.edu/ADASS/adass_proc/adass_95/zaraten/zaraten.html</a>
  * </p>
  *
- * @author Richard van Nieuwenhoven.
+ * @author Richard van Nieuwenhoven and Attila Kovacs
  */
+@SuppressWarnings({"deprecation", "javadoc"})
 public enum STScIExt implements IFitsHeader {
 
     /**
@@ -115,6 +116,21 @@ public enum STScIExt implements IFitsHeader {
      * ?
      */
     JOBNAME(VALUE.STRING, ""),
+
+    /**
+     * Modified Julian date at the start of the exposure. The fractional part of the date is given to better than a
+     * second of time.
+     * <p>
+     * units = 'd'
+     * </p>
+     * <p>
+     * default value = none
+     * </p>
+     * <p>
+     * index = none
+     * </p>
+     */
+    MJD_OBS("MJD-OBS", VALUE.REAL, "[day] MJD of exposure start"),
 
     /**
      * Fractional portion of ephemeris MJD
@@ -214,25 +230,6 @@ public enum STScIExt implements IFitsHeader {
     TIMESYS(VALUE.STRING, "Default time system"),
 
     /**
-     * offset to be applied to TIME column
-     */
-    TIMEZERO(VALUE.REAL, "time offset"),
-
-    /**
-     * The value field of this keyword shall contain the value of the start time of data acquisition in units of
-     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
-     * keyword.
-     */
-    TSTART(VALUE.STRING, "observation start time"),
-
-    /**
-     * The value field of this keyword shall contain the value of the stop time of data acquisition in units of
-     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
-     * keyword.
-     */
-    TSTOP(VALUE.STRING, "observation stop time"),
-
-    /**
      * Version of Data Reduction Software
      */
     VERSION(VALUE.STRING, "data reduction software version"),
@@ -247,22 +244,112 @@ public enum STScIExt implements IFitsHeader {
      */
     ZLREMOV(VALUE.LOGICAL, "whether zodiacal light was removed"),
 
+    // Inherited from CXCStscISharedExt ----------------------------------------->
+
     /**
-     * Modified Julian date at the start of the exposure. The fractional part of the date is given to better than a
-     * second of time.
-     * <p>
-     * units = 'd'
-     * </p>
-     * <p>
-     * default value = none
-     * </p>
-     * <p>
-     * index = none
-     * </p>
+     * Same as {@link CXCStclSharedExt#CLOCKAPP}.
+     * 
+     * @since 1.20.1
      */
-    MJD_OBS("MJD-OBS", VALUE.REAL, "[day] MJD of exposure start");
+    CLOCKAPP(CXCStclSharedExt.CLOCKAPP),
+
+    /**
+     * Same as {@link CXCStclSharedExt#MJDREF}.
+     * 
+     * @since 1.20.1
+     */
+    MJDREF(CXCStclSharedExt.MJDREF),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TASSIGN}.
+     * 
+     * @since 1.20.1
+     */
+    TASSIGN(CXCStclSharedExt.TASSIGN),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEDEL}.
+     * 
+     * @since 1.20.1
+     */
+    TIMEDEL(CXCStclSharedExt.TIMEDEL),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF}.
+     * 
+     * @since 1.20.1
+     * 
+     * @see   #TIMEREF_LOCAL
+     * @see   #TIMEREF_GEOCENTRIC
+     * @see   #TIMEREF_HELIOCENTRIC
+     * @see   #TIMEREF_SOLARSYSTEM
+     */
+    TIMEREF(CXCStclSharedExt.TIMEREF),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEUNIT}.
+     * 
+     * @since 1.20.1
+     */
+    TIMEUNIT(CXCStclSharedExt.TIMEUNIT),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMVERSN}.
+     * 
+     * @since 1.20.1
+     */
+    TIMVERSN(CXCStclSharedExt.TIMVERSN),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEZERO}.
+     * 
+     * @since 1.20.1
+     */
+    TIMEZERO(CXCStclSharedExt.TIMEZERO),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TSTART}.
+     */
+    TSTART(CXCStclSharedExt.TSTART),
+
+    /**
+     * Same as {@link CXCStclSharedExt#TSTOP}.
+     */
+    TSTOP(CXCStclSharedExt.TSTOP);
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF_GEOCENTRIC}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_GEOCENTRIC = CXCStclSharedExt.TIMEREF_GEOCENTRIC;
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF_HELIOCENTRIC}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_HELIOCENTRIC = CXCStclSharedExt.TIMEREF_HELIOCENTRIC;
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF_SOLARSYSTEM}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_SOLARSYSTEM = CXCStclSharedExt.TIMEREF_SOLARSYSTEM;
+
+    /**
+     * Same as {@link CXCStclSharedExt#TIMEREF_LOCAL}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_LOCAL = CXCStclSharedExt.TIMEREF_LOCAL;
 
     private final FitsKey key;
+
+    STScIExt(IFitsHeader key) {
+        this.key = key.impl();
+    }
 
     STScIExt(VALUE valueType, String comment) {
         this(null, valueType, comment);

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -46,161 +46,207 @@ import nom.tam.fits.header.IFitsHeader;
  * @author Richard van Nieuwenhoven.
  */
 public enum STScIExt implements IFitsHeader {
+
     /**
-     * approach vectors
+     * Type approach vectors. E.g. 'COMBINED'
      */
-    APPVEC("approach vectors"),
+    APPVEC(VALUE.STRING, "type of approach vectors"),
+
     /**
-     * Telemetry rate
+     * Telemetry data rate (baud).
      */
-    BIT_RATE("Telemetry rate"),
+    BIT_RATE(VALUE.REAL, "[bit/s] telemetry rate"),
+
     /**
-     * date of initial data represented (dd/mm/yy)
+     * date of initial data represented (yy/mm/dd)
+     * 
+     * @see nom.tam.fits.header.DateTime#DATE_BEG
      */
-    DATE_BEG("DATE-BEG", "date of initial data represented."),
+    DATE_BEG("DATE-BEG", VALUE.STRING, "date of initial data represented."),
+
     /**
-     * Date of original file creation (dd/mm/yy)
+     * Date of original file creation (yy/mm/dd)
      */
-    DATE_MAP("DATE-MAP", "Date of original file creation"),
+    DATE_MAP("DATE-MAP", VALUE.STRING, "date of original file creation"),
+
     /**
-     * File standard deviation of DEC (degrees)
+     * Pointing error DEC (degrees; 1-sigma)
      */
-    DEC_PNTE(""),
+    DEC_PNTE(VALUE.REAL, "[deg] declination pointing error "),
     /**
      * Detector X field of view (mm)
      */
-    FOV_X_MM("Detector X field of view (mm)"),
+    FOV_X_MM(VALUE.REAL, "[mm] detector X field of view"),
     /**
      * Detector X field of view (mm)
      */
-    FOV_Y_MM("Detector Y field of view (mm)"),
+    FOV_Y_MM(VALUE.REAL, "[mm] detector Y field of view"),
+
     /**
-     * BITS/PIXEL OF IPPS RASTER. In truth this is an illegal FITS keyword, as the character '/' is not allowed in
-     * standard FITS keywords. If possible, avoid using it since it may result in FITS that is not readable by some
-     * software.
+     * BITS/PIXEL OF IPPS RASTER.
+     * 
+     * @deprecated In truth this is an illegal FITS keyword, as the character '/' is not allowed in standard FITS
+     *                 keywords. If possible, avoid using it since it may result in FITS that is not readable by some
+     *                 software.
      */
-    IPPS_B_P("IPPS-B/P", "BITS/PIXEL OF IPPS RASTER."),
+    IPPS_B_P("IPPS-B/P", VALUE.INTEGER, "[bits/pixel] of IPPS raster."),
+
     /**
-     * IPPS identification.
+     * IPPS identification, such as target name, possibly including IPPS configuration
      */
-    IPPS_ID("IPPS-ID", ""),
+    IPPS_ID("IPPS-ID", VALUE.STRING, "IPPS ID"),
+
     /**
-     * MAXIMUM VALUE IN RASTER
+     * Maximum value in raster
      */
-    IPPS_MAX("IPPS-MAX", "MAXIMUM VALUE IN RASTER"),
+    IPPS_MAX("IPPS-MAX", VALUE.REAL, "maximum value in raster"),
+
     /**
-     * MINIMUM VALUE IN RASTER
+     * Minimum value in raster
      */
-    IPPS_MIN("IPPS-MIN", "MINIMUM VALUE IN RASTER"),
+    IPPS_MIN("IPPS-MIN", VALUE.REAL, "minimum value in raster"),
+
     /**
-     * RASTER LFN/RASTER ORDINAL
+     * Raster LFN / raster ordinal
      */
-    IPPS_RF("IPPS-RF", "RASTER LFN/RASTER ORDINAL"),
+    IPPS_RF("IPPS-RF", VALUE.STRING, "raster LFN / raster ordinal"),
+
     /**
      * ?
      */
-    JOBNAME(""),
+    JOBNAME(VALUE.STRING, ""),
+
     /**
      * Fractional portion of ephemeris MJD
      */
-    MJDREFF("Fractional portion of ephemeris MJD"),
+    MJDREFF(VALUE.REAL, "fractional portion of ephemeris MJD"),
+
     /**
      * Integer portion of ephemeris MJD
      */
-    MJDREFI("Integer portion of ephemeris MJD"),
+    MJDREFI(VALUE.INTEGER, "integer portion of ephemeris MJD"),
+
     /**
      * Modal Configuration ID
      */
-    MODAL_ID("Modal Configuration ID"),
+    MODAL_ID(VALUE.STRING, "modal Configuration ID"),
+
     /**
-     * optical attribute number is id.
+     * Optical axis position in both linearized detector coordinates and sky coordinates.
      */
-    OPTICn(""),
+    OPTICn(VALUE.REAL, "Optical axis position along coordinate"),
+
     /**
      * beginning orbit number
      */
-    ORBITBEG("beginning orbit number"),
+    ORBITBEG(VALUE.INTEGER, "beginning orbit number"),
     /**
      * ending orbit number
      */
-    ORBITEND("ending orbit number"),
+    ORBITEND(VALUE.INTEGER, "ending orbit number"),
     /**
-     * File standard deviation of ROLL (degrees)
+     * Pointing error in position angle (degrees; 1-sigma)
      */
-    PA_PNTE("File standard deviation of ROLL"),
+    PA_PNTE(VALUE.REAL, "[deg] position angle error"),
+
     /**
      * Quad tree pixel resolution
      */
-    PIXRESOL("Quad tree pixel resolution"),
+    PIXRESOL(VALUE.REAL, "quad tree pixel resolution"),
+
     /**
      * Processing script version
      */
-    PROCVER("Processing script version"),
+    PROCVER(VALUE.STRING, "processing script version"),
+
     /**
-     * ?
+     * Data product description?
      */
-    PRODUCT(""),
+    PRODUCT(VALUE.STRING, ""),
+
     /**
-     * File standard deviation of RA (degrees)
+     * Pointing error in RA (degrees, 1-sigma)
      */
-    RA_PNTE("File standard deviation of RA "),
+    RA_PNTE(VALUE.REAL, "R.A. pointing error"),
+
     /**
      * Sequential number from ODB
      */
-    SEQNUM("Sequential number from ODB"),
+    SEQNUM(VALUE.INTEGER, "sequential number from ODB"),
+
     /**
      * Number of times sequence processed
      */
-    SEQPNUM("Number of times sequence processed"),
+    SEQPNUM(VALUE.INTEGER, "number of times sequence processed"),
+
     /**
-     * solar elongations included
+     * solar elongations included. E.g. 'ALL'
      */
-    SOLELONG("solar elongations included"),
+    SOLELONG(VALUE.STRING, "selection of solar elongations"),
+
     /**
-     * ?
+     * @deprecated Use the standard {@link nom.tam.fits.header.WCS#TCDLTn} instead.
      */
-    TCDLTn(""),
+    TCDLTn(VALUE.REAL, ""),
+
     /**
-     * ?
+     * @deprecated Use the standard {@link nom.tam.fits.header.WCS#TCRPXn} instead.
      */
-    TCRPXn(""),
+    TCRPXn(VALUE.REAL, ""),
+
     /**
-     * ?
+     * @deprecated Use the standard {@link nom.tam.fits.header.WCS#TCRVLn} instead.
      */
-    TCRVLn(""),
+
+    TCRVLn(VALUE.REAL, ""),
+
     /**
-     * ?
+     * @deprecated Use the standard {@link nom.tam.fits.header.WCS#TCTYPn} instead
      */
-    TCTYPn(""),
+    TCTYPn(VALUE.STRING, ""),
+
     /**
      * Default time system. All times which do not have a "timesys" element associated with them in this dictionary
-     * default to this keyword. time system (same as IRAS)
+     * default to this keyword. time system (same as IRAS).
+     * 
+     * @deprecated Use the standatd {@link nom.tam.fits.header.DateTime#TIMESYS} instead.
      */
-    TIMESYS("Default time system"),
+    TIMESYS(VALUE.STRING, "Default time system"),
+
     /**
      * offset to be applied to TIME column
      */
-    TIMEZERO("offset to be applied to TIME column"),
+    TIMEZERO(VALUE.REAL, "time offset"),
+
     /**
-     * observation start time in TIMESYS system .
+     * The value field of this keyword shall contain the value of the start time of data acquisition in units of
+     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
+     * keyword.
      */
-    TSTART("observation start time"),
+    TSTART(VALUE.STRING, "observation start time"),
+
     /**
-     * observation stop time in TIMESYS system .
+     * The value field of this keyword shall contain the value of the stop time of data acquisition in units of
+     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
+     * keyword.
      */
-    TSTOP("observation stop time"),
+    TSTOP(VALUE.STRING, "observation stop time"),
+
     /**
      * Version of Data Reduction Software
      */
-    VERSION("Version of Data Reduction Software "),
+    VERSION(VALUE.STRING, "data reduction software version"),
+
     /**
-     * nominal wavelength of Band n
+     * nominal wavelength of band <i>n</i>, value + unit. For example '140. microns'.
      */
-    WAVEn("nominal wavelength of Band"),
+    WAVEn(VALUE.STRING, "band wavelength and unit"),
+
     /**
-     * signal from zodiacal dust remains in map
+     * Whether map was corrected for zodiacal light
      */
-    ZLREMOV("signal from zodiacal dust remains in map"),
+    ZLREMOV(VALUE.LOGICAL, "whether zodiacal light was removed"),
+
     /**
      * Modified Julian date at the start of the exposure. The fractional part of the date is given to better than a
      * second of time.
@@ -214,16 +260,16 @@ public enum STScIExt implements IFitsHeader {
      * index = none
      * </p>
      */
-    MJD_OBS("MJD-OBS", "MJD of exposure start");
+    MJD_OBS("MJD-OBS", VALUE.REAL, "[day] MJD of exposure start");
 
     private final FitsKey key;
 
-    STScIExt(String comment) {
-        this(null, comment);
+    STScIExt(VALUE valueType, String comment) {
+        this(null, valueType, comment);
     }
 
-    STScIExt(String key, String comment) {
-        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.CXC, HDU.ANY, VALUE.STRING, comment);
+    STScIExt(String key, VALUE valueType, String comment) {
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.CXC, HDU.ANY, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -356,7 +356,7 @@ public enum STScIExt implements IFitsHeader {
     }
 
     STScIExt(String key, VALUE valueType, String comment) {
-        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.CXC, HDU.ANY, valueType, comment);
+        this.key = new FitsKey(key == null ? name() : key, IFitsHeader.SOURCE.STScI, HDU.ANY, valueType, comment);
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/header/extra/STScIExt.java
+++ b/src/main/java/nom/tam/fits/header/extra/STScIExt.java
@@ -1,5 +1,7 @@
 package nom.tam.fits.header.extra;
 
+import nom.tam.fits.header.DateTime;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -33,6 +35,7 @@ package nom.tam.fits.header.extra;
 
 import nom.tam.fits.header.FitsKey;
 import nom.tam.fits.header.IFitsHeader;
+import nom.tam.fits.header.WCS;
 
 /**
  * <p>
@@ -47,7 +50,6 @@ import nom.tam.fits.header.IFitsHeader;
  *
  * @author Attila Kovacs and Richard van Nieuwenhoven
  */
-@SuppressWarnings({"deprecation", "javadoc"})
 public enum STScIExt implements IFitsHeader {
 
     /**
@@ -59,6 +61,14 @@ public enum STScIExt implements IFitsHeader {
      * Telemetry data rate (baud).
      */
     BIT_RATE(VALUE.REAL, "[bit/s] telemetry rate"),
+
+    /**
+     * Whether clock correction applied (boolean).
+     * <p>
+     * T
+     * </p>
+     */
+    CLOCKAPP(VALUE.LOGICAL, "is clock correction applied?"),
 
     /**
      * date of initial data represented (yy/mm/dd)
@@ -120,29 +130,24 @@ public enum STScIExt implements IFitsHeader {
     JOBNAME(VALUE.STRING, ""),
 
     /**
-     * Modified Julian date at the start of the exposure. The fractional part of the date is given to better than a
-     * second of time.
-     * <p>
-     * units = 'd'
-     * </p>
-     * <p>
-     * default value = none
-     * </p>
-     * <p>
-     * index = none
-     * </p>
+     * @deprecated Use the standard {@link DateTime#MJD_OBS} instead.
      */
-    MJD_OBS("MJD-OBS", VALUE.REAL, HDU.ANY, "[day] MJD of exposure start"),
+    MJD_OBS(DateTime.MJD_OBS),
+
+    /**
+     * @deprecated Use the standard {@link DateTime#MJDREF} instead.
+     */
+    MJDREF(DateTime.MJDREF),
 
     /**
      * Fractional portion of ephemeris MJD
      */
-    MJDREFF(VALUE.REAL, "fractional portion of ephemeris MJD"),
+    MJDREFF(VALUE.REAL, "[day] fractional portion of ephemeris MJD"),
 
     /**
      * Integer portion of ephemeris MJD
      */
-    MJDREFI(VALUE.INTEGER, "integer portion of ephemeris MJD"),
+    MJDREFI(VALUE.INTEGER, "[day] integer portion of ephemeris MJD"),
 
     /**
      * Modal Configuration ID
@@ -152,7 +157,7 @@ public enum STScIExt implements IFitsHeader {
     /**
      * Optical axis position in both linearized detector coordinates and sky coordinates.
      */
-    OPTICn(VALUE.REAL, "Optical axis position along coordinate"),
+    OPTICn(VALUE.REAL, "optical axis position along coordinate"),
 
     /**
      * beginning orbit number
@@ -205,33 +210,84 @@ public enum STScIExt implements IFitsHeader {
     SOLELONG(VALUE.STRING, "selection of solar elongations"),
 
     /**
-     * @deprecated Use the standard {@link nom.tam.fits.header.WCS#TCDLTn} instead.
+     * @deprecated Use the standard {@link WCS#TCDLTn} instead.
      */
-    TCDLTn(VALUE.REAL, ""),
+    TCDLTn(WCS.TCDLTn),
 
     /**
-     * @deprecated Use the standard {@link nom.tam.fits.header.WCS#TCRPXn} instead.
+     * @deprecated Use the standard {@link WCS#TCRPXn} instead.
      */
-    TCRPXn(VALUE.REAL, ""),
+    TCRPXn(WCS.TCRPXn),
 
     /**
-     * @deprecated Use the standard {@link nom.tam.fits.header.WCS#TCRVLn} instead.
+     * @deprecated Use the standard {@link WCS#TCRVLn} instead.
      */
 
-    TCRVLn(VALUE.REAL, ""),
+    TCRVLn(WCS.TCRVLn),
 
     /**
-     * @deprecated Use the standard {@link nom.tam.fits.header.WCS#TCTYPn} instead
+     * @deprecated Use the standard {@link WCS#TCTYPn} instead
      */
-    TCTYPn(VALUE.STRING, ""),
+    TCTYPn(WCS.TCTYPn),
 
     /**
-     * Default time system. All times which do not have a "timesys" element associated with them in this dictionary
-     * default to this keyword. time system (same as IRAS).
+     * <p>
+     * Specifies where the time assignment of the data is done. for example, for EXOSAT time assignment was made at the
+     * Madrid tracking station, so TASSIGN ='Madrid'. Since the document goes on to state that this information is
+     * relevant for barycentric corrections, one assumes that this means what is of interest is not the location of the
+     * computer where time tags where inserted into the telemetry stream, but whether those time tags refer to the
+     * actual photon arrival time or to the time at which the telemetry reached the ground station, etc.
+     * </p>
+     * <p>
+     * For example, for Einstein the time assignment was performed at the ground station but corrected to allow for the
+     * transmission time between satellite and ground, so I presume in this case TASSIGN='SATELLITE'. I believe that for
+     * AXAF, TASSIGN = 'SATELLITE'. OGIP/93-003 also speci es the location for the case of a ground station should be
+     * recorded the keywords GEOLAT, GEOLONG, and ALTITUDE. This is rather unfortunate since it would be nice to reserve
+     * these keywords for the satellite ephemeris position. However, since no ground station is de ned for AXAF, we feel
+     * that we can use GEOLONG, GEOLAT, and ALTITUDE for these purposes, especially since such usage is consistent with
+     * their usage for ground-based observations. TASSIGN has obviously no meaning when TIMESYS = 'TDB'.
+     * </p>
+     */
+    TASSIGN(VALUE.STRING, "location where time was assigned"),
+
+    /**
+     * Time reference frame.
      * 
-     * @deprecated Use the standatd {@link nom.tam.fits.header.DateTime#TIMESYS} instead.
+     * @see #TIMEREF_LOCAL
+     * @see #TIMEREF_GEOCENTRIC
+     * @see #TIMEREF_HELIOCENTRIC
+     * @see #TIMEREF_SOLARSYSTEM
      */
-    TIMESYS(VALUE.STRING, "Default time system"),
+    TIMEREF(VALUE.STRING, "time reference frame"),
+
+    /**
+     * Units of time, for example 's' for seconds. If absent, assume seconds.
+     */
+    TIMEUNIT(VALUE.STRING, "units of time"),
+
+    /**
+     * Version of time specification convention.
+     */
+    TIMVERSN(VALUE.STRING, "version of time convention"),
+
+    /**
+     * Clock correction (if not zero), in {@link #TIMEUNIT}.
+     */
+    TIMEZERO(VALUE.REAL, "clock offset"),
+
+    /**
+     * The value field of this keyword shall contain the value of the start time of data acquisition in units of
+     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
+     * keyword. Similar to {@link DateTime#TSTART} except that it strictly uses decimal values.
+     */
+    TSTART(VALUE.REAL, "start time of observartion"),
+
+    /**
+     * The value field of this keyword shall contain the value of the stop time of data acquisition in units of
+     * TIMEUNIT, relative to MJDREF, JDREF, or DATEREF and TIMEOFFS, in the time system specified by the TIMESYS
+     * keyword. Similar to {@link DateTime#TSTOP} except that it strictly uses decimal values.
+     */
+    TSTOP(VALUE.REAL, "stop time of observation"),
 
     /**
      * Version of Data Reduction Software
@@ -247,79 +303,6 @@ public enum STScIExt implements IFitsHeader {
      * Whether map was corrected for zodiacal light
      */
     ZLREMOV(VALUE.LOGICAL, "whether zodiacal light was removed"),
-
-    // Inherited from CXCStscISharedExt ----------------------------------------->
-
-    /**
-     * Same as {@link CXCStclSharedExt#CLOCKAPP}.
-     * 
-     * @since 1.20.1
-     */
-    CLOCKAPP(CXCStclSharedExt.CLOCKAPP),
-
-    /**
-     * Same as {@link CXCStclSharedExt#MJDREF}.
-     * 
-     * @since 1.20.1
-     */
-    MJDREF(CXCStclSharedExt.MJDREF),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TASSIGN}.
-     * 
-     * @since 1.20.1
-     */
-    TASSIGN(CXCStclSharedExt.TASSIGN),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEDEL}.
-     * 
-     * @since 1.20.1
-     */
-    TIMEDEL(CXCStclSharedExt.TIMEDEL),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEREF}.
-     * 
-     * @since 1.20.1
-     * 
-     * @see   #TIMEREF_LOCAL
-     * @see   #TIMEREF_GEOCENTRIC
-     * @see   #TIMEREF_HELIOCENTRIC
-     * @see   #TIMEREF_SOLARSYSTEM
-     */
-    TIMEREF(CXCStclSharedExt.TIMEREF),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEUNIT}.
-     * 
-     * @since 1.20.1
-     */
-    TIMEUNIT(CXCStclSharedExt.TIMEUNIT),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMVERSN}.
-     * 
-     * @since 1.20.1
-     */
-    TIMVERSN(CXCStclSharedExt.TIMVERSN),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEZERO}.
-     * 
-     * @since 1.20.1
-     */
-    TIMEZERO(CXCStclSharedExt.TIMEZERO),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TSTART}.
-     */
-    TSTART(CXCStclSharedExt.TSTART),
-
-    /**
-     * Same as {@link CXCStclSharedExt#TSTOP}.
-     */
-    TSTOP(CXCStclSharedExt.TSTOP),
 
     // ------------------------------------------------------------->
     // from https://outerspace.stsci.edu/display/MASTDOCS/Common+Metadata
@@ -400,13 +383,6 @@ public enum STScIExt implements IFitsHeader {
     // https://outerspace.stsci.edu/display/MASTDOCS/Image+Metadata
 
     /**
-     * Name of aperture used for exposure (if any)
-     * 
-     * @since 1.20.1
-     */
-    APERTURE(VALUE.STRING, "aperture name"),
-
-    /**
      * ID of detector used for exposure
      * 
      * @since 1.20.1
@@ -414,18 +390,10 @@ public enum STScIExt implements IFitsHeader {
     DETECTOR(VALUE.STRING, "ID of detector used for exposure"),
 
     /**
-     * Name of filter used, or 'MULTI' if more than one defined the passband
-     * 
-     * @see   #FILTER_MULTI
-     * 
-     * @since 1.20.1
-     */
-    FILTER(VALUE.STRING, "Filer/passband name"),
-
-    /**
      * Name(s) of filter(s) used to define the passband, if more than one was used, with nn incrementing from 1 (and
      * zero-pad if nn >9). As such for a passband index of 4, you might use <code>FILTERnn.n(0).n(4)<code> to construct
-     * 'FILTER04'.
+     * 'FILTER04'. It is similar to the more standard {@link nom.tam.fits.header.InstrumentDescription#FILTERn} keyword
+     * except for the 2-digit, zero-padded, indexing for bands 1--9.
      * 
      * @since 1.20.1
      */
@@ -486,7 +454,36 @@ public enum STScIExt implements IFitsHeader {
     FILE_ID(VALUE.STRING, "File name or obervation UID");
 
     /**
-     * Standard {@link #FILTER} value if multiple passbands are used.
+     * Time is reported when detected wavefront passed the center of Earth, a standard value for {@link #TIMEREF}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_GEOCENTRIC = "GEOCENTRIC";
+
+    /**
+     * Time is reported when detected wavefront passed the center of the Sun, a standard value for {@link #TIMEREF}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_HELIOCENTRIC = "HELIOCENTRIC";
+
+    /**
+     * Time is reported when detected wavefront passed the Solar System barycenter, a standard value for
+     * {@link #TIMEREF}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_SOLARSYSTEM = "SOLARSYSTEM";
+
+    /**
+     * Time reported is actual time of detection, a standard value for {@link #TIMEREF}.
+     * 
+     * @since 1.20.1
+     */
+    public static final String TIMEREF_LOCAL = "LOCAL";
+
+    /**
+     * Standard {@link nom.tam.fits.header.InstrumentDescription#FILTER} value if multiple passbands are used.
      */
     public static final String FILTER_MULTI = "MULTI";
 
@@ -515,33 +512,6 @@ public enum STScIExt implements IFitsHeader {
      * Wavelength(s) for the associated flux(es), in units of the TUNIT keyword for this column.
      */
     public static final String COLNAME_WAVELENGTH = "WAVELENGTH";
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEREF_GEOCENTRIC}.
-     * 
-     * @since 1.20.1
-     */
-    public static final String TIMEREF_GEOCENTRIC = CXCStclSharedExt.TIMEREF_GEOCENTRIC;
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEREF_HELIOCENTRIC}.
-     * 
-     * @since 1.20.1
-     */
-    public static final String TIMEREF_HELIOCENTRIC = CXCStclSharedExt.TIMEREF_HELIOCENTRIC;
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEREF_SOLARSYSTEM}.
-     * 
-     * @since 1.20.1
-     */
-    public static final String TIMEREF_SOLARSYSTEM = CXCStclSharedExt.TIMEREF_SOLARSYSTEM;
-
-    /**
-     * Same as {@link CXCStclSharedExt#TIMEREF_LOCAL}.
-     * 
-     * @since 1.20.1
-     */
-    public static final String TIMEREF_LOCAL = CXCStclSharedExt.TIMEREF_LOCAL;
 
     private final FitsKey key;
 

--- a/src/test/java/nom/tam/fits/header/extra/CommonExtTest.java
+++ b/src/test/java/nom/tam/fits/header/extra/CommonExtTest.java
@@ -1,5 +1,49 @@
 package nom.tam.fits.header.extra;
 
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import nom.tam.fits.header.IFitsHeader;
+import nom.tam.fits.header.IFitsHeader.VALUE;
+
 public class CommonExtTest {
 
+    @Test
+    public void testCommonExt() throws Exception {
+        IFitsHeader key = CommonExt.ANGLE;
+
+        Assert.assertEquals("ANGLE", key.key());
+        Assert.assertEquals(VALUE.REAL, key.valueType());
+    }
 }

--- a/src/test/java/nom/tam/fits/header/extra/CommonExtTest.java
+++ b/src/test/java/nom/tam/fits/header/extra/CommonExtTest.java
@@ -1,0 +1,5 @@
+package nom.tam.fits.header.extra;
+
+public class CommonExtTest {
+
+}

--- a/src/test/java/nom/tam/fits/header/extra/ESOExtTest.java
+++ b/src/test/java/nom/tam/fits/header/extra/ESOExtTest.java
@@ -1,0 +1,18 @@
+package nom.tam.fits.header.extra;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import nom.tam.fits.header.IFitsHeader;
+import nom.tam.fits.header.IFitsHeader.VALUE;
+
+public class ESOExtTest {
+
+    @Test
+    public void testESOExt() throws Exception {
+        IFitsHeader key = ESOExt.UTC;
+
+        Assert.assertEquals("UTC", key.key());
+        Assert.assertEquals(VALUE.REAL, key.valueType());
+    }
+}

--- a/src/test/java/nom/tam/fits/header/extra/ESOExtTest.java
+++ b/src/test/java/nom/tam/fits/header/extra/ESOExtTest.java
@@ -1,5 +1,36 @@
 package nom.tam.fits.header.extra;
 
+/*-
+ * #%L
+ * nom.tam.fits
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ * 
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ * 
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
 based on available documentation.

- Fix associated value types for extension keywords. They were all too often incorrect
- Add missing keywords for the MaxIm DL (`MaxImDLExt`) keyword convention.
- Add constants to define standard values where appropriate. 
- Add `CommonExt` to collect other commonly used keywords, e.g. in the amateur astronomy community (thanks @johnmurphyastro)
- Avoid duplicate definitions by referencing the parent enum values where appropriate.
- Edit standard header comment values
- Update Javadoc