### PR TITLE
Enable quantization for lossless compression also

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ Release candidate for the upcoming 1.21 feature release, expected around 15 Marc
 
 ### Fixed
 
- - [#708] `BinaryTable.addRowEntries()` did not work with scalar `Boolean` or `boolean`. (by @attipaci, thanks to @johnmurphyastro) 
+ - [#708] `BinaryTable.addRowEntries()` did not work with scalar `Boolean` or `boolean` values. (by @attipaci, thanks to @johnmurphyastro) 
  
  - [#710] `BinaryTable.addRow()` has some oddities and inconsistencies that resulted in unexpected behavior. (by @attipaci)
+
+ - [#730] Decompression errors when reading compressed images that used compression quantization (`ZSCALE`, `ZZERO`, `ZBLANK`, and `ZQUANTIZ` options) together with a lossless compression algorithm (e.g. GZIP or PLIO). (by @attipaci, thanks to @bogdanni)
 
 ### Added
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/api/ICompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/api/ICompressor.java
@@ -59,4 +59,5 @@ public interface ICompressor<T extends Buffer> {
      * @param buffer     the buffer to fill with the uncompressed data.
      */
     void decompress(ByteBuffer compressed, T buffer);
+
 }

--- a/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/hcompress/HCompressTest.java
@@ -618,4 +618,19 @@ public class HCompressTest {
         Assert.assertEquals(c, o.getHCompressorOption());
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testIntHCompressWrongOptions() throws Exception {
+        int[] data = new int[100];
+
+        for (int i = 0; i < 100; i++) {
+            data[i] = i;
+        }
+
+        IntBuffer buf = IntBuffer.wrap(data);
+        ByteBuffer zip = ByteBuffer.allocateDirect(800);
+
+        ICompressorControl c = CompressorProvider.findCompressorControl(null, Compression.ZCMPTYPE_HCOMPRESS_1, int.class);
+        c.decompress(zip, buf, new RiceCompressOption());
+    }
+
 }


### PR DESCRIPTION
For compression, quantization is independent from the type of compression algorithm used, so compression quantization options (`ZSCALE`, `ZZERO`, `ZBLANK`, and `ZQUANTIZ`) should be supported for all compression types. However, due to an oversight, previously we have supported quantization options only for lossy compression algorithms (which have additional compression options). 