### PR TITLE
Compress cutout fix

### DIFF
--- a/src/main/java/nom/tam/image/compression/CompressedImageTiler.java
+++ b/src/main/java/nom/tam/image/compression/CompressedImageTiler.java
@@ -44,8 +44,8 @@ import nom.tam.fits.Header;
 import nom.tam.fits.compression.algorithm.api.ICompressOption;
 import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
-import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 import nom.tam.fits.compression.provider.CompressorProvider;
+import nom.tam.fits.compression.provider.param.api.ICompressParameters;
 import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.Standard;
 import nom.tam.image.ImageTiler;
@@ -244,10 +244,13 @@ public class CompressedImageTiler implements ImageTiler {
     }
 
     int[] getTileIndexes(final int[] pixelPositions, final int[] tileDimensions) {
-        final int[] tileIndexes = new int[pixelPositions.length];
+        final int n = pixelPositions.length;
+        final int[] tileIndexes = new int[n];
 
-        for (int i = 0; i < pixelPositions.length; i++) {
-            tileIndexes[i] = pixelPositions[i] / tileDimensions[i];
+        for (int i = 0; i < n; i++) {
+            // Positions and tile dimensions are in image index order (ZNAXISn reversed). Table rows use FITS axis
+            // order (NAXIS1 varies fastest), so map each image axis to the corresponding FITS axis index.
+            tileIndexes[n - 1 - i] = pixelPositions[i] / tileDimensions[i];
         }
 
         return tileIndexes;
@@ -293,12 +296,12 @@ public class CompressedImageTiler implements ImageTiler {
      *
      * @return            Buffer instance. Never null.
      */
-    Buffer decompressIntoBuffer(final Object[] row, final ByteBuffer compressed) {
+    Buffer decompressIntoBuffer(final Object[] row, final ByteBuffer compressed) throws FitsException {
         final ElementType<Buffer> bufferElementType = getBaseType();
         final Buffer tileBuffer = bufferElementType.newBuffer(getTileSize());
         tileBuffer.rewind();
         final ICompressorControl compressorControl = getCompressorControl(getBaseType());
-        final ICompressOption option = initCompressionOption(compressorControl.option(), bufferElementType.size());
+        final ICompressOption option = initCompressionOption(compressorControl.option());
         initRowOption(option, row);
         compressorControl.decompress(compressed, tileBuffer, option);
 
@@ -311,12 +314,10 @@ public class CompressedImageTiler implements ImageTiler {
                 elementType.primitiveClass());
     }
 
-    ICompressOption initCompressionOption(final ICompressOption option, final int bytePix) {
-        if (option instanceof RiceCompressOption) {
-            ((RiceCompressOption) option).setBlockSize(getBlockSize());
-            ((RiceCompressOption) option).setBytePix(bytePix);
-        } else if (option instanceof QuantizeOption) {
-            initCompressionOption(((QuantizeOption) option).getCompressOption(), bytePix);
+    ICompressOption initCompressionOption(final ICompressOption option) throws FitsException {
+        final ICompressParameters parameters = option.getCompressionParameters();
+        if (parameters != null) {
+            parameters.getValuesFromHeader(getHeader());
         }
 
         option.setTileHeight(getTileHeight()).setTileWidth(getTileWidth());
@@ -355,8 +356,7 @@ public class CompressedImageTiler implements ImageTiler {
      * @throws FitsException  If the row doesn't exist, or cannot be read.
      */
     Object[] getRow(final int[] positions, final int[] tileDimensions) throws FitsException {
-        final int[] tileIndexes = getTileIndexes(ArrayFuncs.reverseIndices(positions),
-                ArrayFuncs.reverseIndices(tileDimensions));
+        final int[] tileIndexes = getTileIndexes(positions, tileDimensions);
         final int rowNumber = getRowNumber(tileIndexes);
         return compressedImageHDU.getRow(rowNumber);
     }

--- a/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
+++ b/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
@@ -46,6 +46,8 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
@@ -1123,33 +1125,33 @@ public class ReadWriteProvidedCompressedImageTest {
     }
 
     @Test
-    public void testCutout() throws Exception {
+    public void writeCutoutFromCompressed() throws Exception {
         final File tempFile = File.createTempFile("temp", ".fits");
-        // This is a larger (356MB) file.  Don't read it in entirely.
-        final Path filePath = Path.of(resolveLocalOrRemoteFileName("cfht-megacam-1022459p.fits.fz"));
-        final int[] corners9 = new int[] {1, 668};
-        final int[] lengths9 = new int[] {464, 1740-668};
-        byte[] expectedCutout9;
+        // This is a larger (256MB) file.  Don't read it in entirely.
+        final Path filePath = Path.of(resolveLocalOrRemoteFileName("tu1134531.fits.fz"));
+        final int[] corners = new int[] {1, 230};
+        final int[] lengths = new int[] {464, 225};
+        byte[] expectedCutout;
 
         try (final FitsInputStream fitsInputStream = new FitsInputStream(new FileInputStream(filePath.toFile()));
              final Fits fits = new Fits(fitsInputStream);
              final Fits fitsOutput = new Fits(tempFile);
              final FitsOutputStream fitsOutputStream = new FitsOutputStream(new FileOutputStream(tempFile))) {
 
-            final BasicHDU<?> hdu9 = fits.getHDU(9);
-            Assertions.assertInstanceOf(CompressedImageHDU.class, hdu9, "Incorrect type of HDU at index 9");
-            final CompressedImageHDU compressedImageHDU9 = (CompressedImageHDU) hdu9;
-            expectedCutout9 = getCutoutBytes(compressedImageHDU9, corners9, lengths9);
-            final Header header9 = ReadWriteProvidedCompressedImageTest.copyHeader(compressedImageHDU9.getHeader());
-            ReadWriteProvidedCompressedImageTest.adjustMEFHeader(header9, false, 1);
-            ReadWriteProvidedCompressedImageTest.addCutoutFromCompressed(compressedImageHDU9, header9, fitsOutput,
-                    corners9, lengths9);
+            final BasicHDU<?> hdu = fits.getHDU(5);
+            Assertions.assertInstanceOf(CompressedImageHDU.class, hdu, "Incorrect type of HDU at index 5");
+            final CompressedImageHDU compressedImageHDU = (CompressedImageHDU) hdu;
+            expectedCutout = getCutoutBytes(compressedImageHDU, corners, lengths);
+            final Header header = ReadWriteProvidedCompressedImageTest.copyHeader(compressedImageHDU.getHeader());
+            ReadWriteProvidedCompressedImageTest.adjustHeader(header);
+            ReadWriteProvidedCompressedImageTest.addCutoutFromCompressed(compressedImageHDU, header, fitsOutput,
+                    corners, lengths);
 
             fitsOutput.write(fitsOutputStream);
         }
 
         try {
-            assertWrittenCutoutMatches(tempFile, 0, expectedCutout9, lengths9);
+            assertWrittenCutoutMatches(tempFile, 0, expectedCutout, lengths);
         } finally {
             tempFile.delete();
         }
@@ -1202,12 +1204,55 @@ public class ReadWriteProvidedCompressedImageTest {
             Assertions.assertArrayEquals(expectedAxes,
                     ArrayFuncs.getDimensions(imageHdu.getData().getData()),
                     "Java array dimensions at HDU " + hduIndex);
+            final Class<?> arrayType = ArrayFuncs.getBaseClass(imageHdu.getData().getData());
+            final ByteBuffer expectedPixels = java.nio.ByteBuffer.wrap(expected);
+            ReadWriteProvidedCompressedImageTest.writeExpectedCutoutBytes(expectedPixels, imageHdu, lengths, hduIndex,
+                    arrayType);
+        }
+    }
+
+    private static void writeExpectedCutoutBytes(final ByteBuffer expectedPixels, final ImageHDU imageHdu,
+                                                 final int[] lengths, final int hduIndex, final Class<?> arrayType) {
+        if (arrayType == short.class) {
+            final ShortBuffer expectedShortPixels = expectedPixels.asShortBuffer();
             final short[][] data = (short[][]) imageHdu.getData().getData();
-            final ShortBuffer expectedPixels = java.nio.ByteBuffer.wrap(expected).asShortBuffer();
             int index = 0;
             for (int axis2 = 0; axis2 < lengths[0]; axis2++) {
                 for (int axis1 = 0; axis1 < lengths[1]; axis1++) {
-                    Assertions.assertEquals(expectedPixels.get(index), data[axis2][axis1],
+                    Assertions.assertEquals(expectedShortPixels.get(index), data[axis2][axis1],
+                            "pixel differed at cutout index " + index + " in HDU " + hduIndex);
+                    index++;
+                }
+            }
+        } else if (arrayType == float.class) {
+            final FloatBuffer expectedFloatPixels = expectedPixels.asFloatBuffer();
+            final float[][] data = (float[][]) imageHdu.getData().getData();
+            int index = 0;
+            for (int axis2 = 0; axis2 < lengths[0]; axis2++) {
+                for (int axis1 = 0; axis1 < lengths[1]; axis1++) {
+                    Assertions.assertEquals(expectedFloatPixels.get(index), data[axis2][axis1],
+                            "pixel differed at cutout index " + index + " in HDU " + hduIndex);
+                    index++;
+                }
+            }
+        } else if (arrayType == double.class) {
+            final DoubleBuffer expectedDoublePixels = expectedPixels.asDoubleBuffer();
+            final double[][] data = (double[][]) imageHdu.getData().getData();
+            int index = 0;
+            for (int axis2 = 0; axis2 < lengths[0]; axis2++) {
+                for (int axis1 = 0; axis1 < lengths[1]; axis1++) {
+                    Assertions.assertEquals(expectedDoublePixels.get(index), data[axis2][axis1],
+                            "pixel differed at cutout index " + index + " in HDU " + hduIndex);
+                    index++;
+                }
+            }
+        }  else if (arrayType == int.class) {
+            final IntBuffer expectedIntPixels = expectedPixels.asIntBuffer();
+            final int[][] data = (int[][]) imageHdu.getData().getData();
+            int index = 0;
+            for (int axis2 = 0; axis2 < lengths[0]; axis2++) {
+                for (int axis1 = 0; axis1 < lengths[1]; axis1++) {
+                    Assertions.assertEquals(expectedIntPixels.get(index), data[axis2][axis1],
                             "pixel differed at cutout index " + index + " in HDU " + hduIndex);
                     index++;
                 }
@@ -1245,19 +1290,13 @@ public class ReadWriteProvidedCompressedImageTest {
         }
     }
 
-    static void adjustMEFHeader(final Header header, final boolean firstHDUAlreadyWritten,
-                                final int nextEndSize) {
+    static void adjustHeader(final Header header) {
         header.deleteKey(Standard.SIMPLE);
         header.deleteKey(Standard.XTENSION);
         header.deleteKey(Standard.EXTEND);
         header.deleteKey(Standard.TFIELDS);
 
-        if (firstHDUAlreadyWritten) {
-            header.addValue(Standard.XTENSION, Standard.XTENSION_IMAGE);
-        } else {
-            header.addValue(Standard.SIMPLE, Boolean.TRUE);
-            ReadWriteProvidedCompressedImageTest.setupPrimaryHeader(header, nextEndSize);
-        }
+        header.addValue(Standard.XTENSION, Standard.XTENSION_IMAGE);
 
         // Values set as per FITS standard for IMAGE and SIMPLE extensions.
         header.addValue(Standard.PCOUNT, 0);

--- a/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
+++ b/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
@@ -43,9 +43,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
+import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -54,6 +58,11 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.WindowConstants;
 
+import nom.tam.fits.HeaderCardException;
+import nom.tam.fits.header.DataDescription;
+import nom.tam.image.StreamingTileImageData;
+import nom.tam.image.compression.CompressedImageTiler;
+import nom.tam.util.FitsInputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,7 +87,7 @@ import nom.tam.util.ArrayFuncs;
 import nom.tam.util.FitsOutputStream;
 import nom.tam.util.SafeClose;
 
-@SuppressWarnings({"javadoc", "deprecation"})
+@SuppressWarnings({"deprecation"})
 public class ReadWriteProvidedCompressedImageTest {
 
     private ImageHDU m13;
@@ -127,7 +136,7 @@ public class ReadWriteProvidedCompressedImageTest {
             double d2 = actual[index];
             if (Double.isNaN(d1) || Double.isNaN(d2)) {
                 if (checkNaN) {
-                    Assertions.assertTrue(Double.isNaN(d1) == Double.isNaN(d2)); //
+                    Assertions.assertEquals(Double.isNaN(d1), Double.isNaN(d2)); //
                 }
             } else {
                 Assertions.assertEquals(d1, d2, delta);
@@ -143,7 +152,7 @@ public class ReadWriteProvidedCompressedImageTest {
     }
 
     /**
-     * Assertions.assert two files files (one compressed and one uncompressed and use as little memory as possible.
+     * Assertions.assert two files; one compressed and one uncompressed and use as little memory as possible.
      */
     @SuppressWarnings("unchecked")
     private <T>
@@ -230,98 +239,50 @@ public class ReadWriteProvidedCompressedImageTest {
     @Test
     public void blackboxTest_c4s_060126_182642_zri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("c4s_060126_182642_zri.fits.fz"), //
-                resolveLocalOrRemoteFileName("c4s_060126_182642_zri.fits"), short[][].class, new IHDUAsserter<short[][]>() {
-
-                    @Override
-                    public void assertData(short[][] expected, short[][] actual) {
-                        assert_short_image(actual, expected);
-                    }
-                });
+                resolveLocalOrRemoteFileName("c4s_060126_182642_zri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_c4s_060127_070751_cri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("c4s_060127_070751_cri.fits.fz"), //
-                resolveLocalOrRemoteFileName("c4s_060127_070751_cri.fits"), short[][].class, new IHDUAsserter<short[][]>() {
-
-                    @Override
-                    public void assertData(short[][] expected, short[][] actual) {
-                        assert_short_image(actual, expected);
-                    }
-                });
+                resolveLocalOrRemoteFileName("c4s_060127_070751_cri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_kwi_041217_212603_fri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("kwi_041217_212603_fri.fits.fz"), //
-                resolveLocalOrRemoteFileName("kwi_041217_212603_fri.fits"), short[][].class, new IHDUAsserter<short[][]>() {
-
-                    @Override
-                    public void assertData(short[][] expected, short[][] actual) {
-                        assert_short_image(actual, expected);
-                    }
-                });
+                resolveLocalOrRemoteFileName("kwi_041217_212603_fri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_kwi_041217_213100_fri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("kwi_041217_213100_fri.fits.fz"), //
-                resolveLocalOrRemoteFileName("kwi_041217_213100_fri.fits"), short[][].class, new IHDUAsserter<short[][]>() {
-
-                    @Override
-                    public void assertData(short[][] expected, short[][] actual) {
-                        assert_short_image(actual, expected);
-                    }
-                });
+                resolveLocalOrRemoteFileName("kwi_041217_213100_fri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_psa_140305_191552_zri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("psa_140305_191552_zri.fits.fz"), //
-                resolveLocalOrRemoteFileName("psa_140305_191552_zri.fits"), short[][].class, new IHDUAsserter<short[][]>() {
-
-                    @Override
-                    public void assertData(short[][] expected, short[][] actual) {
-                        assert_short_image(actual, expected);
-                    }
-                });
+                resolveLocalOrRemoteFileName("psa_140305_191552_zri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_psa_140305_194520_fri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("psa_140305_194520_fri.fits.fz"), //
-                resolveLocalOrRemoteFileName("psa_140305_194520_fri.fits"), short[][].class, new IHDUAsserter<short[][]>() {
-
-                    @Override
-                    public void assertData(short[][] expected, short[][] actual) {
-                        assert_short_image(actual, expected);
-                    }
-                });
+                resolveLocalOrRemoteFileName("psa_140305_194520_fri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_tu1134529() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("tu1134529.fits.fz"), //
-                resolveLocalOrRemoteFileName("tu1134529.fits"), int[][].class, new IHDUAsserter<int[][]>() {
-
-                    @Override
-                    public void assertData(int[][] expected, int[][] actual) {
-                        assert_int_image(actual, expected);
-                    }
-                });
+                resolveLocalOrRemoteFileName("tu1134529.fits"), int[][].class, (IHDUAsserter<int[][]>) (expected, actual) -> assert_int_image(actual, expected));
 
     }
 
     @Test
     public void blackboxTest_tu1134531() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("tu1134531.fits.fz"), //
-                resolveLocalOrRemoteFileName("tu1134531.fits"), float[][].class, new IHDUAsserter<float[][]>() {
-
-                    @Override
-                    public void assertData(float[][] expected, float[][] actual) {
-                        assert_float_image(actual, expected, 15f);
-                    }
-                });
+                resolveLocalOrRemoteFileName("tu1134531.fits"), float[][].class, (IHDUAsserter<float[][]>) (expected, actual) -> assert_float_image(actual, expected, 15f));
     }
 
     @Test
@@ -718,21 +679,21 @@ public class ReadWriteProvidedCompressedImageTest {
         try (Fits f = new Fits()) {
             CompressedImageHDU compressedHdu = CompressedImageHDU.fromImageHDU(m13, 300, 15);
             compressedHdu.setCompressAlgorithm(Compression.ZCMPTYPE_HCOMPRESS_1)//
-                    .setQuantAlgorithm((String) null)//
+                    .setQuantAlgorithm(null)//
                     .getCompressOption(HCompressorOption.class)//
                     /**/.setScale(1);
             compressedHdu.compress();
             f.addHDU(compressedHdu);
             compressedHdu = CompressedImageHDU.fromImageHDU(m13, 300, 1);
             compressedHdu.setCompressAlgorithm(Compression.ZCMPTYPE_HCOMPRESS_1)//
-                    .setQuantAlgorithm((String) null)//
+                    .setQuantAlgorithm(null)//
                     .getCompressOption(HCompressorOption.class)//
                     /**/.setScale(1);
             compressedHdu.compress();
             f.addHDU(compressedHdu);
             compressedHdu = CompressedImageHDU.fromImageHDU(m13, 100, 300);
             compressedHdu.setCompressAlgorithm(Compression.ZCMPTYPE_HCOMPRESS_1)//
-                    .setQuantAlgorithm((String) null)//
+                    .setQuantAlgorithm(null)//
                     .getCompressOption(HCompressorOption.class)//
                     /**/.setSmooth(true)//
                     /**/.setScale(1);
@@ -1145,19 +1106,144 @@ public class ReadWriteProvidedCompressedImageTest {
 
     @Test
     public void testDitherDecompress() throws Exception {
-        ImageHDU im = null;
+        final ImageHDU im;
 
         try (Fits fits = new Fits("../blackbox-images/fpack.fits.fz")) {
             fits.readHDU();
             im = ((CompressedImageHDU) fits.readHDU()).asImageHDU();
-            fits.close();
         }
 
         try (Fits fits = new Fits("../blackbox-images/funpack.fits")) {
             ImageHDU ref = (ImageHDU) fits.readHDU();
 
             assertArrayEquals((float[][]) ref.getData().getData(), (float[][]) im.getData().getData(), 0.01f);
-            fits.close();
+        }
+    }
+
+    @Test
+    public void testCutout() throws Exception {
+        final File tempFile = File.createTempFile("temp", ".fits");
+        // This is a larger (356MB) file.  Don't read it in entirely.
+        final Path filePath = Path.of(resolveLocalOrRemoteFileName("1030185p.fits.fz"));
+
+        System.out.println("Output File: " + tempFile.getAbsolutePath());
+        System.out.println("Input File: " + filePath.toAbsolutePath());
+
+        try (final FitsInputStream fitsInputStream = new FitsInputStream(new FileInputStream(filePath.toFile()));
+             final Fits fits = new Fits(fitsInputStream);
+             final Fits fitsOutput = new Fits(tempFile);
+             final FitsOutputStream fitsOutputStream = new FitsOutputStream(new FileOutputStream(tempFile))) {
+
+            System.out.println("Starting read at HDU 8");
+            final BasicHDU<?> hdu8 = fits.getHDU(8);
+            System.out.println("Starting read at HDU 8: OK");
+            Assertions.assertInstanceOf(CompressedImageHDU.class, hdu8, "Incorrect type of HDU at index 8");
+            final CompressedImageHDU compressedImageHDU8 = (CompressedImageHDU) hdu8;
+            final Header header8 = ReadWriteProvidedCompressedImageTest.copyHeader(compressedImageHDU8.getHeader());
+            ReadWriteProvidedCompressedImageTest.adjustMEFHeader(header8,  false, 1);
+            ReadWriteProvidedCompressedImageTest.addCutoutFromCompressed(compressedImageHDU8, header8, fitsOutput,
+                    new int[]{1, 1}, new int[]{95, 104});
+
+            System.out.println("Starting read at HDU 9");
+            final BasicHDU<?> hdu9 = fits.getHDU(9);
+            System.out.println("Starting read at HDU 9: OK");
+            Assertions.assertInstanceOf(CompressedImageHDU.class, hdu9, "Incorrect type of HDU at index 9");
+            final CompressedImageHDU compressedImageHDU9 = (CompressedImageHDU) hdu9;
+            final Header header9 = ReadWriteProvidedCompressedImageTest.copyHeader(compressedImageHDU9.getHeader());
+            ReadWriteProvidedCompressedImageTest.adjustMEFHeader(header9,  true, 1);
+            ReadWriteProvidedCompressedImageTest.addCutoutFromCompressed(compressedImageHDU9, header9, fitsOutput,
+                    new int[]{1115, 0}, new int[]{2112, 92});
+
+            fitsOutput.write(fitsOutputStream);
+        }
+    }
+
+    static void addCutoutFromCompressed(final CompressedImageHDU compressedImageHDU, final Header adjustedHeader,
+                                        final Fits fitsOutput, final int[] corners, final int[] lengths) {
+        final CompressedImageTiler compressedImageTiler = new CompressedImageTiler(compressedImageHDU);
+        final StreamingTileImageData streamingTileImageData8 = new StreamingTileImageData(adjustedHeader,
+                compressedImageTiler, corners, lengths, new int[]{1, 1});
+        fitsOutput.addHDU(new ImageHDU(adjustedHeader, streamingTileImageData8));
+    }
+
+    static void adjustMEFHeader(final Header header, final boolean firstHDUAlreadyWritten,
+                                final int nextEndSize) {
+        header.deleteKey(Standard.SIMPLE);
+        header.deleteKey(Standard.XTENSION);
+        header.deleteKey(Standard.EXTEND);
+        header.deleteKey(Standard.TFIELDS);
+
+        if (firstHDUAlreadyWritten) {
+            header.addValue(Standard.XTENSION, Standard.XTENSION_IMAGE);
+        } else {
+            header.addValue(Standard.SIMPLE, Boolean.TRUE);
+            ReadWriteProvidedCompressedImageTest.setupPrimaryHeader(header, nextEndSize);
+        }
+
+        // Values set as per FITS standard for IMAGE and SIMPLE extensions.
+        header.addValue(Standard.PCOUNT, 0);
+        header.addValue(Standard.GCOUNT, 1);
+    }
+
+    private static Header copyHeader(final Header source) throws HeaderCardException {
+        final Header destination = new Header();
+        for (final Iterator<HeaderCard> headerCardIterator = source.iterator(); headerCardIterator.hasNext(); ) {
+            final HeaderCard headerCard = headerCardIterator.next();
+            final String headerCardKey = headerCard.getKey();
+            final Class<?> valueType = headerCard.valueType();
+
+            // Check for blank lines or just plain comments that are not standard FITS comments.
+            if (headerCardKey == null || headerCardKey.trim().isEmpty()) {
+                destination.addValue(headerCardKey, (String) null, headerCard.getComment());
+            } else if (Standard.COMMENT.key().equals(headerCardKey)) {
+                destination.insertComment(headerCard.getComment());
+            } else if (Standard.HISTORY.key().equals(headerCardKey)) {
+                destination.insertHistory(headerCard.getComment());
+            } else {
+                if (valueType == String.class || valueType == null) {
+                    destination.addValue(headerCardKey, headerCard.getValue(), headerCard.getComment());
+                } else if (valueType == Boolean.class) {
+                    destination.addValue(headerCardKey, Boolean.parseBoolean(headerCard.getValue()),
+                            headerCard.getComment());
+                } else if (valueType == Integer.class || valueType == BigInteger.class) {
+                    destination.addValue(headerCardKey, new BigInteger(headerCard.getValue()),
+                            headerCard.getComment());
+                } else if (valueType == Long.class) {
+                    destination.addValue(headerCardKey, Long.parseLong(headerCard.getValue()),
+                            headerCard.getComment());
+                } else if (valueType == Double.class) {
+                    destination.addValue(headerCardKey, Double.parseDouble(headerCard.getValue()),
+                            headerCard.getComment());
+                } else if (valueType == BigDecimal.class) {
+                    destination.addValue(headerCardKey, new BigDecimal(headerCard.getValue()),
+                            headerCard.getComment());
+                } else if (valueType == Float.class) {
+                    destination.addValue(headerCardKey, Float.parseFloat(headerCard.getValue()),
+                            headerCard.getComment());
+                }
+            }
+        }
+
+        return destination;
+    }
+
+    private static void setupPrimaryHeader(final Header header, final int nextEndSize) throws HeaderCardException {
+        final HeaderCard nextEndCard = header.findCard(DataDescription.NEXTEND);
+
+        // Adjust the NEXTEND appropriately.
+        if (nextEndCard == null) {
+            header.addValue(DataDescription.NEXTEND, nextEndSize);
+        } else {
+            nextEndCard.setValue(nextEndSize);
+        }
+
+        final HeaderCard extendFlagCard = header.findCard(Standard.EXTEND);
+
+        // Adjust the EXTEND appropriately.
+        if (extendFlagCard == null) {
+            header.addValue(Standard.EXTEND, true);
+        } else {
+            extendFlagCard.setValue(true);
         }
     }
 }

--- a/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
+++ b/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
@@ -36,6 +36,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -83,6 +84,7 @@ import nom.tam.fits.header.Standard;
 import nom.tam.fits.util.BlackBoxImages;
 import nom.tam.image.StandardImageTiler;
 import nom.tam.image.compression.hdu.CompressedImageHDU;
+import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
 import nom.tam.util.FitsOutputStream;
 import nom.tam.util.SafeClose;
@@ -1124,46 +1126,123 @@ public class ReadWriteProvidedCompressedImageTest {
     public void testCutout() throws Exception {
         final File tempFile = File.createTempFile("temp", ".fits");
         // This is a larger (356MB) file.  Don't read it in entirely.
-        final Path filePath = Path.of(resolveLocalOrRemoteFileName("1030185p.fits.fz"));
-
-        System.out.println("Output File: " + tempFile.getAbsolutePath());
-        System.out.println("Input File: " + filePath.toAbsolutePath());
+        final Path filePath = Path.of(resolveLocalOrRemoteFileName("cfht-megacam-1022459p.fits.fz"));
+        final int[] corners9 = new int[] {1, 668};
+        final int[] lengths9 = new int[] {464, 1740-668};
+        byte[] expectedCutout9;
 
         try (final FitsInputStream fitsInputStream = new FitsInputStream(new FileInputStream(filePath.toFile()));
              final Fits fits = new Fits(fitsInputStream);
              final Fits fitsOutput = new Fits(tempFile);
              final FitsOutputStream fitsOutputStream = new FitsOutputStream(new FileOutputStream(tempFile))) {
 
-            System.out.println("Starting read at HDU 8");
-            final BasicHDU<?> hdu8 = fits.getHDU(8);
-            System.out.println("Starting read at HDU 8: OK");
-            Assertions.assertInstanceOf(CompressedImageHDU.class, hdu8, "Incorrect type of HDU at index 8");
-            final CompressedImageHDU compressedImageHDU8 = (CompressedImageHDU) hdu8;
-            final Header header8 = ReadWriteProvidedCompressedImageTest.copyHeader(compressedImageHDU8.getHeader());
-            ReadWriteProvidedCompressedImageTest.adjustMEFHeader(header8,  false, 1);
-            ReadWriteProvidedCompressedImageTest.addCutoutFromCompressed(compressedImageHDU8, header8, fitsOutput,
-                    new int[]{1, 1}, new int[]{95, 104});
-
-            System.out.println("Starting read at HDU 9");
             final BasicHDU<?> hdu9 = fits.getHDU(9);
-            System.out.println("Starting read at HDU 9: OK");
             Assertions.assertInstanceOf(CompressedImageHDU.class, hdu9, "Incorrect type of HDU at index 9");
             final CompressedImageHDU compressedImageHDU9 = (CompressedImageHDU) hdu9;
+            expectedCutout9 = getCutoutBytes(compressedImageHDU9, corners9, lengths9);
             final Header header9 = ReadWriteProvidedCompressedImageTest.copyHeader(compressedImageHDU9.getHeader());
-            ReadWriteProvidedCompressedImageTest.adjustMEFHeader(header9,  true, 1);
+            ReadWriteProvidedCompressedImageTest.adjustMEFHeader(header9, false, 1);
             ReadWriteProvidedCompressedImageTest.addCutoutFromCompressed(compressedImageHDU9, header9, fitsOutput,
-                    new int[]{1115, 0}, new int[]{2112, 92});
+                    corners9, lengths9);
 
             fitsOutput.write(fitsOutputStream);
+        }
+
+        try {
+            assertWrittenCutoutMatches(tempFile, 0, expectedCutout9, lengths9);
+        } finally {
+            tempFile.delete();
         }
     }
 
     static void addCutoutFromCompressed(final CompressedImageHDU compressedImageHDU, final Header adjustedHeader,
-                                        final Fits fitsOutput, final int[] corners, final int[] lengths) {
+                                        final Fits fitsOutput, final int[] corners, final int[] lengths)
+            throws HeaderCardException {
+        ReadWriteProvidedCompressedImageTest.adjustCutoutHeader(adjustedHeader, lengths);
         final CompressedImageTiler compressedImageTiler = new CompressedImageTiler(compressedImageHDU);
-        final StreamingTileImageData streamingTileImageData8 = new StreamingTileImageData(adjustedHeader,
-                compressedImageTiler, corners, lengths, new int[]{1, 1});
-        fitsOutput.addHDU(new ImageHDU(adjustedHeader, streamingTileImageData8));
+        final StreamingTileImageData streamingTileImageData = new StreamingTileImageData(adjustedHeader,
+                compressedImageTiler, corners, lengths, new int[] {1, 1});
+        fitsOutput.addHDU(new ImageHDU(adjustedHeader, streamingTileImageData));
+    }
+
+    static void adjustCutoutHeader(final Header header, final int[] lengths) throws HeaderCardException {
+        if (header.containsKey(Compression.ZBITPIX.key())) {
+            header.setBitpix(header.getIntValue(Compression.ZBITPIX));
+        }
+        header.setNaxes(2);
+        // corners/lengths follow CompressedImageTiler image index order [NAXIS2, NAXIS1].
+        header.setNaxis(1, lengths[1]);
+        header.setNaxis(2, lengths[0]);
+        removeCompressedImageKeys(header);
+    }
+
+    private static byte[] getCutoutBytes(final CompressedImageHDU compressedImageHDU, final int[] corners,
+            final int[] lengths) throws FitsException, IOException {
+        final CompressedImageTiler tiler = new CompressedImageTiler(compressedImageHDU);
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (final ArrayDataOutput arrayDataOutput = new FitsOutputStream(byteArrayOutputStream)) {
+            tiler.getTile(arrayDataOutput, corners, lengths);
+            arrayDataOutput.flush();
+        }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    private static void assertWrittenCutoutMatches(final File outputFile, final int hduIndex, final byte[] expected,
+            final int[] lengths) throws Exception {
+        final int[] expectedAxes = new int[] {lengths[0], lengths[1]};
+        try (final Fits fits = new Fits(outputFile)) {
+            final ImageHDU imageHdu = (ImageHDU) fits.getHDU(hduIndex);
+            final Header header = imageHdu.getHeader();
+            Assertions.assertEquals(lengths[1], header.getIntValue(Standard.NAXISn.n(1)),
+                    "NAXIS1 at HDU " + hduIndex);
+            Assertions.assertEquals(lengths[0], header.getIntValue(Standard.NAXISn.n(2)),
+                    "NAXIS2 at HDU " + hduIndex);
+            Assertions.assertArrayEquals(expectedAxes, imageHdu.getAxes(),
+                    "cutout NAXIS dimensions at HDU " + hduIndex);
+            Assertions.assertArrayEquals(expectedAxes,
+                    ArrayFuncs.getDimensions(imageHdu.getData().getData()),
+                    "Java array dimensions at HDU " + hduIndex);
+            final short[][] data = (short[][]) imageHdu.getData().getData();
+            final ShortBuffer expectedPixels = java.nio.ByteBuffer.wrap(expected).asShortBuffer();
+            int index = 0;
+            for (int axis2 = 0; axis2 < lengths[0]; axis2++) {
+                for (int axis1 = 0; axis1 < lengths[1]; axis1++) {
+                    Assertions.assertEquals(expectedPixels.get(index), data[axis2][axis1],
+                            "pixel differed at cutout index " + index + " in HDU " + hduIndex);
+                    index++;
+                }
+            }
+        }
+    }
+
+    private static void removeCompressedImageKeys(final Header header) {
+        header.deleteKey(Compression.ZTABLE);
+        header.deleteKey(Compression.ZIMAGE);
+        header.deleteKey(Compression.ZCMPTYPE);
+        header.deleteKey(Compression.ZBITPIX);
+        header.deleteKey(Compression.ZNAXIS);
+        header.deleteKey(Compression.ZQUANTIZ);
+        header.deleteKey(Compression.ZMASKCMP);
+        header.deleteKey(Compression.ZSIMPLE);
+        header.deleteKey(Compression.ZTENSION);
+        header.deleteKey(Compression.ZEXTEND);
+        header.deleteKey(Compression.ZBLOCKED);
+        header.deleteKey(Compression.ZPCOUNT);
+        header.deleteKey(Compression.ZGCOUNT);
+        header.deleteKey(Compression.ZHECKSUM);
+        header.deleteKey(Compression.ZDATASUM);
+        header.deleteKey(Compression.ZDITHER0);
+        header.deleteKey(Compression.ZBLANK);
+        header.deleteKey(Compression.ZTHEAP);
+        header.deleteKey(Compression.ZTILELEN);
+        for (int n = 1; n <= 9; n++) {
+            header.deleteKey(Compression.ZNAXISn.n(n));
+            header.deleteKey(Compression.ZTILEn.n(n));
+            header.deleteKey(Compression.ZNAMEn.n(n));
+            header.deleteKey(Compression.ZVALn.n(n));
+            header.deleteKey(Compression.ZFORMn.n(n));
+            header.deleteKey(Compression.ZCTYPn.n(n));
+        }
     }
 
     static void adjustMEFHeader(final Header header, final boolean firstHDUAlreadyWritten,

--- a/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
+++ b/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
@@ -370,8 +370,8 @@ public class CompressedImageTilerTest {
             final Header header = imageHDU.getHeader();
             header.setSimple(true);
             header.setNaxes(2);
-            header.setNaxis(1, lengths[0]);
-            header.setNaxis(2, lengths[1]);
+            header.setNaxis(1, lengths[1]);
+            header.setNaxis(2, lengths[0]);
             header.findCard("CRPIX1").setValue(51.5D);
             header.findCard("CRPIX2").setValue(51.5D);
             header.deleteKey("CHECKSUM");

--- a/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
+++ b/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
@@ -79,6 +79,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -127,6 +128,7 @@ import nom.tam.fits.compression.algorithm.api.ICompressorControl;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressorOption;
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
+import nom.tam.fits.compression.provider.param.api.ICompressParameters;
 import nom.tam.fits.compression.provider.param.rice.RiceCompressParameters;
 import nom.tam.fits.header.Compression;
 import nom.tam.fits.header.Standard;
@@ -323,15 +325,264 @@ public class CompressedImageTilerTest {
 
             testSubject.initCompressionOption(option);
             Assertions.assertEquals(32, option.getBlockSize());
+            Assertions.assertEquals(RiceCompressOption.DEFAULT_RICE_BYTEPIX, option.getBytePix());
 
             testSubject.initCompressionOption(quantizeOption);
             Assertions.assertEquals(quantizeOption.getBScale(), Double.NaN, 0.0D);
             Assertions.assertEquals(quantizeOption.getBZero(), Double.NaN, 0.0D);
 
+            final AtomicBoolean headerParametersLoaded = new AtomicBoolean(false);
+            final RiceCompressOption trackingOption = new RiceCompressOption() {
+                @Override
+                public RiceCompressParameters getCompressionParameters() {
+                    return new RiceCompressParameters(this) {
+                        @Override
+                        public void getValuesFromHeader(final Header header) throws nom.tam.fits.HeaderCardException {
+                            headerParametersLoaded.set(true);
+                            super.getValuesFromHeader(header);
+                        }
+                    };
+                }
+            };
+            testSubject.initCompressionOption(trackingOption);
+            Assertions.assertTrue(headerParametersLoaded.get(), "getValuesFromHeader should load Rice parameters");
+
+            final ICompressOption noParametersOption = createOptionWithoutParameters();
+            testSubject.initCompressionOption(noParametersOption);
+            Assertions.assertEquals(cfitsioTable.getHeader().getIntValue(Compression.ZTILEn.n(2), 1),
+                    noParametersOption.getTileHeight());
+
             // Should be ignored.
             final HCompressorOption ignoredOption = new HCompressorOption();
             testSubject.initCompressionOption(ignoredOption);
             Assertions.assertEquals(1, ignoredOption.getTileHeight());
+        }
+    }
+
+    private static ICompressOption createOptionWithoutParameters() {
+        return new ICompressOption() {
+            private int tileHeight;
+            private int tileWidth;
+
+            @Override
+            public ICompressOption copy() {
+                return this;
+            }
+
+            @Override
+            public ICompressParameters getCompressionParameters() {
+                return null;
+            }
+
+            @Override
+            public boolean isLossyCompression() {
+                return false;
+            }
+
+            @Override
+            public void setParameters(final ICompressParameters parameters) {
+            }
+
+            @Override
+            public ICompressOption setTileHeight(final int value) {
+                tileHeight = value;
+                return this;
+            }
+
+            @Override
+            public ICompressOption setTileWidth(final int value) {
+                tileWidth = value;
+                return this;
+            }
+
+            @Override
+            public int getTileHeight() {
+                return tileHeight;
+            }
+
+            @Override
+            public int getTileWidth() {
+                return tileWidth;
+            }
+
+            @Override
+            public <T> T unwrap(final Class<T> clazz) {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void doTestInitIgnoresMissingColumnType() throws Exception {
+        final File sourceFile = new File("src/test/resources/nom/tam/image/provided/m13_rice.fits");
+        try (final Fits sourceFits = new Fits(sourceFile, true)) {
+            final CompressedImageHDU compressedImageHDU = (CompressedImageHDU) sourceFits.getHDU(1);
+            compressedImageHDU.getHeader().deleteKey(Standard.TTYPEn.n(1));
+            final CompressedImageTiler testSubject = new CompressedImageTiler(compressedImageHDU);
+            Assertions.assertNotNull(testSubject);
+        }
+    }
+
+    @Test
+    public void doTestIncrementPositionMultiDimensional() {
+        final int[] start = new int[] {0, 0, 0};
+        final int[] current = new int[] {0, 0, 0};
+        final int[] lengths = new int[] {2, 2, 2};
+        final int[] steps = new int[] {1, 1, 1};
+
+        Assertions.assertTrue(CompressedImageTiler.incrementPosition(start, current, lengths, steps));
+        Assertions.assertArrayEquals(new int[] {0, 1, 0}, current);
+
+        Assertions.assertTrue(CompressedImageTiler.incrementPosition(start, current, lengths, steps));
+        Assertions.assertArrayEquals(new int[] {1, 0, 0}, current);
+    }
+
+    @Test
+    public void doTestGetTileOffsetsForRowWiseTiling() {
+        final CompressedImageTiler testSubject = new CompressedImageTiler(null) {
+            @Override
+            void init() {
+            }
+
+            @Override
+            int getNumberOfDimensions() {
+                return 2;
+            }
+        };
+
+        final int[] offsets = testSubject.getTileOffsets(new int[] {1115, 523}, new int[] {1, 2112});
+        Assertions.assertEquals(0, offsets[0], "row-wise tile offset along axis 2");
+        Assertions.assertEquals(523, offsets[1]);
+    }
+
+    @Test
+    public void doTestGetTileRejectsNegativeLength() throws Exception {
+        final CompressedImageTiler testSubject = new CompressedImageTiler(null) {
+            @Override
+            void init() {
+            }
+
+            @Override
+            int[] getImageDimensions() {
+                return new int[] {100, 100};
+            }
+        };
+
+        try (final ArrayDataOutput output = new FitsOutputStream(new ByteArrayOutputStream())) {
+            Assertions.assertThrows(IOException.class,
+                    () -> testSubject.getTile(output, new int[] {0, 0}, new int[] {10, -1}, new int[] {1, 1}));
+        }
+    }
+
+    @Test
+    public void doTestGetTileOffsetsOnTileBoundary() {
+        final CompressedImageTiler testSubject = new CompressedImageTiler(null) {
+            @Override
+            void init() {
+            }
+
+            @Override
+            int getNumberOfDimensions() {
+                return 2;
+            }
+        };
+
+        Assertions.assertArrayEquals(new int[] {0, 0},
+                testSubject.getTileOffsets(new int[] {100, 200}, new int[] {100, 100}));
+    }
+
+    @Test
+    public void doTestGetTileSkipsInvalidSegment() throws Exception {
+        final CompressedImageTiler testSubject = new CompressedImageTiler(null) {
+            @Override
+            void init() {
+            }
+
+            @Override
+            int getZBitPix() {
+                return 16;
+            }
+
+            @Override
+            int[] getTileDimensions() {
+                return new int[] {10, 10};
+            }
+
+            @Override
+            int getNumberOfDimensions() {
+                return 2;
+            }
+
+            @Override
+            Object getDecompressedTileData(final int[] positions, final int[] tileDimensions) {
+                return new short[10][10];
+            }
+        };
+
+        final ByteArrayOutputStream outputByteStream = new ByteArrayOutputStream();
+        try (final ArrayDataOutput output = new FitsOutputStream(outputByteStream)) {
+            testSubject.getTile(output, new int[] {10, 10}, new int[] {0, 10}, new int[] {2, 2}, new int[] {1, 1});
+        }
+
+        Assertions.assertEquals(0, outputByteStream.size());
+    }
+
+    @Test
+    public void doTestGetTileAppliesStepOffsetAcrossTiles() throws Exception {
+        final CompressedImageTiler testSubject = new CompressedImageTiler(null) {
+            @Override
+            void init() {
+            }
+
+            @Override
+            int getZBitPix() {
+                return 16;
+            }
+
+            @Override
+            int[] getTileDimensions() {
+                return new int[] {10, 10};
+            }
+
+            @Override
+            int getNumberOfDimensions() {
+                return 2;
+            }
+
+            @Override
+            int[] getImageDimensions() {
+                return new int[] {100, 100};
+            }
+
+            @Override
+            Object getDecompressedTileData(final int[] positions, final int[] tileDimensions) {
+                return new short[10][10];
+            }
+        };
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+        try (final ArrayDataOutput arrayDataOutput = new FitsOutputStream(byteArrayOutputStream)) {
+            testSubject.getTile(arrayDataOutput, new int[] {0, 0}, new int[] {1, 13}, new int[] {1, 3});
+            arrayDataOutput.flush();
+        }
+
+        Assertions.assertEquals(5 * ElementType.SHORT.size(), byteArrayOutputStream.size());
+    }
+
+    @Test
+    public void doTestDecompressIntoBufferLoadsRiceParametersFromHeader() throws Exception {
+        final File sourceFile = new File("src/test/resources/nom/tam/image/provided/m13_rice.fits");
+        try (final Fits sourceFits = new Fits(sourceFile, true)) {
+            final CompressedImageHDU compressedImageHDU = (CompressedImageHDU) sourceFits.getHDU(1);
+            final CompressedImageTiler testSubject = new CompressedImageTiler(compressedImageHDU);
+            final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+            try (final ArrayDataOutput arrayDataOutput = new FitsOutputStream(byteArrayOutputStream)) {
+                testSubject.getTile(arrayDataOutput, new int[] {0, 0}, new int[] {5, 5});
+                arrayDataOutput.flush();
+            }
+
+            Assertions.assertEquals(5 * 5 * ElementType.SHORT.size(), byteArrayOutputStream.size());
         }
     }
 

--- a/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
+++ b/src/test/java/nom/tam/image/compression/CompressedImageTilerTest.java
@@ -321,16 +321,16 @@ public class CompressedImageTilerTest {
                 }
             };
 
-            testSubject.initCompressionOption(option, 8);
+            testSubject.initCompressionOption(option);
             Assertions.assertEquals(32, option.getBlockSize());
 
-            testSubject.initCompressionOption(quantizeOption, 8);
+            testSubject.initCompressionOption(quantizeOption);
             Assertions.assertEquals(quantizeOption.getBScale(), Double.NaN, 0.0D);
             Assertions.assertEquals(quantizeOption.getBZero(), Double.NaN, 0.0D);
 
             // Should be ignored.
             final HCompressorOption ignoredOption = new HCompressorOption();
-            testSubject.initCompressionOption(ignoredOption, 8);
+            testSubject.initCompressionOption(ignoredOption);
             Assertions.assertEquals(1, ignoredOption.getTileHeight());
         }
     }
@@ -627,6 +627,82 @@ public class CompressedImageTilerTest {
 
         // Start at 21, 21 and get offsets for tiles of size 5x5.
         Assertions.assertArrayEquals(new int[] {4, 4}, testSubject.getTileOffsets(new int[] {19, 4}, new int[] {5, 5}));
+    }
+
+    @Test
+    public void doTestGetTileIndexesAndRowNumber() throws Exception {
+        final CompressedImageTiler testSubject = new CompressedImageTiler(null) {
+            @Override
+            void init() {
+            }
+
+            @Override
+            int getNumberOfDimensions() {
+                return 2;
+            }
+
+            @Override
+            int[] getTableDimensions() {
+                return new int[] {5, 5};
+            }
+        };
+
+        // Image positions are [axis2, axis1]; tile dimensions are [ZTILE2, ZTILE1].
+        Assertions.assertArrayEquals(new int[] {2, 1},
+                testSubject.getTileIndexes(new int[] {150, 250}, new int[] {100, 100}));
+        Assertions.assertEquals(7, testSubject.getRowNumber(new int[] {2, 1}));
+
+        // Row-wise tiling (ZTILE2 = 1): table row tracks the image row (axis 2).
+        Assertions.assertArrayEquals(new int[] {0, 1115},
+                testSubject.getTileIndexes(new int[] {1115, 0}, new int[] {1, 2112}));
+
+        final CompressedImageTiler rowWiseTiler = new CompressedImageTiler(null) {
+            @Override
+            void init() {
+            }
+
+            @Override
+            int getNumberOfDimensions() {
+                return 2;
+            }
+
+            @Override
+            int[] getTableDimensions() {
+                return new int[] {1, 4644};
+            }
+        };
+        Assertions.assertEquals(1115, rowWiseTiler.getRowNumber(new int[] {0, 1115}));
+    }
+
+    @Test
+    public void doTestCutoutPixelValuesAsymmetricCorner() throws Exception {
+        final File sourceFile = new File("src/test/resources/nom/tam/image/provided/m13_rice.fits");
+
+        try (final Fits sourceFits = new Fits(sourceFile, true)) {
+            final CompressedImageHDU compressedImageHDU = (CompressedImageHDU) sourceFits.getHDU(1);
+            final short[][] full = (short[][]) compressedImageHDU.asImageHDU().getData().getData();
+            final CompressedImageTiler testSubject = new CompressedImageTiler(compressedImageHDU);
+
+            final int[] corners = new int[] {10, 15};
+            final int[] lengths = new int[] {5, 7};
+            final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+            try (final ArrayDataOutput arrayDataOutput = new FitsOutputStream(byteArrayOutputStream)) {
+                testSubject.getTile(arrayDataOutput, corners, lengths);
+                arrayDataOutput.flush();
+            }
+
+            final short[] cutout = new short[lengths[0] * lengths[1]];
+            java.nio.ByteBuffer.wrap(byteArrayOutputStream.toByteArray()).asShortBuffer().get(cutout);
+
+            int index = 0;
+            for (int axis0 = 0; axis0 < lengths[0]; axis0++) {
+                for (int axis1 = 0; axis1 < lengths[1]; axis1++) {
+                    Assertions.assertEquals(full[corners[0] + axis0][corners[1] + axis1], cutout[index++],
+                            "pixel differed at cutout index " + (index - 1));
+                }
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
# Description
Cutouts from compressed files often result in a `BufferUnderflowException`.  This is caused by expecting more bytes than is actually available.

# Changes
**CompressedImageTiler**
- Properly read headers in rather than try to adapt to specific algorithms during decompression (see `initCompressionOption` method).
- Remove reverse traversal from row read in favour of ZNAXIS reverse read

Added tests.