### PR TITLE
Fix corrupted pixels when a GZIP_1 tile spans several inflate chunks

### DIFF
--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressor.java
@@ -211,11 +211,6 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
             to.putArray(toBuffer, toArray);
             return byteCount * to.size() / from.size();
         }
-
-        /** The size in bytes of one element as stored in the compressed stream. */
-        int fromSize() {
-            return from.size();
-        }
     }
 
     private static final int DEFAULT_GZIP_BUFFER_SIZE = 65536;
@@ -263,26 +258,27 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
 
         // The size of one element as it appears in the compressed stream, which is the element size of the
         // pixel data unless the stream stores a narrower or wider type that needs converting.
-        int elementSize = typeConverter == null ? primitiveSize : typeConverter.fromSize();
+        int elementSize = typeConverter == null ? primitiveSize : typeConverter.from.size();
 
         try (GZIPInputStream zip = createGZipInputStream(compressed)) {
-            int pending = 0;
-            int count;
-            // GZIPInputStream.read() returns whatever the inflater has available, so a chunk may end in the
-            // middle of an element. Only whole elements can be handed on; the trailing bytes of a partial
-            // element are moved to the front of the buffer and completed by the next read.
-            while ((count = zip.read(buffer, pending, buffer.length - pending)) >= 0) {
-                int available = pending + count;
-                int whole = available - available % elementSize;
-                if (whole > 0) {
-                    int converted = typeConverter == null ? whole : typeConverter.copy(whole);
-                    nioBuffer.position(0);
-                    nioBuffer.limit(converted / primitiveSize);
-                    setPixel(pixelData, null);
-                }
-                pending = available - whole;
-                if (pending > 0) {
-                    System.arraycopy(buffer, whole, buffer, 0, pending);
+            int len = 0; // Number of bytes loaded into buffer
+            int nRead = 0; // Number of bytes read from input
+
+            while ((nRead = zip.read(buffer, len, buffer.length - len)) > 0) {
+                len += nRead;
+
+                // Convert only whole elements in buffer
+                int elementBytes = len - len % elementSize;
+                int converted = typeConverter == null ? elementBytes : typeConverter.copy(elementBytes);
+
+                nioBuffer.position(0);
+                nioBuffer.limit(converted / primitiveSize);
+                setPixel(pixelData, null);
+
+                len -= elementBytes; // unprocessed remainder bytes that were already loaded.
+                if (len > 0) {
+                    // Move unprocessed loaded remainder to front of the buffer
+                    System.arraycopy(buffer, elementBytes, buffer, 0, len);
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressor.java
@@ -211,6 +211,11 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
             to.putArray(toBuffer, toArray);
             return byteCount * to.size() / from.size();
         }
+
+        /** The size in bytes of one element as stored in the compressed stream. */
+        int fromSize() {
+            return from.size();
+        }
     }
 
     private static final int DEFAULT_GZIP_BUFFER_SIZE = 65536;
@@ -255,15 +260,30 @@ public abstract class GZipCompressor<T extends Buffer> implements ICompressor<T>
     public void decompress(ByteBuffer compressed, T pixelData) {
         nioBuffer.rewind();
         TypeConversion<Buffer> typeConverter = getTypeConverter(compressed, pixelData.limit());
+
+        // The size of one element as it appears in the compressed stream, which is the element size of the
+        // pixel data unless the stream stores a narrower or wider type that needs converting.
+        int elementSize = typeConverter == null ? primitiveSize : typeConverter.fromSize();
+
         try (GZIPInputStream zip = createGZipInputStream(compressed)) {
+            int pending = 0;
             int count;
-            while ((count = zip.read(buffer)) >= 0) {
-                if (typeConverter != null) {
-                    count = typeConverter.copy(count);
+            // GZIPInputStream.read() returns whatever the inflater has available, so a chunk may end in the
+            // middle of an element. Only whole elements can be handed on; the trailing bytes of a partial
+            // element are moved to the front of the buffer and completed by the next read.
+            while ((count = zip.read(buffer, pending, buffer.length - pending)) >= 0) {
+                int available = pending + count;
+                int whole = available - available % elementSize;
+                if (whole > 0) {
+                    int converted = typeConverter == null ? whole : typeConverter.copy(whole);
+                    nioBuffer.position(0);
+                    nioBuffer.limit(converted / primitiveSize);
+                    setPixel(pixelData, null);
                 }
-                nioBuffer.position(0);
-                nioBuffer.limit(count / primitiveSize);
-                setPixel(pixelData, null);
+                pending = available - whole;
+                if (pending > 0) {
+                    System.arraycopy(buffer, whole, buffer, 0, pending);
+                }
             }
         } catch (IOException e) {
             throw new IllegalStateException("could not gunzip data", e);

--- a/src/main/java/nom/tam/fits/compression/algorithm/gzip2/GZip2Compressor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/gzip2/GZip2Compressor.java
@@ -179,13 +179,9 @@ public abstract class GZip2Compressor<T extends Buffer> extends GZipCompressor<T
         int pixelDataLimit = pixelData.limit();
         byte[] pixelBytes = new byte[pixelDataLimit * primitiveSize];
         try (GZIPInputStream zip = createGZipInputStream(compressed)) {
-            int count = 0;
-            int offset = 0;
-            while (offset < pixelBytes.length && count >= 0) {
-                count = zip.read(pixelBytes, offset, pixelBytes.length - offset);
-                if (count >= 0) {
-                    offset = offset + count;
-                }
+            int len = 0, nRead = 0;
+            while ((nRead = zip.read(pixelBytes, len, pixelBytes.length - len)) > 0) {
+                len += nRead;
             }
         } catch (IOException e) {
             throw new IllegalStateException("could not gunzip data", e);

--- a/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
+++ b/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
@@ -966,6 +966,63 @@ public class ReadWriteProvidedCompressedImageTest {
         }
     }
 
+    /**
+     * Tiles that are stored losslessly in the GZIP_COMPRESSED_DATA column and whose uncompressed size exceeds the
+     * 64 kB internal buffer of the GZIP decompressor. cfitsio produces this layout on its own whenever quantization
+     * fails for a tile, which is how such files reach the reader in practice. The pixel values are noise, so that
+     * gzip barely compresses them and the inflater delivers the tile in chunks that do not align with the 4-byte
+     * pixel boundaries.
+     */
+    @Test
+    public void writeRiceFloatWithForceNoLossTileLargerThanGzipBuffer() throws Exception {
+        Random random = new Random(42);
+        float[][] noise = new float[300][300];
+        for (float[] row : noise) {
+            for (int x = 0; x < row.length; x++) {
+                row[x] = random.nextFloat() * 1000.0f;
+            }
+        }
+        ImageData imageData = ImageHDU.encapsulate(noise);
+        ImageHDU noiseHdu = new ImageHDU(ImageHDU.manufactureHeader(imageData), imageData);
+
+        try (Fits f = new Fits()) {
+            // 300 x 150 tiles are 180000 bytes uncompressed, well past the 65536-byte gzip buffer.
+            CompressedImageHDU compressedHdu = CompressedImageHDU.fromImageHDU(noiseHdu, 300, 150);
+            compressedHdu.setCompressAlgorithm(Compression.ZCMPTYPE_RICE_1)//
+                    .setQuantAlgorithm(Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_2)//
+                    .forceNoLoss(0, 0, 300, 300)//
+                    .getCompressOption(QuantizeOption.class)//
+                    /**/.setQlevel(1.0)//
+                    .getCompressOption(RiceCompressOption.class)//
+                    /**/.setBlockSize(32);
+            compressedHdu.compress();
+            f.addHDU(compressedHdu);
+
+            try (FitsOutputStream bdos = new FitsOutputStream(
+                    new FileOutputStream("target/write_noise_own_noloss_large_tile.fits.fz"))) {
+                f.write(bdos);
+            }
+        }
+
+        try (Fits f = new Fits("target/write_noise_own_noloss_large_tile.fits.fz")) {
+            f.readHDU();
+            CompressedImageHDU hdu = (CompressedImageHDU) f.readHDU();
+
+            int gzipColumn = hdu.findColumn(Compression.GZIP_COMPRESSED_DATA_COLUMN);
+            Assertions.assertTrue(gzipColumn >= 0, "expected a GZIP_COMPRESSED_DATA column");
+            for (int tile = 0; tile < hdu.getData().getNRows(); tile++) {
+                Assertions.assertTrue(((byte[]) hdu.getData().get(tile, gzipColumn)).length > 0,
+                        "tile " + tile + " should have been stored as gzipped floats");
+            }
+
+            // Losslessly stored tiles must be reconstructed exactly.
+            float[][] actual = (float[][]) hdu.asImageHDU().getData().getData();
+            for (int y = 0; y < noise.length; y++) {
+                Assertions.assertArrayEquals(noise[y], actual[y], 0.0f, "row " + y);
+            }
+        }
+    }
+
     @Test
     public void writeRiceDouble() throws Exception {
         double[][] m13_double_data = (double[][]) ArrayFuncs.convertArray(m13_data_real, double.class);

--- a/src/test/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/gzip/GZipCompressTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
@@ -42,6 +43,8 @@ import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
+import java.util.Random;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import org.junit.jupiter.api.Assertions;
@@ -437,5 +440,191 @@ public class GZipCompressTest {
         } finally {
             SafeClose.close(file);
         }
+    }
+
+    /**
+     * A chunk size that is not a multiple of 2, 4 or 8, so that every read but the last ends in the middle of a
+     * multi-byte element.
+     */
+    private static final int MISALIGNED_CHUNK_SIZE = 1023;
+
+    /**
+     * Enough elements that the decompressed data spans several internal buffers, as it does for the tiles of a real
+     * tile-compressed image.
+     */
+    private static final int LARGE_ELEMENT_COUNT = 30000;
+
+    /**
+     * Wraps a gzip stream so that no read returns more than {@link #MISALIGNED_CHUNK_SIZE} bytes.
+     * {@link GZIPInputStream} makes no promise about returning a whole number of elements, and does return awkward
+     * counts in practice once the data spans more than one internal buffer.
+     */
+    private static GZIPInputStream misalignedChunks(ByteBuffer compressed) throws IOException {
+        return new GZIPInputStream(new ByteBufferInputStream(compressed), 65536) {
+
+            @Override
+            public int read(byte[] b, int off, int len) throws IOException {
+                return super.read(b, off, Math.min(len, MISALIGNED_CHUNK_SIZE));
+            }
+        };
+    }
+
+    private static <T extends Buffer> ByteBuffer gzip(GZipCompressor<T> compressor, T data, int rawByteCount) {
+        ByteBuffer compressed = ByteBuffer.wrap(new byte[rawByteCount + 1024]);
+        compressor.compress(data, compressed);
+        compressed.rewind();
+        return compressed;
+    }
+
+    @Test
+    public void testGzipDecompressMisalignedChunksByte() throws Exception {
+        byte[] expected = new byte[LARGE_ELEMENT_COUNT];
+        new Random(42).nextBytes(expected);
+
+        ByteBuffer compressed = gzip(new ByteGZipCompressor(), ByteBuffer.wrap(expected), expected.length);
+
+        byte[] actual = new byte[expected.length];
+        new ByteGZipCompressor() {
+
+            @Override
+            protected GZIPInputStream createGZipInputStream(ByteBuffer c) throws IOException {
+                return misalignedChunks(c);
+            }
+        }.decompress(compressed, ByteBuffer.wrap(actual));
+
+        Assertions.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testGzipDecompressMisalignedChunksShort() throws Exception {
+        Random random = new Random(42);
+        short[] expected = new short[LARGE_ELEMENT_COUNT];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = (short) random.nextInt();
+        }
+
+        ByteBuffer compressed = gzip(new ShortGZipCompressor(), ShortBuffer.wrap(expected), expected.length * 2);
+
+        short[] actual = new short[expected.length];
+        new ShortGZipCompressor() {
+
+            @Override
+            protected GZIPInputStream createGZipInputStream(ByteBuffer c) throws IOException {
+                return misalignedChunks(c);
+            }
+        }.decompress(compressed, ShortBuffer.wrap(actual));
+
+        Assertions.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testGzipDecompressMisalignedChunksInt() throws Exception {
+        Random random = new Random(42);
+        int[] expected = new int[LARGE_ELEMENT_COUNT];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = random.nextInt();
+        }
+
+        ByteBuffer compressed = gzip(new IntGZipCompressor(), IntBuffer.wrap(expected), expected.length * 4);
+
+        int[] actual = new int[expected.length];
+        new IntGZipCompressor() {
+
+            @Override
+            protected GZIPInputStream createGZipInputStream(ByteBuffer c) throws IOException {
+                return misalignedChunks(c);
+            }
+        }.decompress(compressed, IntBuffer.wrap(actual));
+
+        Assertions.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testGzipDecompressMisalignedChunksLong() throws Exception {
+        Random random = new Random(42);
+        long[] expected = new long[LARGE_ELEMENT_COUNT];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = random.nextLong();
+        }
+
+        ByteBuffer compressed = gzip(new LongGZipCompressor(), LongBuffer.wrap(expected), expected.length * 8);
+
+        long[] actual = new long[expected.length];
+        new LongGZipCompressor() {
+
+            @Override
+            protected GZIPInputStream createGZipInputStream(ByteBuffer c) throws IOException {
+                return misalignedChunks(c);
+            }
+        }.decompress(compressed, LongBuffer.wrap(actual));
+
+        Assertions.assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testGzipDecompressMisalignedChunksFloat() throws Exception {
+        Random random = new Random(42);
+        float[] expected = new float[LARGE_ELEMENT_COUNT];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = Float.intBitsToFloat(random.nextInt());
+        }
+
+        ByteBuffer compressed = gzip(new FloatGZipCompressor(), FloatBuffer.wrap(expected), expected.length * 4);
+
+        float[] actual = new float[expected.length];
+        new FloatGZipCompressor() {
+
+            @Override
+            protected GZIPInputStream createGZipInputStream(ByteBuffer c) throws IOException {
+                return misalignedChunks(c);
+            }
+        }.decompress(compressed, FloatBuffer.wrap(actual));
+
+        // Compared as bits, since the random patterns include NaNs.
+        for (int i = 0; i < expected.length; i++) {
+            Assertions.assertEquals(Float.floatToRawIntBits(expected[i]), Float.floatToRawIntBits(actual[i]),
+                    "pixel " + i);
+        }
+    }
+
+    @Test
+    public void testGzipDecompressMisalignedChunksDouble() throws Exception {
+        Random random = new Random(42);
+        double[] expected = new double[LARGE_ELEMENT_COUNT];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = Double.longBitsToDouble(random.nextLong());
+        }
+
+        ByteBuffer compressed = gzip(new DoubleGZipCompressor(), DoubleBuffer.wrap(expected), expected.length * 8);
+
+        double[] actual = new double[expected.length];
+        new DoubleGZipCompressor() {
+
+            @Override
+            protected GZIPInputStream createGZipInputStream(ByteBuffer c) throws IOException {
+                return misalignedChunks(c);
+            }
+        }.decompress(compressed, DoubleBuffer.wrap(actual));
+
+        for (int i = 0; i < expected.length; i++) {
+            Assertions.assertEquals(Double.doubleToRawLongBits(expected[i]), Double.doubleToRawLongBits(actual[i]),
+                    "pixel " + i);
+        }
+    }
+
+    @Test
+    public void testGzipRoundTripLargerThanInternalBuffer() throws Exception {
+        Random random = new Random(1234);
+        float[] expected = new float[LARGE_ELEMENT_COUNT];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = random.nextFloat() * 1000.0f;
+        }
+
+        ByteBuffer compressed = gzip(new FloatGZipCompressor(), FloatBuffer.wrap(expected), expected.length * 4);
+
+        float[] actual = new float[expected.length];
+        new FloatGZipCompressor().decompress(compressed, FloatBuffer.wrap(actual));
+
+        Assertions.assertArrayEquals(expected, actual, 0.0f);
     }
 }


### PR DESCRIPTION
When reading some of the new LSST Data Preview 2 data we noticed:


<img width="599" height="268" alt="Screen Shot to Yoink2026-08-05 at 3 29 48 PM" src="https://github.com/user-attachments/assets/2104e021-3a4f-4924-8fea-d2b8e109c5c9" />

There are weird 150 x ~30 pixel tiles with +/- 1E38 pixels. Our tile sizes are 150 x 150 pixels. The problem is with the tiles that Astropy decides can't be RICE_1 compressed and falls back to using GZIP_1 compression instead. GZIP_2 decompression is fine.

I asked Claude to look at a fix. It definitely seems to fix the problem. Your choice as to whether you want to use the code. Claude also reported the following analysis.

# Fix corrupted pixels when a GZIP_1 tile spans more than one inflate chunk

## Summary

`GZipCompressor.decompress()` assumed that every `GZIPInputStream.read()` returns a whole number
of primitive elements. It does not. Once a tile's decompressed size exceeds the 64 kB internal
buffer, the reads do end in the middle of an element, and the trailing bytes were silently
discarded — so every element after the first chunk was assembled from misaligned bytes.

For a float image this produces values of order 1e38, which destroys the image scaling for any
client that computes a min/max. This was found because the Firefly display tool renders LSST
coadd images unreadably, while astropy and SAOImageDS9 read the same files correctly.

The bug has been present since the original GZIP implementation (1.14.0, 2015).

## The bug

```java
while ((count = zip.read(buffer)) >= 0) {
    if (typeConverter != null) {
        count = typeConverter.copy(count);
    }
    nioBuffer.position(0);
    nioBuffer.limit(count / primitiveSize);   // <-- count % primitiveSize bytes are dropped
    setPixel(pixelData, null);
}
```

`GZIPInputStream.read()` returns whatever the inflater currently has available, which is not
constrained to a multiple of the element size. `count / primitiveSize` truncates, the remaining
`count % primitiveSize` bytes are dropped, and the next iteration restarts at `buffer[0]`. Every
element after the first chunk is therefore built from bytes shifted by however much was dropped,
and the tile's last element is never written at all.

A concrete example, from a 150x150 float tile (90000 bytes) in one of the affected files. The
three reads return 65536, 4919 and 19545 bytes; the second and third are not multiples of 4, so
4 bytes are dropped in total and 22499 of 22500 pixels are written:

| tile row | read sizes | 65536/4 + (2nd read)/4 | first corrupted pixel |
|---:|---|---:|---:|
| 208 | 65536, 4919, 19545 | 16384 + 1229 = 17613 | 17613 |
| 211 | 65536, 10007, 14457 | 16384 + 2501 = 18885 | 18885 |
| 232 | 65536, 8351, 16113 | 16384 + 2087 = 18471 | 18471 |
| 233 | 65536, 15377, 9087 | 16384 + 3844 = 20228 | 20228 |
| 234 | 65536, 9747, 14717 | 16384 + 2436 = 18820 | 18820 |

Each tile's first 16384 pixels are correct and each goes wrong exactly at its own chunk boundary,
confirming the fault is internal to a single tile's stream. Tiles are decoded with independent
`GZipCompressor` instances (`CompressorProvider.TileCompressorControl.decompress()` calls
`newCompressor(option).decompress(in, out)`), so nothing leaks between tiles.

## Which data is affected

Three conditions must hold together:

1. The tile is decoded by GZIP_1. That happens either when `ZCMPTYPE = 'GZIP_1'`, or for any
   individual tile that took the lossless fallback — `getGzipCompressorControl()` hardcodes
   `ZCMPTYPE_GZIP_1` regardless of the primary algorithm.
2. The tile's uncompressed size exceeds `DEFAULT_GZIP_BUFFER_SIZE` (65536 bytes), i.e. more than
   16384 pixels for a 4-byte type.
3. The tile's *compressed* size also exceeds 65536 bytes, so the inflater needs more than one
   input fill and returns a short middle chunk. Highly compressible tiles are delivered in
   aligned chunks and escape unharmed.

`ZCMPTYPE = 'GZIP_2'` is unaffected: `GZip2Compressor.decompress()` accumulates into a full-size
byte array with offset tracking and was always correct.

Condition 1 is easy to hit in practice without any GZIP keyword appearing in the header. cfitsio
(and astropy, which reimplements it) stores an individual tile losslessly whenever quantization
fails for that tile — `fits_quantize_float` returning `status == 0`, surfaced in astropy as
`QuantizationFailedException`, after which the tile is compressed with GZIP_1 and its
`COMPRESSED_DATA` entry is left empty. So a header saying `ZCMPTYPE = 'RICE_1'` can still contain
GZIP_1 tiles.

The LSST/Rubin coadd files that exposed this are `RICE_1` + `SUBTRACTIVE_DITHER_2` with 150x150
float32 tiles (90000 bytes uncompressed). Quantization failed for a minority of tiles for all
three of the usual reasons — constant tiles, tiles containing non-finite values, and tiles whose
required number of quantization levels exceeds int32:

| HDU | fallback tiles | corrupted before this fix | corrupted pixels |
|---|---:|---:|---:|
| IMAGE | 5 of 484 | 5 | 18483 |
| VARIANCE | 222 of 484 | 79 | 205784 |
| NOISE_REALIZATIONS/0 | 116 of 484 | 0 | 0 |
| MASK (GZIP_2) | n/a | 0 | 0 |

Whole-image statistics for the IMAGE HDU of that file, before and after:

| reader | min | max | mean | stddev | NaN |
|---|---|---|---|---|---|
| astropy 8.0.1 | -1675.0472 | 94325.719 | 268.23214 | 1421.4871 | 0 |
| nom-tam-fits, before | -2.6238775e+38 | 2.6136446e+38 | -2.0194821e+32 | 7.5617686e+35 | 36 |
| nom-tam-fits, after | -1675.0472 | 94325.719 | 268.23214 | 1421.4871 | 0 |

Worth noting for anyone assessing impact: a second file from the same dataset, whose IMAGE HDU
contains no fallback tiles and therefore read correctly, still had one corrupted tile (3076
pixels) in its VARIANCE HDU. Because the corruption is per tile and the affected planes are often
not the displayed one, it can be present without being visible.

## The fix

Carry the bytes of a partial element over to the next read instead of discarding them:

```java
int elementSize = typeConverter == null ? primitiveSize : typeConverter.fromSize();

try (GZIPInputStream zip = createGZipInputStream(compressed)) {
    int pending = 0;
    int count;
    while ((count = zip.read(buffer, pending, buffer.length - pending)) >= 0) {
        int available = pending + count;
        int whole = available - available % elementSize;
        if (whole > 0) {
            int converted = typeConverter == null ? whole : typeConverter.copy(whole);
            nioBuffer.position(0);
            nioBuffer.limit(converted / primitiveSize);
            setPixel(pixelData, null);
        }
        pending = available - whole;
        if (pending > 0) {
            System.arraycopy(buffer, whole, buffer, 0, pending);
        }
    }
}
```

Alignment is on the element size *of the compressed stream*, which is `primitiveSize` unless a
`TypeConversion` is active — hence the new `TypeConversion.fromSize()`. Reading into
`buffer[pending..]` keeps the amount handed to `setPixel()` within `nioBuffer`'s capacity, so the
existing conversion arithmetic is untouched.

## Tests

`GZipCompressTest` gains seven tests. Six wrap the gzip stream so that no read returns more than
1023 bytes — not a multiple of 2, 4 or 8 — covering byte, short, int, float, long and double; the
seventh is a plain round trip larger than the internal buffer. Before the fix six of the seven
fail; the byte case correctly passes, since single-byte elements cannot misalign.

`ReadWriteProvidedCompressedImageTest.writeRiceFloatWithForceNoLossTileLargerThanGzipBuffer`
covers the path end to end: a 300x300 float image compressed with `RICE_1` and
`SUBTRACTIVE_DITHER_2` in 300x150 tiles (180000 bytes each), with `forceNoLoss` over the whole
image so both tiles take the GZIP fallback, written out and read back with exact-equality
assertions. Before the fix it fails with `expected: <311.27942> but was: <-2.7092922E-22>`.

Two notes on why that test is built the way it is, since both are easy to get wrong:

- The pixel values are noise, which gzip compresses only about 1.11:1. That ratio is what makes
  the inflater deliver the tile in chunks of 65536, 7449, 65536, 7509, 33970 — the misaligned
  pattern seen in the real files. Written first against the existing `m13real` test image, the
  test passed even without the fix: that data compresses roughly 2:1, so the chunks land at
  65536, 65536, 48928, all multiples of 4.
- The existing `writeRiceFloatWithForceNoLoss` test does exercise the GZIP fallback, but with
  300x15 tiles of 18000 bytes, comfortably inside the 65536-byte buffer. That is why the path was
  covered yet the bug was not caught.

Full suite: 1854 tests, 0 failures, 8 skipped (unchanged).

## Verification against real data

With the fix, both LSST files read identically to astropy 8.0.1 for every float image HDU, and the
five formerly corrupt tiles decode bit-for-bit identically to a plain `GZIPInputStream` gunzip of
the same `GZIP_COMPRESSED_DATA` blob.

One unrelated difference remains and is not addressed here: in the *quantized* tiles the two
readers disagree on many pixels by at most 0.004 absolute, against ZSCALE quantization steps of
0.24 to 6.6 — around 0.1% of one quantization level. This appears equally in files with no GZIP
tiles at all and looks like ordinary rounding in the dequantization arithmetic.