### PR TITLE
Default image tiler for non-random-accessible inputs

### DIFF
--- a/src/main/java/nom/tam/fits/ImageData.java
+++ b/src/main/java/nom/tam/fits/ImageData.java
@@ -189,13 +189,14 @@ public class ImageData extends Data {
     }
 
     /**
-     * Returns the class that can be used to divide this image into tiles that may be processed separately (and in
-     * parallel).
+     * Returns the an image tiler instance that can be used to divide this image into tiles that may be processed
+     * separately (and in parallel). A default tiler, which returns the image in memory, is returned for images not
+     * associated with a random-accessible input.
      * 
      * @return image tiler for this image instance.
      */
     public StandardImageTiler getTiler() {
-        return tiler;
+        return tiler != null ? tiler : new ImageDataTiler(null, 0, dataDescription);
     }
 
     /**

--- a/src/test/java/nom/tam/image/ImageTilerTest.java
+++ b/src/test/java/nom/tam/image/ImageTilerTest.java
@@ -102,6 +102,8 @@ package nom.tam.image;
 import org.junit.Assert;
 import org.junit.Test;
 
+import nom.tam.fits.ImageData;
+
 public class ImageTilerTest {
     @Test
     public void defaultImplementation() throws Exception {
@@ -138,5 +140,13 @@ public class ImageTilerTest {
         public Object getCompleteImage() {
             return null;
         }
+    }
+
+    @Test
+    public void testDefaultTiler() throws Exception {
+        ImageData im = new ImageData();
+        ImageTiler tiler = im.getTiler();
+
+        Assert.assertNotNull(tiler);
     }
 }


### PR DESCRIPTION
It is useful to return a default image tiler (one, which returns the entire image in memory) even for non-random accessible inputs.  (thanks to @sguzzo-dkist-nso).