### PR TITLE
Add tests for #847 and improvements to Stokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the nom.tam.fits library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.22.1-rc1] - 2026-06-03
 
 Upcoming maintenance release, possibly around June 15, 2026.
 

--- a/src/main/java/nom/tam/fits/AsciiTable.java
+++ b/src/main/java/nom/tam/fits/AsciiTable.java
@@ -216,6 +216,10 @@ public class AsciiTable extends AbstractTableData {
                 throw new HeaderCardException("Invalid " + TFORMn.n(i + 1).key() + " value: '" + s + "'");
             }
 
+            if (lengths[i] < 0) {
+                throw new HeaderCardException("Invalid " + TFORMn.n(i + 1).key() + " value: '" + s + "'");
+            }
+
             switch (c) {
             case 'A':
                 types[i] = String.class;

--- a/src/main/java/nom/tam/fits/BinaryTable.java
+++ b/src/main/java/nom/tam/fits/BinaryTable.java
@@ -1659,17 +1659,19 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
     }
 
     /**
-     * @deprecated       (<i>for internal use</i>) It may be reduced to private visibility in the future. Parse the
-     *                       TDIMS value. If the TDIMS value cannot be deciphered a one-d array with the size given in
-     *                       arrsiz is returned.
+     * @deprecated                     (<i>for internal use</i>) It may be reduced to private visibility in the future.
+     *                                     Parse the TDIMS value. If the TDIMS value cannot be deciphered a one-d array
+     *                                     with the size given in arrsiz is returned.
      *
-     * @param      tdims The value of the TDIMSn card.
+     * @param      tdims               The value of the TDIMSn card.
      *
-     * @return           An int array of the desired dimensions. Note that the order of the tdims is the inverse of the
-     *                       order in the TDIMS key.
+     * @return                         An int array of the desired dimensions. Note that the order of the tdims is the
+     *                                     inverse of the order in the TDIMS key.
+     * 
+     * @throws     HeaderCardException if the argument does not confirm to the FITS specification for the TDIMn keyword.
      */
     @Deprecated
