### PR TITLE
Parsing of canonical comment keys with '=' in column 9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the nom.tam.fits library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+
+ - [#748] `COMMENT`, `HISTORY` or blank keywords should always be comments as per the FITS standard, even if there is a value indicator `=` in column 9. (by @attipaci, thanks to @svensk-pojke)
+
+
 ## [1.21.0] - 2025-03-11
 
 Feature release, with a few bug fixes.

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -42,6 +42,7 @@ import java.util.logging.Logger;
 import nom.tam.fits.FitsFactory.FitsSettings;
 import nom.tam.fits.header.IFitsHeader;
 import nom.tam.fits.header.NonStandard;
+import nom.tam.fits.header.Standard;
 import nom.tam.fits.header.hierarch.IHierarchKeyFormatter;
 import nom.tam.util.ArrayDataInput;
 import nom.tam.util.AsciiFuncs;
@@ -511,6 +512,14 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @see                        #set(String, String, String, Class)
      */
     private HeaderCard(String key, String value, String comment, Class<?> type) throws HeaderCardException {
+        if (value == null) {
+            if (key == null || key.equals(Standard.COMMENT.key()) || key.equals(Standard.BLANKS.key())
+                    || key.equals(Standard.HISTORY.key())) {
+                // Force comment
+                type = null;
+            }
+        }
+
         set(key, value, comment, type);
         this.type = type;
     }

--- a/src/main/java/nom/tam/fits/HeaderCard.java
+++ b/src/main/java/nom/tam/fits/HeaderCard.java
@@ -512,12 +512,17 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @see                        #set(String, String, String, Class)
      */
     private HeaderCard(String key, String value, String comment, Class<?> type) throws HeaderCardException {
-        if (value == null) {
-            if (key == null || key.equals(Standard.COMMENT.key()) || key.equals(Standard.BLANKS.key())
-                    || key.equals(Standard.HISTORY.key())) {
-                // Force comment
-                type = null;
+        if (key != null) {
+            key = trimEnd(key);
+        }
+
+        if (key == null || key.isEmpty() || key.equals(Standard.COMMENT.key()) || key.equals(Standard.HISTORY.key())) {
+            if (value != null) {
+                throw new HeaderCardException("Standard commentary keywords may not have an assigned value.");
             }
+
+            // Force comment
+            type = null;
         }
 
         set(key, value, comment, type);
@@ -543,14 +548,15 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
 
         type = aType;
 
-        // AK: Map null and blank keys to BLANKS.key()
-        // This simplifies things as we won't have to check for null keys separately!
-        if ((aKey == null) || aKey.trim().isEmpty()) {
-            aKey = EMPTY_KEY;
+        // Remove trailing spaces
+        if (aKey != null) {
+            aKey = trimEnd(aKey);
         }
 
-        if (aKey.isEmpty() && aValue != null) {
-            throw new HeaderCardException("Blank or null key for value: [" + sanitize(aValue) + "]");
+        // AK: Map null and blank keys to BLANKS.key()
+        // This simplifies things as we won't have to check for null keys separately!
+        if ((aKey == null) || aKey.isEmpty()) {
+            aKey = EMPTY_KEY;
         }
 
         try {
@@ -772,7 +778,7 @@ public class HeaderCard implements CursorValue<String>, Cloneable {
      * @see    #isCommentStyleCard()
      */
     public synchronized boolean isKeyValuePair() {
-        return !isCommentStyleCard() && !(key.isEmpty() || value == null);
+        return !isCommentStyleCard() && value != null;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/HeaderCardParser.java
+++ b/src/main/java/nom/tam/fits/HeaderCardParser.java
@@ -366,13 +366,12 @@ class HeaderCardParser {
      * @see                           FitsFactory#setAllowHeaderRepairs(boolean)
      */
     private void parseValue() throws UnclosedQuoteException {
-        if (key.isEmpty() || !skipSpaces()) {
-            // nothing left to parse.
+        if (key.isEmpty() || key.equals(Standard.COMMENT.key()) || key.equals(Standard.HISTORY.key())) {
             return;
         }
 
-        if (key.equals(Standard.COMMENT.key()) || key.equals(Standard.BLANKS.key()) || key.equals(Standard.HISTORY.key())) {
-            return;
+        if (!skipSpaces()) {
+            return; // nothing left to parse.
         }
 
         if (CONTINUE.key().equals(key)) {

--- a/src/main/java/nom/tam/fits/HeaderCardParser.java
+++ b/src/main/java/nom/tam/fits/HeaderCardParser.java
@@ -39,6 +39,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import nom.tam.fits.header.Standard;
 import nom.tam.util.ComplexValue;
 import nom.tam.util.FlexFormat;
 
@@ -367,6 +368,10 @@ class HeaderCardParser {
     private void parseValue() throws UnclosedQuoteException {
         if (key.isEmpty() || !skipSpaces()) {
             // nothing left to parse.
+            return;
+        }
+
+        if (key.equals(Standard.COMMENT.key()) || key.equals(Standard.BLANKS.key()) || key.equals(Standard.HISTORY.key())) {
             return;
         }
 

--- a/src/test/java/nom/tam/fits/HeaderTest.java
+++ b/src/test/java/nom/tam/fits/HeaderTest.java
@@ -1667,18 +1667,21 @@ public class HeaderTest {
                 new FitsInputStream(new FileInputStream(new File("src/test/resources/nom/tam/fits/test/test.fits"))));
         Header hdr = f.readHDU().getHeader();
         HeaderCard[] cds = hdr.findCards("NAX.*");
-        /* ought to find 3 cards, NAXIS, NAXIS1, NAXIS2, that start with NAX
-        */
+        /*
+         * ought to find 3 cards, NAXIS, NAXIS1, NAXIS2, that start with NAX
+         */
         assertEquals(3, cds.length);
 
         cds = hdr.findCards(".*Y.*");
-        /* ought to find no card which has a key with a Y
-        */
+        /*
+         * ought to find no card which has a key with a Y
+         */
         assertEquals(0, cds.length);
 
         cds = hdr.findCards(".*\\d");
-        /* ought to find the two cards that end on digits, namely NAXIS1 and NAXIS2
-        */
+        /*
+         * ought to find the two cards that end on digits, namely NAXIS1 and NAXIS2
+         */
         assertEquals(2, cds.length);
     }
 

--- a/src/test/java/nom/tam/fits/test/HeaderCardTest.java
+++ b/src/test/java/nom/tam/fits/test/HeaderCardTest.java
@@ -2031,4 +2031,63 @@ public class HeaderCardTest {
         HeaderCard c = new HeaderCard("HIERARCH.TEST.AAA.BBB", (String) null, null);
         Assert.assertEquals("HIERARCH TEST AAA BBB =", c.toString().trim());
     }
+
+    @Test
+    public void testCommentCardConstructs() {
+        HeaderCard c = new HeaderCard("COMMENT", (String) null, "blah");
+        Assert.assertTrue(c.isCommentStyleCard());
+        Assert.assertNull(c.getValue());
+        Assert.assertEquals("blah", c.getComment());
+
+        c = new HeaderCard("HISTORY", (String) null, "blah");
+        Assert.assertTrue(c.isCommentStyleCard());
+        Assert.assertNull(c.getValue());
+        Assert.assertEquals("blah", c.getComment());
+
+        c = new HeaderCard("", (String) null, "blah");
+        Assert.assertTrue(c.isCommentStyleCard());
+        Assert.assertNull(c.getValue());
+        Assert.assertEquals("blah", c.getComment());
+
+        c = new HeaderCard(null, (String) null, "blah");
+        Assert.assertTrue(c.isCommentStyleCard());
+        Assert.assertNull(c.getValue());
+        Assert.assertEquals("blah", c.getComment());
+    }
+
+    @Test(expected = HeaderCardException.class)
+    public void testCommentCardConstructWithValueException() {
+        HeaderCard c = new HeaderCard("COMMENT", "whatever", "blah");
+    }
+
+    // COMMENT, HISTORY or blank keywords can have a value indicator "= " in columns 9 and 10
+    // and are still understood to be commentary keywords, with the comment starting in
+    // column 9.
+    @Test
+    public void testParseCommentWithEquals() throws Exception {
+        String im;
+        HeaderCard c;
+
+        im = "COMMENT = blah                                                                  ";
+        c = new HeaderCard(new FitsInputStream(new ByteArrayInputStream(im.getBytes())));
+        Assert.assertEquals(Standard.COMMENT.key(), c.getKey());
+        Assert.assertTrue(c.isCommentStyleCard());
+        Assert.assertNull(c.getValue());
+        Assert.assertEquals("= blah", c.getComment());
+
+        im = "HISTORY = blah                                                                  ";
+        c = new HeaderCard(new FitsInputStream(new ByteArrayInputStream(im.getBytes())));
+        Assert.assertEquals(Standard.HISTORY.key(), c.getKey());
+        Assert.assertTrue(c.isCommentStyleCard());
+        Assert.assertNull(c.getValue());
+        Assert.assertEquals("= blah", c.getComment());
+
+        im = "        = blah                                                                  ";
+        c = new HeaderCard(new FitsInputStream(new ByteArrayInputStream(im.getBytes())));
+        Assert.assertEquals(Standard.BLANKS.key(), c.getKey());
+        Assert.assertTrue(c.isCommentStyleCard());
+        Assert.assertNull(c.getValue());
+        Assert.assertEquals("= blah", c.getComment());
+    }
+
 }


### PR DESCRIPTION
The FITS standard states:

> 4.1.2.2. Value indicator (Bytes 9 and 10)
>
> If the two ASCII characters '= ' (decimal 61 followed by decimal 32) are present in Bytes 9 and 10 of the keyword
> record, this indicates that the keyword has a value field associated with it, unless it is one of the commentary keywords
> defined in Sect. 4.4.2 (i.e., a HISTORY, COMMENT, or completely blank keyword name), which, by definition, have no value.

So, we should comply.