### PR TITLE
Refactor (again) to RandomAccessFileChannel etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changes coming to the next release, expected around 15 March 2025.
 
 ### Added
 
- - [#717] New `RandomAccessFileChannel` class, which wraps `FileChannel` objects to provide `RandomAccessFileIO` for FITS files. You might use it to access FITS files efficinetly on as Amazon S3, or other cloud resources. (by @at88mph)
+ - [#717] New `RandomAccessFileChannel` class, which wraps `FileChannel` objects to provide `RandomAccessFileIO` for FITS files. For example, this could be used in conjunction with the Amazon Java SDK (https://aws.amazon.com/sdk-for-java/) to connect to an S3 instance. (by @at88mph)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,11 @@ Changes coming to the next release, expected around 15 March 2025.
 
 ### Added
 
- - [717] New `RandomFileIOChannel` class, which wraps `FileChannel` objects to provide `RandomAccessFileIO` for FITS files. You might use it to access FITS files efficinetly on as Amazon S3, or other cloud resources. (by @at88mph)
+ - [#717] New `RandomAccessFileChannel` class, which wraps `FileChannel` objects to provide `RandomAccessFileIO` for FITS files. You might use it to access FITS files efficinetly on as Amazon S3, or other cloud resources. (by @at88mph)
 
 ### Changed
 
- - [#722] Synchronization fixed for issues detected by latest spotbugs. These should improve thread safety, especially of binary
-   tables and compressed tables.
+ - [#722] Synchronization fixes for issues detected by latest spotbugs. These should improve thread safety, especially of binary tables and compressed tables.
 
 
 ## [1.20.2] - 2024-12-01

--- a/src/main/java/nom/tam/util/RandomAccessFileChannel.java
+++ b/src/main/java/nom/tam/util/RandomAccessFileChannel.java
@@ -44,16 +44,16 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A random accessible {@link FileChannel} implementation for FITS I/O purposes. It allows for resources that are not
- * local files, but which provide file-like access through a <code>FileChannel</code> object, to become usable by the
- * nom-tam-fits library. This class provides a generic implementation, which may be used, for example, with the NIO SPI
- * file system provider to Amazon S3.
+ * A random accessible {@link FileChannel} implementation for FITS I/O purposes. It enables file-like access for
+ * nom-tam-fits that goes beyond local files. This class provides a generic implementation, which may be used, for
+ * example, with the NIO SPI file system provider to Amazon S3.
  *
  * @author Dustin Jenkins, Attila Kovacs
  * 
  * @since  1.21
  *
  * @see    <a href="https://github.com/awslabs/aws-java-nio-spi-for-s3">AWS NIO SPI library</a>
+ * @see    FitsFile
  */
 public class RandomAccessFileChannel implements RandomAccessFileIO {
     private static final Logger LOGGER = LoggerHelper.getLogger(RandomAccessFileChannel.class);

--- a/src/main/java/nom/tam/util/RandomAccessFileChannel.java
+++ b/src/main/java/nom/tam/util/RandomAccessFileChannel.java
@@ -44,19 +44,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Concrete implementation of the {@link RandomAccessFileIO} interface for {@link FileChannel}s. It allows
- * <code>FileChannel</code> resources containing FITS files to be fully accessible for the nom-tam-fits library. This
- * class provides a generic implementation, which may be used, for example, with the NIO SPI file system provider to
- * Amazon S3.
+ * A random accessible {@link FileChannel} implementation for FITS I/O purposes. It allows for resources that are not
+ * local files, but which provide file-like access through a <code>FileChannel</code> object, to become usable by the
+ * nom-tam-fits library. This class provides a generic implementation, which may be used, for example, with the NIO SPI
+ * file system provider to Amazon S3.
  *
- * @author Dustin Jenkins
+ * @author Dustin Jenkins, Attila Kovacs
  * 
  * @since  1.21
  *
  * @see    <a href="https://github.com/awslabs/aws-java-nio-spi-for-s3">AWS NIO SPI library</a>
  */
-public class RandomFileIOChannel implements RandomAccessFileIO {
-    private static final Logger LOGGER = LoggerHelper.getLogger(RandomFileIOChannel.class);
+public class RandomAccessFileChannel implements RandomAccessFileIO {
+    private static final Logger LOGGER = LoggerHelper.getLogger(RandomAccessFileChannel.class);
 
     private final long fileSize;
     private final FileChannel fileChannel;
@@ -73,9 +73,9 @@ public class RandomFileIOChannel implements RandomAccessFileIO {
      * 
      * @since              1.21
      * 
-     * @see                #RandomFileIOChannel(Path, boolean)
+     * @see                #RandomAccessFileChannel(Path, boolean)
      */
-    public RandomFileIOChannel(final Path filePath) throws IOException {
+    public RandomAccessFileChannel(final Path filePath) throws IOException {
         this(filePath, true);
     }
 
@@ -92,10 +92,10 @@ public class RandomFileIOChannel implements RandomAccessFileIO {
      * 
      * @since              1.21
      * 
-     * @see                #RandomFileIOChannel(Path, boolean)
+     * @see                #RandomAccessFileChannel(Path, boolean)
      */
     @SuppressWarnings("resource")
-    public RandomFileIOChannel(final Path filePath, final boolean readOnly) throws IOException {
+    public RandomAccessFileChannel(final Path filePath, final boolean readOnly) throws IOException {
         this(Files.size(filePath), FileChannel.open(filePath, readOnly ? new OpenOption[] {StandardOpenOption.READ} :
                 new OpenOption[] {StandardOpenOption.READ, StandardOpenOption.WRITE}));
     }
@@ -106,7 +106,7 @@ public class RandomFileIOChannel implements RandomAccessFileIO {
      * @param fileSize    The size (length) of the file in bytes.
      * @param fileChannel The open channel to the file.
      */
-    RandomFileIOChannel(long fileSize, FileChannel fileChannel) {
+    RandomAccessFileChannel(long fileSize, FileChannel fileChannel) {
         this.fileSize = fileSize;
         this.fileChannel = Objects.requireNonNull(fileChannel, "FileChannel cannot be null.");
     }
@@ -118,7 +118,7 @@ public class RandomFileIOChannel implements RandomAccessFileIO {
     }
 
     @Override
-    public FileChannel getChannel() {
+    public final FileChannel getChannel() {
         return this.fileChannel;
     }
 
@@ -143,17 +143,17 @@ public class RandomFileIOChannel implements RandomAccessFileIO {
     }
 
     @Override
-    public long position() throws IOException {
+    public final long position() throws IOException {
         return fileChannel.position();
     }
 
     @Override
-    public void position(long l) throws IOException {
+    public final void position(long l) throws IOException {
         fileChannel.position(l);
     }
 
     @Override
-    public long length() {
+    public final long length() {
         return this.fileSize;
     }
 
@@ -163,7 +163,7 @@ public class RandomFileIOChannel implements RandomAccessFileIO {
     }
 
     /**
-     * Read bytes from the file channel, starting at offset for readLength bytes.
+     * Read bytes from the underlying file channel.
      *
      * @param  bytes       The byte array to read into.
      * @param  offset      The offset in the FileChannel to start reading.
@@ -190,7 +190,7 @@ public class RandomFileIOChannel implements RandomAccessFileIO {
     }
 
     /**
-     * Write bytes to the file channel.
+     * Write bytes to the underlying file channel.
      *
      * @param  bytes       The byte array to write.
      * @param  offset      The offset in the FileChannel to start writing from.

--- a/src/test/java/nom/tam/util/RandomAccessFileChannelTest.java
+++ b/src/test/java/nom/tam/util/RandomAccessFileChannelTest.java
@@ -42,11 +42,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 
-public class RandomFileIOChannelTest {
+public class RandomAccessFileChannelTest {
 
     @Test
     public void testConstructor() throws Exception {
-        try (final RandomFileIOChannel _testSubject = new RandomFileIOChannel(0, null)) {
+        try (final RandomAccessFileChannel _testSubject = new RandomAccessFileChannel(0, null)) {
             Assert.fail("Expected NullPointerException");
         } catch (NullPointerException e) {
             Assert.assertEquals("FileChannel cannot be null.", e.getMessage());
@@ -65,7 +65,7 @@ public class RandomFileIOChannelTest {
         final Path testPath = tempFile.toPath();
         final int readLength = 2;
         final byte[] buffer = new byte[readLength];
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath)) {
             testSubject.read(buffer, "te".getBytes(StandardCharsets.UTF_8).length, readLength);
         }
 
@@ -80,7 +80,7 @@ public class RandomFileIOChannelTest {
         final Path testPath = tempFile.toPath();
         final byte[] buffer = "testdataforwrite".getBytes(StandardCharsets.UTF_8);
 
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             testSubject.write(buffer);
         }
 
@@ -99,7 +99,7 @@ public class RandomFileIOChannelTest {
         }
 
         final Path testPath = tempFile.toPath();
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             Assert.assertEquals("Wrong length", buffer.length, testSubject.length());
         }
     }
@@ -115,7 +115,7 @@ public class RandomFileIOChannelTest {
         }
 
         final Path testPath = tempFile.toPath();
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             testSubject.position(5);
             Assert.assertEquals("Wrong position", 5, testSubject.position());
         }
@@ -127,7 +127,7 @@ public class RandomFileIOChannelTest {
         tempFile.deleteOnExit();
 
         final Path testPath = tempFile.toPath();
-        final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath);
+        final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath);
         testSubject.close();
 
         Assert.assertFalse("File channel not closed", testSubject.getChannel().isOpen());
@@ -140,7 +140,7 @@ public class RandomFileIOChannelTest {
 
         final Path testPath = tempFile.toPath();
 
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             testSubject.write(0);
             Assert.fail("Expected UnsupportedOperationException");
         } catch (UnsupportedOperationException e) {
@@ -155,7 +155,7 @@ public class RandomFileIOChannelTest {
 
         final Path testPath = tempFile.toPath();
 
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             testSubject.readUTF();
             Assert.fail("Expected UnsupportedOperationException");
         } catch (UnsupportedOperationException e) {
@@ -170,7 +170,7 @@ public class RandomFileIOChannelTest {
 
         final Path testPath = tempFile.toPath();
 
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             testSubject.getFD();
             Assert.fail("Expected UnsupportedOperationException");
         } catch (UnsupportedOperationException e) {
@@ -185,7 +185,7 @@ public class RandomFileIOChannelTest {
 
         final Path testPath = tempFile.toPath();
 
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             testSubject.setLength(3);
             Assert.fail("Expected UnsupportedOperationException");
         } catch (UnsupportedOperationException e) {
@@ -200,7 +200,7 @@ public class RandomFileIOChannelTest {
 
         final Path testPath = tempFile.toPath();
 
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             testSubject.writeUTF("data");
             Assert.fail("Expected UnsupportedOperationException");
         } catch (UnsupportedOperationException e) {
@@ -215,7 +215,7 @@ public class RandomFileIOChannelTest {
 
         final Path testPath = tempFile.toPath();
 
-        try (final RandomFileIOChannel testSubject = new RandomFileIOChannel(testPath, false)) {
+        try (final RandomAccessFileChannel testSubject = new RandomAccessFileChannel(testPath, false)) {
             testSubject.read();
             Assert.fail("Expected UnsupportedOperationException");
         } catch (UnsupportedOperationException e) {


### PR DESCRIPTION
Hi again @at88mph,

Thanks for the quick review of the changes. Unfortunately, after sleeping on it, I decided to tweak it a bit more. I could not resist another refactoring, because the class name still sounded so awkward. I also declared the methods that return concrete values as `final` as no subclasses should ever mess with these.

A bit unusually, this PR us on the same branch as the one before it, since I did not realize you have already merged the previous changes when I committed new ones.