-    public static int[] parseTDims(String tdims) {
+    public static int[] parseTDims(String tdims) throws HeaderCardException {
         if (tdims == null) {
             return null;
         }
@@ -1695,6 +1697,10 @@ public class BinaryTable extends AbstractTableData implements Cloneable {
                 try {
                     dims[i] = Integer.parseInt(st.nextToken().trim());
                 } catch (NumberFormatException e) {
+                    throw new HeaderCardException("Invalid TDIMn value: '" + tdims + "'");
+                }
+
+                if (dims[i] < 0) {
                     throw new HeaderCardException("Invalid TDIMn value: '" + tdims + "'");
                 }
             }

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -153,7 +153,7 @@ import static nom.tam.fits.header.Standard.EXTVER;
  * 
  * @see     FitsFactory
  *
- * @version 1.21
+ * @version 1.22
  */
 @SuppressWarnings("deprecation")
 public class Fits implements Closeable {

--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -70,8 +70,8 @@ public class FitsDate implements Comparable<FitsDate> {
 
     private static final int NEW_FORMAT_YEAR_GROUP = 2;
 
-    private static final Pattern NORMAL_REGEX = Pattern.compile(
-            "\\s*(([0-9][0-9][0-9][0-9])-([0-9][0-9])-([0-9][0-9]))(T([0-9][0-9]):([0-9][0-9]):([0-9][0-9])(\\.([0-9]+))?)?\\s*");
+    private static final Pattern NORMAL_REGEX = Pattern
+            .compile("\\s*((\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d))(T(\\d\\d):(\\d\\d):(\\d\\d)(\\.(\\d+))?)?\\s*");
 
     private static final int OLD_FORMAT_DAY_OF_MONTH_GROUP = 1;
 
@@ -79,7 +79,7 @@ public class FitsDate implements Comparable<FitsDate> {
 
     private static final int OLD_FORMAT_YEAR_GROUP = 3;
 
-    private static final Pattern OLD_REGEX = Pattern.compile("\\s*([0-9][0-9])/([0-9][0-9])/([0-9][0-9])\\s*");
+    private static final Pattern OLD_REGEX = Pattern.compile("\\s*(\\d\\d)/(\\d\\d)/(\\d\\d)\\s*");
 
     private static final int YEAR_OFFSET = 1900;
 
@@ -177,30 +177,28 @@ public class FitsDate implements Comparable<FitsDate> {
             return;
         }
 
-        try {
-            Matcher match = FitsDate.NORMAL_REGEX.matcher(dStr);
-            if (match.matches()) {
-                year = getInt(match, FitsDate.NEW_FORMAT_YEAR_GROUP);
-                month = getInt(match, FitsDate.NEW_FORMAT_MONTH_GROUP);
-                mday = getInt(match, FitsDate.NEW_FORMAT_DAY_OF_MONTH_GROUP);
-                hour = getInt(match, FitsDate.NEW_FORMAT_HOUR_GROUP);
-                minute = getInt(match, FitsDate.NEW_FORMAT_MINUTE_GROUP);
-                second = getInt(match, FitsDate.NEW_FORMAT_SECOND_GROUP);
-                millisecond = getMilliseconds(match, FitsDate.NEW_FORMAT_MILLISECOND_GROUP);
-            } else {
-                match = FitsDate.OLD_REGEX.matcher(dStr);
-                if (!match.matches()) {
-                    if (dStr.trim().isEmpty()) {
-                        return;
-                    }
-                    throw new FitsException("Bad FITS date string \"" + dStr + '"');
+        Matcher match = FitsDate.NORMAL_REGEX.matcher(dStr);
+        if (match.matches()) {
+            // The regex match ensures we can never get a NumberFormatException here...
+            year = getInt(match, FitsDate.NEW_FORMAT_YEAR_GROUP);
+            month = getInt(match, FitsDate.NEW_FORMAT_MONTH_GROUP);
+            mday = getInt(match, FitsDate.NEW_FORMAT_DAY_OF_MONTH_GROUP);
+            hour = getInt(match, FitsDate.NEW_FORMAT_HOUR_GROUP);
+            minute = getInt(match, FitsDate.NEW_FORMAT_MINUTE_GROUP);
+            second = getInt(match, FitsDate.NEW_FORMAT_SECOND_GROUP);
+            millisecond = getMilliseconds(match, FitsDate.NEW_FORMAT_MILLISECOND_GROUP);
+        } else {
+            // The regex match ensures we can never get a NumberFormatException here...
+            match = FitsDate.OLD_REGEX.matcher(dStr);
+            if (!match.matches()) {
+                if (dStr.trim().isEmpty()) {
+                    return;
                 }
-                year = getInt(match, FitsDate.OLD_FORMAT_YEAR_GROUP) + FitsDate.YEAR_OFFSET;
-                month = getInt(match, FitsDate.OLD_FORMAT_MONTH_GROUP);
-                mday = getInt(match, FitsDate.OLD_FORMAT_DAY_OF_MONTH_GROUP);
+                throw new FitsException("Bad FITS date string \"" + dStr + '"');
             }
-        } catch (NumberFormatException e) {
-            throw new FitsException("Invalid FITS date string: '" + dStr + "'");
+            year = getInt(match, FitsDate.OLD_FORMAT_YEAR_GROUP) + FitsDate.YEAR_OFFSET;
+            month = getInt(match, FitsDate.OLD_FORMAT_MONTH_GROUP);
+            mday = getInt(match, FitsDate.OLD_FORMAT_DAY_OF_MONTH_GROUP);
         }
     }
 

--- a/src/main/java/nom/tam/fits/header/Stokes.java
+++ b/src/main/java/nom/tam/fits/header/Stokes.java
@@ -47,7 +47,7 @@ import nom.tam.fits.Header;
  * enum provides an implementation of that for this library.
  * </p>
  * <p>
- * An dataset may typically contain 4 or 8 Stokes parameters (or fewer), which depending on the type of measurement can
+ * A dataset may typically contain 4 or 8 Stokes parameters (or fewer), which depending on the type of measurement can
  * be (I, Q, U, [V]), or (RR, LL, RL, LR) and/or (XX, YY, XY, YX). As such, the corresponding {@link WCS#CRPIXna} is
  * typically 0 and {@link WCS#CDELTna} is +/- 1, and depending on the type of measurement {@link WCS#CRVALna} is 1, or
  * -1, or -5. You can use the {@link Parameters} subclass to help populate or interpret Stokes parameters in headers.
@@ -70,7 +70,7 @@ public enum Stokes {
     /** Stokes U: linear polarization U component */
     U(3),
 
-    /** Stokes V: circularly polarization */
+    /** Stokes V: circular polarization */
     V(4),
 
     /** circular cross-polarization between two right-handed wave components */
@@ -79,10 +79,10 @@ public enum Stokes {
     /** circular cross-polarization between two left-handed wave components */
     LL(-2),
 
-    /** circular cross-polarization between a right-handled (input 1) and a left-handed (input 2) wave component */
+    /** circular cross-polarization between a right-handed (input 1) and a left-handed (input 2) wave component */
     RL(-3),
 
-    /** circular cross-polarization between a left-handled (input 1) and a right-handed (input 2) wave component */
+    /** circular cross-polarization between a left-handed (input 1) and a right-handed (input 2) wave component */
     LR(-4),
 
     /** linear cross-polarization between two 'horizontal' wave components (in local orientation) */
@@ -137,14 +137,21 @@ public enum Stokes {
      * 
      * @param  value                     The image coordinate value
      * 
-     * @return                           The Stokes parameter, which corresponds to that coordinate value.
+     * @return                           The Stokes parameter, which corresponds to that coordinate value. For values
+     *                                       1--4, the singular Stokes parameters I, Q, U, or V is returned. For
+     *                                       negative values, -1 through -8, the cross polarization parameters are
+     *                                       returned. For all other values and `IndexOutOfBoundsException` is thrown
      * 
-     * @throws IndexOutOfBoundsException if the coordinate value is outt of the range of acceptable Stokes coordinate
-     *                                       values.
+     * @throws IndexOutOfBoundsException if the coordinate value is 0 or out of the range of acceptable Stokes
+     *                                       coordinate values.
      * 
      * @see                              #getCoordinateValue()
      */
     public static Stokes forCoordinateValue(int value) throws IndexOutOfBoundsException {
+        if (value == 0) {
+            throw new IndexOutOfBoundsException(
+                    "Value must be in the range [1:4] for single-ended or else [-1:-8] for cross-polarization.");
+        }
         return ordered[value - YX.getCoordinateValue()];
     }
 

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -1348,6 +1348,12 @@ public class BinaryTableNewTest {
     }
 
     @Test
+    public void testParseTDimsException() throws Exception {
+        Assertions.assertThrows(HeaderCardException.class, () -> BinaryTable.parseTDims("(1,z,3)"), "non-integer");
+        Assertions.assertThrows(HeaderCardException.class, () -> BinaryTable.parseTDims("(1,-2,3)"), "negative value");
+    }
+
+    @Test
     public void testParseTDimsEmpty() throws Exception {
         Assertions.assertNull(BinaryTable.parseTDims("()"));
     }

--- a/src/test/java/nom/tam/fits/header/StokesTest.java
+++ b/src/test/java/nom/tam/fits/header/StokesTest.java
@@ -63,6 +63,10 @@ public class StokesTest {
 
     @Test
     public void testForCoordinateValues() throws Exception {
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> Stokes.forCoordinateValue(0), "0");
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> Stokes.forCoordinateValue(5), "5");
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> Stokes.forCoordinateValue(-9), "-9");
+
         Assertions.assertEquals(Stokes.I, Stokes.forCoordinateValue(1));
         Assertions.assertEquals(Stokes.Q, Stokes.forCoordinateValue(2));
         Assertions.assertEquals(Stokes.U, Stokes.forCoordinateValue(3));

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -897,6 +897,22 @@ public class AsciiTableTest {
     }
 
     @Test
+    public void testInvalidTFORM() throws Exception {
+        Header hdr = new Header();
+        hdr.card(Standard.XTENSION).value(Standard.XTENSION_ASCIITABLE)//
+                .card(Standard.NAXIS1).value(1)//
+                .card(Standard.NAXIS2).value(1)//
+                .card(Standard.TFIELDS).value(1)//
+                .card(Standard.TBCOLn.n(1)).value(4)//
+                .card(Standard.TFORMn.n(1)).value("Iz");
+
+        Assertions.assertThrows(FitsException.class, () -> new AsciiTable(hdr));
+
+        hdr.addValue(Standard.TFORMn.n(1), "I-1");
+        Assertions.assertThrows(FitsException.class, () -> new AsciiTable(hdr));
+    }
+
+    @Test
     public void testI10() throws Exception {
         // Test configurable edge case of ASCII table with format I10 columns;
         // there are pros and cons for interpreting these as int or long,


### PR DESCRIPTION
- Add tests for PR #847 
- `Stokes.forCoordinateValue` to throw `IndexOutOfBoundsException` instead of returning `null` for 0.