### PR TITLE
TableHDU.getColumnMeta() for non-string descriptors and standard keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,20 @@ Upcoming bug fix release, likely around 15 September 2026.
 
  - [#879] Fixed GZIP HDU decompression so it properly handles unprocessed remainder data in the internal buffer between successive reads. (by @timj and @attipaci).
 
+
+### Added
+
+ - [883] Added `TableHDU.getColumnMeta(int, IFitsHeader)` to support standard keyword enums beside the existing string keyword form. (by @attipaci)
+
 ### Changed
 
  - [#879] Simplified GZIP2 decompression code. (by @attipaci)
+ 
+ - [#882] `TableHDU.getColumnMeta()` changed to work with non-string values also, returning the string representation of the header value for all header value types. Also the method now throws an `IndexOutOfBoundsException` whenever the supplied zero-based column index is negative to exceeds the maximum value given the number of columns in the table. (by @attipaci)
+ 
+ - [#883] `IFitsHeader.n()` changed to throw the more specific `HeaderCardException` instead of the original `IllegalStateException` when the resulting indexed keyword is too long to be a standard FITS keyword. The change is backward compatible. The same applies downstream, e.g. for `TableHDU.setColumnMeta()` / `.getColumnMeta()`. (by @attipaci)
+ 
+ - [#883] `TableHDU.getColumnName()` no longer trims the string value stored in by the `TTYPEn` keyword, in line with the leading spaces being significant in the FITS standard. The caller may trim the result as necessary when it's not `null`. (by @attipaci)
 
  - The latest build and runtime Maven dependencies. (by @attipaci)
  

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -1,7 +1,10 @@
 package nom.tam.fits;
 
+import java.util.NoSuchElementException;
+
 import nom.tam.fits.header.GenericKey;
 import nom.tam.fits.header.IFitsHeader;
+import nom.tam.fits.header.Standard;
 
 import static nom.tam.fits.header.Standard.NAXISn;
 import static nom.tam.fits.header.Standard.TFIELDS;
@@ -343,51 +346,99 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
     /**
      * Get the FITS type of a column in the table.
      *
-     * @param  index         The 0-based index of the column.
+     * @param  index0        The 0-based index of the column.
      *
      * @return               The FITS type.
      *
-     * @throws FitsException if an invalid index was requested.
+     * @throws FitsException if the index is less than 0 or greater than or equals to the number of columns in the
+     *                           table.
      */
-    public String getColumnFormat(int index) throws FitsException {
-        int flds = myHeader.getIntValue(TFIELDS, 0);
-        if (index < 0 || index >= flds) {
-            throw new FitsException("Bad column index " + index + " (only " + flds + " columns)");
+    public String getColumnFormat(int index0) throws FitsException {
+        if (index0 < 0 || index0 >= getNCols()) {
+            throw new FitsException("Bad column index " + index0 + " (only " + getNCols() + " columns)");
         }
 
-        return myHeader.getStringValue(TFORMn.n(index + 1)).trim();
+        return myHeader.getStringValue(TFORMn.n(index0 + 1)).trim();
     }
 
     /**
-     * Convenience method for getting column data. Note that this works only for metadata that returns a string value.
-     * This is equivalent to getStringValue(type+index);
+     * Convenience method for getting column metadata, as a string. Note, that the return value is always a string even
+     * if the underlying metadata is some other type in the FITS header. For accessing column descriptions specified via
+     * standard FITS keywords, you should prefer using `{@link #getColumnMeta(int, IFitsHeader)}. And, to get metadata
+     * of known other types (e.g. integers), you may use one of the type-specific getter methods of {@link Header}, such
+     * as <code>getHeader().getIntValue(...)</code>.
      *
-     * @return       meta data string value
+     * @param  index0                    zero-based index index of the colum
+     * @param  keyBase                   the base header keyword of the descriptor, without the column index, e.g.
+     *                                       `"TTYPE"`.
      *
-     * @param  index index of the colum
-     * @param  type  the key type to get
+     * @return                           column meta data as a string, or <code>null</code> if there is no such metadata
+     *                                       in the header.
+     * 
+     * @throws IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of columns
+     *                                       in the table.
+     *
+     * @see                              #getColumnMeta(int, IFitsHeader)
+     * @see                              #getHeader()
      */
-    public String getColumnMeta(int index, String type) {
-        return myHeader.getStringValue(type + (index + 1));
+    public String getColumnMeta(int index0, String keyBase) throws IndexOutOfBoundsException {
+        if (index0 < 0 || index0 >= getNCols()) {
+            throw new IndexOutOfBoundsException("Zero-based column index " + index0 + " is out of range");
+        }
+
+        HeaderCard c = myHeader.getCard(keyBase + (index0 + 1));
+        return c == null ? null : c.getValue();
+    }
+
+    /**
+     * Convenience method for getting column metadata, as a string. Note, that the return value is always a string even
+     * if the underlying metadata is some other type@throws IndexOutOfBoundsException if the index is less than 0 or
+     * greater than or equals to the number of columns in the table. in the FITS header. To get metadata of known other
+     * types (e.g. integers), you may use one of the type-specific getter methods of {@link Header}, such as
+     * <code>getHeader().getIntValue(...)</code>.
+     * 
+     * @param  index0                    zero-based index index of the colum
+     * @param  keyBase                   the standard FITS key to get, without the column indexing, e.g.
+     *                                       `Standard.TTYPEn`.
+     * 
+     * @return                           column meta data as a string, or <code>null</code> if there is no such metadata
+     *                                       in the header.
+     * 
+     * @throws IndexOutOfBoundsException if the index is less than 0, or greater than or equals to the number of columns
+     *                                       in the table.
+     * @throws HeaderCardException       if the resulting indexed keyword exceeds the maximum 8-bytes allowed for
+     *                                       standard FITS keywords.
+     * @throws NoSuchElementException    If more indices were supplied than can be filled for this keyword.
+     * 
+     * @since                            1.22.3
+     * 
+     * @see                              #getHeader()
+     */
+    public String getColumnMeta(int index0, IFitsHeader keyBase)
+            throws IndexOutOfBoundsException, HeaderCardException, NoSuchElementException {
+        if (index0 < 0 || index0 >= getNCols()) {
+            throw new IndexOutOfBoundsException("Zero-based column index " + index0 + " is out of range");
+        }
+
+        HeaderCard c = myHeader.getCard(keyBase.n(index0 + 1));
+        return c == null ? null : c.getValue();
     }
 
     /**
      * Gets the name of a column in the table, as it appears in this HDU's header. It may differ from a more currently
      * assigned name of the binary table data column after the HDU creation or reading.
      *
-     * @param  index The 0-based column index.
+     * @param  index0                    The 0-based column index.
      *
-     * @return       The column name.
+     * @return                           The column name, or <code>null</code> if it was undefined.
+     *
+     * @throws IndexOutOfBoundsException if the index is less than 0, or greater than or equals to the number of columns
+     *                                       in the table.
      * 
-     * @see          BinaryTable.ColumnDesc#name()
+     * @see                              BinaryTable.ColumnDesc#name()
      */
-    public String getColumnName(int index) {
-
-        String ttype = myHeader.getStringValue(TTYPEn.n(index + 1));
-        if (ttype != null) {
-            ttype = ttype.trim();
-        }
-        return ttype;
+    public String getColumnName(int index0) throws IndexOutOfBoundsException {
+        return getColumnMeta(index0, Standard.TTYPEn);
     }
 
     /**
@@ -502,193 +553,236 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
      * Specify column metadata for a given column in a way that allows all of the column metadata for a given column to
      * be organized together.
      *
-     * @param  index               The 0-based index of the column
-     * @param  key                 The column key. I.e., the keyword will be key+(index+1)
-     * @param  value               The value to be placed in the header.
-     * @param  comment             The comment for the header
-     * @param  after               Should the header card be after the current column metadata block
-     *                                 (<code>true</code>), or immediately before the TFORM card (<code>false</code>).
+     * @param  index0                    The 0-based index of the column
+     * @param  key                       The column key. I.e., the keyword will be key+(index+1)
+     * @param  value                     The value to be placed in the header.
+     * @param  comment                   The comment for the header
+     * @param  after                     Should the header card be after the current column metadata block
+     *                                       (<code>true</code>), or immediately before the TFORM card
+     *                                       (<code>false</code>).
      *
-     * @throws HeaderCardException if the header could not be updated
+     * @throws HeaderCardException       if the header could not be updated, or if the indexed FITS keyword is too long
+     *                                       (exceeds the maximum 8 bytes allowed by the FITS standard).
+     * @throws IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of columns
+     *                                       in t@throws IndexOutOfBoundsException if the index is less than 0 or
+     *                                       greater than or equals to the number of columns in the table.
      */
-    public void setColumnMeta(int index, IFitsHeader key, String value, String comment, boolean after)
-            throws HeaderCardException {
-        setCurrentColumn(index, after);
-        myHeader.addLine(new HeaderCard(key.n(index + 1).key(), value, comment));
+    public void setColumnMeta(int index0, IFitsHeader key, String value, String comment, boolean after)
+            throws IndexOutOfBoundsException, HeaderCardException {
+        setCurrentColumn(index0, after);
+        myHeader.addLine(new HeaderCard(key.n(index0 + 1).key(), value, comment));
     }
 
     /**
      * Specify column metadata for a given column in a way that allows all of the column metadata for a given column to
      * be organized together.
      *
-     * @param  index               The 0-based index of the column
-     * @param  key                 The column key. I.e., the keyword will be key+(index+1)
-     * @param  value               The value to be placed in the header.
-     * @param  comment             The comment for the header
-     * @param  after               Should the header card be after the current column metadata block
-     *                                 (<code>true</code>), or immediately before the TFORM card (<code>false</code>).
+     * @param  index0                    The 0-based index of the column
+     * @param  key                       The column key. I.e., the keyword will be key+(index+1)
+     * @param  value                     The value to be placed in the header.
+     * @param  comment                   The comment for the header
+     * @param  after                     Should the header card be after the current column metadata block
+     *                                       (<code>true</code>), or immediately before the TFORM card
+     *                                       (<code>false</code>).
      *
-     * @throws HeaderCardException if the header could not be updated
+     * @throws HeaderCardException       if the header could not be updated, or if the indexed FITS keyword is too long
+     *                                       (exceeds the maximum 8 bytes allowed by the FITS standard).
+     * @throws IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of columns
+     *                                       in t@throws IndexOutOfBoundsException if the index is less than 0 or
+     *                                       greater than or equals to the number of columns in the table.
      *
-     * @since                      1.16
+     * @since                            1.16
      */
-    public void setColumnMeta(int index, IFitsHeader key, Number value, String comment, boolean after)
-            throws HeaderCardException {
-        setCurrentColumn(index, after);
-        myHeader.addLine(new HeaderCard(key.n(index + 1).key(), value, comment));
+    public void setColumnMeta(int index0, IFitsHeader key, Number value, String comment, boolean after)
+            throws IndexOutOfBoundsException, HeaderCardException {
+        setCurrentColumn(index0, after);
+        myHeader.addLine(new HeaderCard(key.n(index0 + 1).key(), value, comment));
     }
 
     /**
      * Specify column metadata for a given column in a way that allows all of the column metadata for a given column to
      * be organized together.
      *
-     * @param  index               The 0-based index of the column
-     * @param  key                 The column key. I.e., the keyword will be key+(index+1)
-     * @param  value               The value to be placed in the header.
-     * @param  comment             The comment for the header
-     * @param  after               Should the header card be after the current column metadata block
-     *                                 (<code>true</code>), or immediately before the TFORM card (<code>false</code>).
+     * @param  index0                    The 0-based index of the column
+     * @param  key                       The column key. I.e., the keyword will be key+(index+1)
+     * @param  value                     The value to be placed in the header.
+     * @param  comment                   The comment for the header
+     * @param  after                     Should the header card be after the current column metadata block
+     *                                       (<code>true</code>), or immediately before the TFORM card
+     *                                       (<code>false</code>).
      *
-     * @throws HeaderCardException if the header could not be updated
+     * @throws HeaderCardException       if the header could not be updated, or if the indexed FITS keyword is too long
+     *                                       (exceeds the maximum 8 bytes allowed by the FITS standard).
+     * @throws IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of columns
+     *                                       in t@throws IndexOutOfBoundsException if the index is less than 0 or
+     *                                       greater than or equals to the number of columns in the table.
      */
-    public void setColumnMeta(int index, String key, Boolean value, String comment, boolean after)
-            throws HeaderCardException {
-        setCurrentColumn(index, after);
-        myHeader.addLine(new HeaderCard(key + (index + 1), value, comment));
+    public void setColumnMeta(int index0, String key, Boolean value, String comment, boolean after)
+            throws IndexOutOfBoundsException, HeaderCardException {
+        setCurrentColumn(index0, after);
+        myHeader.addLine(new HeaderCard(key + (index0 + 1), value, comment));
     }
 
     /**
      * Specify column metadata for a given column in a way that allows all of the column metadata for a given column to
      * be organized together.
      *
-     * @param  index               The 0-based index of the column
-     * @param  key                 The column key. I.e., the keyword will be key+(index+1)
-     * @param  value               The value to be placed in the header.
-     * @param  comment             The comment for the header
-     * @param  after               Should the header card be after the current column metadata block
-     *                                 (<code>true</code>), or immediately before the TFORM card (<code>false</code>).
+     * @param  index0                    The 0-based index of the column
+     * @param  key                       The column key. I.e., the keyword will be key+(index+1)
+     * @param  value                     The value to be placed in the header.
+     * @param  comment                   The comment for the header
+     * @param  after                     Should the header card be after the current column metadata block
+     *                                       (<code>true</code>), or immediately before the TFORM card
+     *                                       (<code>false</code>).
      *
-     * @throws HeaderCardException if the header could not be updated
+     * @throws HeaderCardException       if the header could not be updated, or if the indexed FITS keyword is too long
+     *                                       (exceeds the maximum 8 bytes allowed by the FITS standard).
+     * @throws IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of columns
+     *                                       in t@throws IndexOutOfBoundsException if the index is less than 0 or
+     *                                       greater than or equals to the number of columns in the table.
      */
-    public void setColumnMeta(int index, String key, Number value, String comment, boolean after)
-            throws HeaderCardException {
-        setCurrentColumn(index, after);
-        myHeader.addLine(new HeaderCard(key + (index + 1), value, comment));
+    public void setColumnMeta(int index0, String key, Number value, String comment, boolean after)
+            throws IndexOutOfBoundsException, HeaderCardException {
+        setCurrentColumn(index0, after);
+        myHeader.addLine(new HeaderCard(key + (index0 + 1), value, comment));
     }
 
     /**
      * Specify column metadata for a given column in a way that allows all of the column metadata for a given column to
      * be organized together.
      *
-     * @param  index               The 0-based index of the column
-     * @param  key                 The column key. I.e., the keyword will be key+(index+1)
-     * @param  value               The value to be placed in the header.
-     * @param  precision           The maximum number of decimal places to show after the leading figure. (Trailing
-     *                                 zeroes will be ommitted.)
-     * @param  comment             The comment for the header
-     * @param  after               Should the header card be after the current column metadata block
-     *                                 (<code>true</code>), or immediately before the TFORM card (<code>false</code>).
+     * @param  index0                    The 0-based index of the column
+     * @param  key                       The column key. I.e., the keyword will be key+(index+1)
+     * @param  value                     The value to be placed in the header.
+     * @param  precision                 The maximum number of decimal places to show after the leading figure.
+     *                                       (Trailing zeroes will be ommitted.)
+     * @param  comment                   The comment for the header
+     * @param  after                     Should the header card be after the current column metadata block
+     *                                       (<code>true</code>), or immediately before the TFORM card
+     *                                       (<code>false</code>).
      *
-     * @throws HeaderCardException if the header could not be updated
+     * @throws HeaderCardException       if the header could not be updated, or if the indexed FITS keyword is too long
+     *                                       (exceeds the maximum 8 bytes allowed by the FITS standard).
+     * @throws IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of columns
+     *                                       in t@throws IndexOutOfBoundsException if the index is less than 0 or
+     *                                       greater than or equals to the number of columns in the table.
      */
-    public void setColumnMeta(int index, String key, Number value, int precision, String comment, boolean after)
-            throws HeaderCardException {
-        setCurrentColumn(index, after);
-        myHeader.addLine(new HeaderCard(key + (index + 1), value, precision, comment));
+    public void setColumnMeta(int index0, String key, Number value, int precision, String comment, boolean after)
+            throws IndexOutOfBoundsException, HeaderCardException {
+        setCurrentColumn(index0, after);
+        myHeader.addLine(new HeaderCard(key + (index0 + 1), value, precision, comment));
     }
 
     /**
      * Specify column metadata for a given column in a way that allows all of the column metadata for a given column to
      * be organized together.
      *
-     * @param  index               The 0-based index of the column
-     * @param  key                 The column key. I.e., the keyword will be key+(index+1)
-     * @param  value               The value to be placed in the header.
-     * @param  comment             The comment for the header
+     * @param  index0                    The 0-based index of the column
+     * @param  key                       The column key. I.e., the keyword will be key+(index+1)
+     * @param  value                     The value to be placed in the header.
+     * @param  comment                   The comment for the header
      *
-     * @throws HeaderCardException if the header could not be updated
+     * @throws HeaderCardException       if the header could not be updated, or if the indexed FITS keyword is too long
+     *                                       (exceeds the maximum 8 bytes allowed by the FITS standard).
+     * @throws IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of columns
+     *                                       in t@throws IndexOutOfBoundsException if the index is less than 0 or
+     *                                       greater than or equals to the number of columns in the table.
      */
-    public void setColumnMeta(int index, String key, String value, String comment) throws HeaderCardException {
-        setColumnMeta(index, key, value, comment, true);
+    public void setColumnMeta(int index0, String key, String value, String comment)
+            throws IndexOutOfBoundsException, HeaderCardException {
+        setColumnMeta(index0, key, value, comment, true);
     }
 
     /**
      * Specify column metadata for a given column in a way that allows all of the column metadata for a given column to
      * be organized together.
      *
-     * @param      index               The 0-based index of the column
-     * @param      key                 The column key. I.e., the keyword will be key+(index+1)
-     * @param      value               The value to be placed in the header.
-     * @param      comment             The comment for the header
-     * @param      after               Should the header card be after the current column metadata block (true), or
-     *                                     immediately before the TFORM card (false). @throws FitsException if the
-     *                                     operation failed
+     * @param      index0                    The 0-based index of the column
+     * @param      key                       The column key. I.e., the keyword will be key+(index+1)
+     * @param      value                     The value to be placed in the header.
+     * @param      comment                   The comment for the header
+     * @param      after                     Should the header card be after the current column metadata block (true),
+     *                                           or immediately before the TFORM card (false). @throws FitsException if
+     *                                           the operation failed
      *
-     * @throws     HeaderCardException if the header could not be updated
+     * @throws     HeaderCardException       if the header could not be updated, or if the indexed FITS keyword is too
+     *                                           long (exceeds the maximum 8 bytes allowed by the FITS standard).
+     * @throws     IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of
+     *                                           columns in t@throws IndexOutOfBoundsException if the index is less than
+     *                                           0 or greater than or equals to the number of columns in the table.
      *
-     * @deprecated                     use {@link #setColumnMeta(int, IFitsHeader, String, String, boolean)}
+     * @deprecated                           use {@link #setColumnMeta(int, IFitsHeader, String, String, boolean)}
      */
     @Deprecated
-    public void setColumnMeta(int index, String key, String value, String comment, boolean after)
-            throws HeaderCardException {
-        setCurrentColumn(index, after);
-        myHeader.addLine(new HeaderCard(key + (index + 1), value, comment));
+    public void setColumnMeta(int index0, String key, String value, String comment, boolean after)
+            throws IndexOutOfBoundsException, HeaderCardException {
+        setCurrentColumn(index0, after);
+        myHeader.addLine(new HeaderCard(key + (index0 + 1), value, comment));
     }
 
     /**
      * Sets the name / ID of a specific column in this table. Naming columns is generally a good idea so that people can
      * figure out what sort of data actually appears in specific table columns.
      * 
-     * @param  index                     the column index
+     * @param  index0                    the 0-based column index
      * @param  name                      the name or ID we want to assing to the column
      * @param  comment                   Any additional comment we would like to store alongside in the FITS header.
      *                                       (The comment may be truncated or even ommitted, depending on space
      *                                       constraints in the FITS header.
      * 
-     * @throws IndexOutOfBoundsException if the table has no column matching the index
      * @throws HeaderCardException       if there was a problem wil adding the associated descriptive FITS header
      *                                       keywords to this table's header.
+     * @throws IndexOutOfBoundsException if the table has no column matching the index
      * 
      * @see                              #getColumnName(int)
      * @see                              #getDefaultColumnName(int)
      */
-    public void setColumnName(int index, String name, String comment)
+    public void setColumnName(int index0, String name, String comment)
             throws IndexOutOfBoundsException, HeaderCardException {
-        if (index < 0 || index >= getNCols()) {
-            throw new IndexOutOfBoundsException(
-                    "column index " + index + " is out of bounds for table with " + getNCols() + " columns");
-        }
-        setColumnMeta(index, TTYPEn, name, comment, true);
+        setColumnMeta(index0, TTYPEn, name, comment, true);
     }
 
     /**
      * Set the cursor in the header to point after the metadata for the specified column
      *
-     * @param      col The 0-based index of the column
+     * @param      col                       The 0-based index of the column
      * 
-     * @deprecated     (<i>for internal use</i>) Will be removed int the future (no longer used).
+     * @throws     IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of
+     *                                           columns in t@throws IndexOutOfBoundsException if the index is less than
+     *                                           0 or greater than or equals to the number of columns in the table.
+     * 
+     * @deprecated                           (<i>for internal use</i>) Will be removed int the future (no longer used).
      */
     @Deprecated
-    public void setCurrentColumn(int col) {
+    public void setCurrentColumn(int col) throws IndexOutOfBoundsException {
         setCurrentColumn(col, true);
     }
 
     /**
      * Set the cursor in the header to point either before the TFORMn value or after the column metadata
      *
-     * @param      col   The 0-based index of the column
-     * @param      after True if the cursor should be placed after the existing column metadata or false if the cursor
-     *                       is to be placed before the TFORM value. If no corresponding TFORM is found, the cursor will
-     *                       be placed at the end of current header.
+     * @param      col0                      The 0-based index of the column
+     * @param      after                     True if the cursor should be placed after the existing column metadata or
+     *                                           false if the cursor is to be placed before the TFORM value. If no
+     *                                           corresponding TFORM is found, the cursor will be placed at the end of
+     *                                           current header.
      * 
-     * @deprecated       (<i>for internal use</i>) Will have private access in the future.
+     * @throws     IndexOutOfBoundsException if the index is less than 0 or greater than or equals to the number of
+     *                                           columns in t@throws IndexOutOfBoundsException if the index is less than
+     *                                           0 or greater than or equals to the number of columns in the table.
+     * 
+     * @deprecated                           (<i>for internal use</i>) Will have private access in the future.
      */
     @Deprecated
-    public void setCurrentColumn(int col, boolean after) {
+    public void setCurrentColumn(int col0, boolean after) throws IndexOutOfBoundsException {
+        if (col0 < 0 || col0 >= getNCols()) {
+            throw new IndexOutOfBoundsException("Zero-based column index " + col0 + " is out of range");
+        }
+
         if (after) {
-            myHeader.positionAfterIndex(TFORMn, col + 1);
+            myHeader.positionAfterIndex(TFORMn, col0 + 1);
         } else {
-            myHeader.findCard(TFORMn.n(col + 1));
+            myHeader.findCard(TFORMn.n(col0 + 1));
         }
     }
 

--- a/src/main/java/nom/tam/fits/header/IFitsHeader.java
+++ b/src/main/java/nom/tam/fits/header/IFitsHeader.java
@@ -3,6 +3,7 @@ package nom.tam.fits.header;
 import java.util.NoSuchElementException;
 
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 
 /*
  * #%L
@@ -251,13 +252,13 @@ public interface IFitsHeader {
      * @throws IndexOutOfBoundsException if the index is less than 0 or exceeds 999. (In truth we should throw an
      *                                       exception for 0 as well, but seems to be common not-quite-legal FITS usage
      *                                       with 0 indices. Hence we relax the condition).
-     * @throws IllegalStateException     if the resulting indexed keyword exceeds the maximum 8-bytes allowed for
+     * @throws HeaderCardException       if the resulting indexed keyword exceeds the maximum 8-bytes allowed for
      *                                       standard FITS keywords.
      * @throws NoSuchElementException    If more indices were supplied than can be filled for this keyword.
      * 
      * @see                              #extractIndices(String)
      */
-    default IFitsHeader n(int... numbers) throws IndexOutOfBoundsException, NoSuchElementException, IllegalStateException {
+    default IFitsHeader n(int... numbers) throws IndexOutOfBoundsException, NoSuchElementException, HeaderCardException {
         StringBuffer headerName = new StringBuffer(key());
         for (int number : numbers) {
             if (number < 0 || number > MAX_INDEX) {
@@ -274,7 +275,7 @@ public interface IFitsHeader {
         }
 
         if (headerName.length() > HeaderCard.MAX_KEYWORD_LENGTH) {
-            throw new IllegalStateException("indexed keyword " + headerName.toString() + " is too long.");
+            throw new HeaderCardException("indexed keyword " + headerName.toString() + " is too long.");
         }
 
         return new FitsKey(headerName.toString(), status(), hdu(), valueType(), comment());

--- a/src/test/java/nom/tam/fits/BinaryTableNewTest.java
+++ b/src/test/java/nom/tam/fits/BinaryTableNewTest.java
@@ -37,6 +37,7 @@ import java.io.FileInputStream;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -2133,5 +2134,46 @@ public class BinaryTableNewTest {
     public void addVariableSizeColumnException() throws Exception {
         BinaryTable bt = new BinaryTable();
         Assertions.assertThrows(TableException.class, () -> bt.addVariableSizeColumn(true));
+    }
+
+    @Test
+    public void getColumnFormatTestException() throws Exception {
+        BinaryTable bt = new BinaryTable();
+        bt.addColumn(BinaryTable.ColumnDesc.createForScalars(boolean.class));
+        BinaryTableHDU hdu = bt.toHDU();
+
+        Assertions.assertThrows(FitsException.class, () -> hdu.getColumnFormat(-1), "-1");
+        Assertions.assertThrows(FitsException.class, () -> hdu.getColumnFormat(1), "big");
+    }
+
+    @Test
+    public void getColumnMetaTest() throws Exception {
+        BinaryTable bt = new BinaryTable();
+        bt.addColumn(BinaryTable.ColumnDesc.createForScalars(boolean.class));
+        BinaryTableHDU hdu = bt.toHDU();
+        hdu.setColumnMeta(0, "TZERO", 3, "quantization offset", true);
+
+        Assertions.assertEquals(hdu.getColumnMeta(0, "TZERO"), "3");
+        Assertions.assertEquals(hdu.getColumnMeta(0, Standard.TZEROn), "3");
+
+        Assertions.assertNull(hdu.getColumnMeta(0, "TBLAH"), "blah");
+        Assertions.assertNull(hdu.getColumnMeta(0, Standard.TSCALn), "TSCALn");
+    }
+
+    @Test
+    public void getColumnMetaTestException() throws Exception {
+        BinaryTable bt = new BinaryTable();
+        bt.addColumn(BinaryTable.ColumnDesc.createForScalars(boolean.class));
+        BinaryTableHDU hdu = bt.toHDU();
+        hdu.setColumnMeta(0, "TZERO", 3, "quantization offset", true);
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> hdu.getColumnMeta(-1, "TZERO"), "-1");
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> hdu.getColumnMeta(-1, Standard.TZEROn), "-1");
+
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> hdu.getColumnMeta(1, "TZERO"), "big");
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> hdu.getColumnMeta(1, Standard.TZEROn), "big");
+
+        Assertions.assertThrows(NoSuchElementException.class, () -> hdu.getColumnMeta(0, Standard.BZERO),
+                "too many indices");
     }
 }

--- a/src/test/java/nom/tam/fits/test/AsciiTableTest.java
+++ b/src/test/java/nom/tam/fits/test/AsciiTableTest.java
@@ -590,6 +590,7 @@ public class AsciiTableTest {
             AsciiTableHDU hdu = (AsciiTableHDU) f.getHDU(1);
             Assertions.assertEquals("I10", hdu.getColumnFormat(1));
             Assertions.assertEquals("I10", hdu.getColumnMeta(1, "TFORM"));
+            Assertions.assertEquals("I10", hdu.getColumnMeta(1, Standard.TFORMn));
             Assertions.assertEquals(TableHDU.getDefaultColumnName(1), hdu.getColumnName(1));
 
             hdu.setColumnMeta(1, "TTYPE", "TATA", null);


### PR DESCRIPTION
### Added

  - `String TableHDU.getColumnMeta(int index0, IFitsHeader keyBase)` to retrieve column descriptors using the unindexed base form of standard indexable FITS keys.
  
### Changed

 - `String TableHDU.getColumnMeta(int index0, String keyStrem)` to retrieve non-string column data also.
 - `IFitsHeader.n()` changed to throw the more specific `HeaderCardException` instead of the original `IllegalStateException` when the resulting indexed keyword is too long to be a standard FITS keyword. The change is backward compatible. The same applies downstream, e.g. for `TableHDU.setColumnMeta()` / `.getColumnMeta()`.
 - `TableHDU.getColumnName()` no longer trims the string value stored in by the `TTYPEn` keyword, in line with the leading spaces being significant in the FITS standard. The caller may trim the result as necessary when it's not `null`.