### PR TITLE
Compression quantization fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ Upcoming feature release, likely around 15 September 2026.
 
  - [#883] Added `TableHDU.getColumnMeta(int, IFitsHeader)` to support standard keyword enums beside the existing string keyword form. (by @attipaci)
  
- - [#884] Added `setColumnData(Object)`, `createColumnData(int), and `setColumnSize(int)` methods to `ICompressColumnParameter`. (by @attipaci)
+ - [#884] Added `setColumnData(Object)`, `createColumnData(int)`, and `setColumnSize(int)` methods to `ICompressColumnParameter`. (by @attipaci)
  
  - [#884] Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression. (by @attipaci)
+ 
+ - [#885] Added `QuantizeOption.toInt(double)` and `.toDouble(int)` methods which actually perform the conversion. The `.toDouble()` method now uses `Math.fma()` to match cfistion / funpack more closely (thanks to @keastrid). (by @attipaci)
 
 ### Changed
 
@@ -52,6 +54,10 @@ Upcoming feature release, likely around 15 September 2026.
  - [#885] The default null-value indicator in compressed HDUs is changed to -2147483648, as recommended by the FITS standard. (by @attipaci)
  
  - [#885] Removed `null` options checks from compression parameter methods, and instead commented on the constructors that the parameters should not be instantiated with `null` option parameter. Under the normal behavior of the library the parameters are always created with valid option arguments, so it would take a deliberate effort by the user to do otherwise. (by @attipaci)
+ 
+ - [#885] Speed up compression / decompression by eliminating extraneous arrays / buffers from the processing. (by @attipaci, thanks to @keastrid)
+ 
+ - [#885] `QuantizeOption.toDouble()` method now uses `Math.fma()` to match cfistio / funpack more closely. (by @attipaci, thanks to @keastrid)
 
  - The latest build and runtime Maven dependencies. (by @attipaci)
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Upcoming feature release, likely around 15 September 2026.
  - [#884] Fixed header `ZBLANK` value not being used in decompression, when the compressed FITS does not provide per-tile blanking values in a column otherwise. (by @attipaci, thanks to @robyww).
  
  - [#885] `QuantizeProcessor` had extraneous rounding by half, and sometimes in the wrong direction. Fixed to conform to the FITS specification more completely. (by @attipaci)
+ 
+ - [#887] Fixed PLIO decompression of 32-bit integer data to restore the upper 2 bytes also.
 
 ### Added
 
@@ -26,8 +28,6 @@ Upcoming feature release, likely around 15 September 2026.
  - [#884] Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression. (by @attipaci)
  
  - [#885] Added `QuantizeOption.toInt(double)` and `.toDouble(int)` methods which actually perform the conversion. The `.toDouble()` method now uses `Math.fma()` to match cfistion / funpack more closely (thanks to @keastrid). (by @attipaci)
- 
- - [#887] Fixed PLIO decompression of 32-bit integer data to restore the upper 2 bytes also.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,15 @@ Upcoming feature release, likely around 15 September 2026.
  
  - [#884] Fixed header `ZBLANK` value not being used in decompression, when the compressed FITS does not provide per-tile blanking values in a column otherwise. (by @attipaci, thanks to @robyww).
  
- - [#884] `QuantizeProcessor` had extraneous rounding by half, and sometimes in the wrong direction. Fixed to conform to the FITS specification more completely. (by @attipaci)
- 
- - [#884] `QuantizeProcessor` integer min/max ranges to use floor / ceil to accomodate dither. (by @attipaci)
+ - [#885] `QuantizeProcessor` had extraneous rounding by half, and sometimes in the wrong direction. Fixed to conform to the FITS specification more completely. (by @attipaci)
 
 ### Added
 
  - [#883] Added `TableHDU.getColumnMeta(int, IFitsHeader)` to support standard keyword enums beside the existing string keyword form. (by @attipaci)
  
- - [#884] Added `setColumnData(Object)`, `createColumnData(int), and `ensureColumnData(int)` methods to `ICompressColumnParameter`. (by @attipaci)
+ - [#884] Added `setColumnData(Object)`, `createColumnData(int), and `setColumnSize(int)` methods to `ICompressColumnParameter`. (by @attipaci)
  
- - [#884] Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression.
+ - [#884] Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression. (by @attipaci)
 
 ### Changed
 
@@ -37,19 +35,23 @@ Upcoming feature release, likely around 15 September 2026.
  
  - [#883] `TableHDU.getColumnName()` no longer trims the string value stored in by the `TTYPEn` keyword, in line with the leading spaces being significant in the FITS standard. The caller may trim the result as necessary when it's not `null`. (by @attipaci)
 
- - [#884] Quantization in HDU compression has been overhauled, and much simplified. Many strenuous internal classes have been eliminated in favor of simpler, easier to follow, logic. (by @attipaci)
- 
- - [#884] `QuantizeProcessor` defaults to `ZSCALE` 1.0 and `ZZERO` 0.0 if there are no quantizable valid data (such as only null or explicit zero values). (by @attipaci)
- 
- - [#884] `Quantize.calculateNoise()` changed to use only regular data, excluding special values like NaNs, infinities, null and zero indicators. (by @attipaci)
- 
- - [#884] `Quantize.quantize()` changed to set default values (`ZSCALE` -> 1.0, `ZZERO` -> 0.0, int min/max -> 0) when there is no valid data to quantize. (by @attipaci)
- 
- - [#884] The default null-value indicator in compressed HDUs is changed to -2147483648, as recommended by the FITS standard. (by @attipaci)
- 
  - [#884] Fully disentangled initialization of compression quantization column data for compression (where prior data may not exist) and decompression (where existing data must be provided). (by @attipaci)
  
  - [#884] Quantized compression to either add `ZBLANK` header value or per-tile column data, but not both, and possibly neither -- as necessary. (by @attipaci)
+
+ - [#885] Quantization in HDU compression has been overhauled, and much simplified. Many strenuous internal classes have been eliminated in favor of simpler, easier to follow, logic. (by @attipaci)
+  
+ - [#885] `QuantizeProcessor` integer min/max ranges to use floor / ceil to accommodate dither. (by @attipaci)
+ 
+ - [#885] `QuantizeProcessor` defaults to `ZSCALE` 1.0 and `ZZERO` 0.0 if there are no quantizable valid data (such as only null or explicit zero values). (by @attipaci)
+ 
+ - [#885] `Quantize.calculateNoise()` changed to use only regular data, excluding special values like NaNs, infinities, null and zero indicators. (by @attipaci)
+ 
+ - [#885] `Quantize.quantize()` changed to set default values (`ZSCALE` -> 1.0, `ZZERO` -> 0.0, int min/max -> 0) when there is no valid data to quantize. (by @attipaci)
+ 
+ - [#885] The default null-value indicator in compressed HDUs is changed to -2147483648, as recommended by the FITS standard. (by @attipaci)
+ 
+ - [#885] Removed `null` options checks from compression parameter methods, and instead commented on the constructors that the parameters should not be instantiated with `null` option parameter. Under the normal behavior of the library the parameters are always created with valid option arguments, so it would take a deliberate effort by the user to do otherwise. (by @attipaci)
 
  - The latest build and runtime Maven dependencies. (by @attipaci)
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Upcoming feature release, likely around 15 September 2026.
  - [#884] Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression. (by @attipaci)
  
  - [#885] Added `QuantizeOption.toInt(double)` and `.toDouble(int)` methods which actually perform the conversion. The `.toDouble()` method now uses `Math.fma()` to match cfistion / funpack more closely (thanks to @keastrid). (by @attipaci)
+ 
+ - [#887] Fixed PLIO decompression of 32-bit integer data to restore the upper 2 bytes also.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-Upcoming bug fix release, likely around 15 September 2026.
+Upcoming feature release, likely around 15 September 2026.
 
 ### Fixed
 
  - [#879] Fixed GZIP HDU decompression so it properly handles unprocessed remainder data in the internal buffer between successive reads. (by @timj and @attipaci).
-
+ 
+ - [#884] Fixed header `ZBLANK` value not being used in decompression, when the compressed FITS does not provide per-tile blanking values in a column otherwise. (by @attipaci, thanks to @robyww).
+ 
+ - [#884] `QuantizeProcessor` had extraneous rounding by half, and sometimes in the wrong direction. Fixed to conform to the FITS specification more completely. (by @attipaci)
+ 
+ - [#884] `QuantizeProcessor` integer min/max ranges to use floor / ceil to accomodate dither. (by @attipaci)
 
 ### Added
 
- - [883] Added `TableHDU.getColumnMeta(int, IFitsHeader)` to support standard keyword enums beside the existing string keyword form. (by @attipaci)
+ - [#883] Added `TableHDU.getColumnMeta(int, IFitsHeader)` to support standard keyword enums beside the existing string keyword form. (by @attipaci)
+ 
+ - [#884] Added `setColumnData(Object)`, `createColumnData(int), and `ensureColumnData(int)` methods to `ICompressColumnParameter`. (by @attipaci)
 
 ### Changed
 
@@ -28,7 +35,21 @@ Upcoming bug fix release, likely around 15 September 2026.
  
  - [#883] `TableHDU.getColumnName()` no longer trims the string value stored in by the `TTYPEn` keyword, in line with the leading spaces being significant in the FITS standard. The caller may trim the result as necessary when it's not `null`. (by @attipaci)
 
+ - [#884] Quantization in HDU compression has been overhauled, and much simplified. Many strenuous internal classes have been eliminated in favor of simpler, easier to follow, logic. (by @attipaci)
+ 
+ - [#884] `QuantizeProcessor` defaults to `ZSCALE` 1.0 and `ZZERO` 0.0 if there are no quantizable valid data (only null or explicit zero values). (by @attipaci)
+ 
+ - [#884] `Quantize.calculateNoise()` changed to use only regular data, excluding special values like NaNs, infinities, null and zero indicators. (by @attipaci)
+ 
+ - [#884] `Quantize.quantize()` changed to set default values (`ZSCALE` -> 1.0, `ZZERO` -> 0.0, int min/max -> 0) when there is no valid data to quantize. (by @attipaci)
+ 
+ - [#884] The default null-value indicator in compressed HDUs is changed to -2147483648, as recommended by the FITS standard. (by @attipaci)
+
  - The latest build and runtime Maven dependencies. (by @attipaci)
+ 
+### Deprecated
+
+ - [#884] Deprecated `ICompressColumnParameter.setColumnData(Object, int)`. Its dual functionality has been split into separate `.setColumnData(Object)`, `createColumnData(int)` and `ensureColumnData(int)` methods. (by @attipaci)
  
 
 ## [1.22.2] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Upcoming feature release, likely around 15 September 2026.
  - [#883] Added `TableHDU.getColumnMeta(int, IFitsHeader)` to support standard keyword enums beside the existing string keyword form. (by @attipaci)
  
  - [#884] Added `setColumnData(Object)`, `createColumnData(int), and `ensureColumnData(int)` methods to `ICompressColumnParameter`. (by @attipaci)
+ 
+ - [#884] Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression.
 
 ### Changed
 
@@ -37,13 +39,17 @@ Upcoming feature release, likely around 15 September 2026.
 
  - [#884] Quantization in HDU compression has been overhauled, and much simplified. Many strenuous internal classes have been eliminated in favor of simpler, easier to follow, logic. (by @attipaci)
  
- - [#884] `QuantizeProcessor` defaults to `ZSCALE` 1.0 and `ZZERO` 0.0 if there are no quantizable valid data (only null or explicit zero values). (by @attipaci)
+ - [#884] `QuantizeProcessor` defaults to `ZSCALE` 1.0 and `ZZERO` 0.0 if there are no quantizable valid data (such as only null or explicit zero values). (by @attipaci)
  
  - [#884] `Quantize.calculateNoise()` changed to use only regular data, excluding special values like NaNs, infinities, null and zero indicators. (by @attipaci)
  
  - [#884] `Quantize.quantize()` changed to set default values (`ZSCALE` -> 1.0, `ZZERO` -> 0.0, int min/max -> 0) when there is no valid data to quantize. (by @attipaci)
  
  - [#884] The default null-value indicator in compressed HDUs is changed to -2147483648, as recommended by the FITS standard. (by @attipaci)
+ 
+ - [#884] Fully disentangled initialization of compression quantization column data for compression (where prior data may not exist) and decompression (where existing data must be provided). (by @attipaci)
+ 
+ - [#884] Quantized compression to either add `ZBLANK` header value or per-tile column data, but not both, and possibly neither -- as necessary. (by @attipaci)
 
  - The latest build and runtime Maven dependencies. (by @attipaci)
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Upcoming feature release, likely around 15 September 2026.
  - [#884] Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression. (by @attipaci)
  
  - [#885] Added `QuantizeOption.toInt(double)` and `.toDouble(int)` methods which actually perform the conversion. The `.toDouble()` method now uses `Math.fma()` to match cfistion / funpack more closely (thanks to @keastrid). (by @attipaci)
+ 
+  - [#885] `QuantizeOption.useFMA()` method can select whether `Math.fma()` should be used instead of regular arithmetics (default) when converting quantized integers back to their floating-point values. The use of `fma()` matches cfistio / funpack and astropy more closely, but may be very slow on platforms without hardware support. (by @attipaci, thanks to @keastrid)
+
 
 ### Changed
 
@@ -59,8 +62,6 @@ Upcoming feature release, likely around 15 September 2026.
  
  - [#885] Speed up compression / decompression by eliminating extraneous arrays / buffers from the processing. (by @attipaci, thanks to @keastrid)
  
- - [#885] `QuantizeOption.toDouble()` method now uses `Math.fma()` to match cfistio / funpack more closely. (by @attipaci, thanks to @keastrid)
-
  - The latest build and runtime Maven dependencies. (by @attipaci)
  
 ### Deprecated

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 0.03%
+        threshold: 0.1%
         removed_code_behavior: adjust_base
 
 parsers:

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   
   <groupId>gov.nasa.gsfc.heasarc</groupId>
   <artifactId>nom-tam-fits</artifactId>
-  <version>1.22.3-SNAPSHOT</version>
+  <version>1.23.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>nom.tam.fits</name>
   <description>Java library for reading and writing FITS files. FITS, the Flexible Image Transport System, is commonly used for the archival and distribution of astronomical data.</description>

--- a/src/main/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/checkstyle/checkstyle-suppressions.xml
@@ -11,4 +11,6 @@
 	<suppress checks="FileLength" files="nom.tam.fits.header[\\/]" />
 	<!-- backward compatibility for two methods -->
 	<suppress checks="MethodName" files="nom.tam.fits.FitsFactory" />
+	<!-- we want explicit indexed array access over 9 elements -->
+	<suppress checks="MagicNumber" files="nom.tam.fits.compression.algorithm.quant.Quantize" />
 </suppressions>

--- a/src/main/java/nom/tam/fits/Fits.java
+++ b/src/main/java/nom/tam/fits/Fits.java
@@ -153,7 +153,7 @@ import static nom.tam.fits.header.Standard.EXTVER;
  * 
  * @see     FitsFactory
  *
- * @version 1.22
+ * @version 1.23
  */
 @SuppressWarnings("deprecation")
 public class Fits implements Closeable {

--- a/src/main/java/nom/tam/fits/compression/algorithm/plio/PLIOCompress.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/plio/PLIOCompress.java
@@ -133,7 +133,7 @@ public abstract class PLIOCompress {
 
         @Override
         protected void put(int index, int pixel) {
-            pixelData.put(index, (short) pixel);
+            pixelData.put(index, pixel);
         }
     }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
@@ -1,5 +1,9 @@
 package nom.tam.fits.compression.algorithm.quant;
 
+import java.nio.Buffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -42,31 +46,6 @@ import java.util.Arrays;
 @Deprecated
 @SuppressWarnings("javadoc")
 public class Quantize {
-
-    @Deprecated
-    static class DoubleArrayPointer {
-
-        private final double[] array;
-
-        private int startIndex;
-
-        @Deprecated
-        DoubleArrayPointer(double[] arrayIn) {
-            array = arrayIn;
-        }
-
-        @Deprecated
-        public DoubleArrayPointer copy(long l) {
-            DoubleArrayPointer result = new DoubleArrayPointer(array);
-            result.startIndex = (int) l;
-            return result;
-        }
-
-        @Deprecated
-        public double get(int ii) {
-            return array[ii + startIndex];
-        }
-    }
 
     private static final double DEFAULT_QUANT_LEVEL = 4.;
 
@@ -142,21 +121,28 @@ public class Quantize {
      * flux(i-2) - flux(i+2))) The returned estimates are the median of the values that are computed for each row of the
      * image.
      * 
-     * @param arrayIn 2 dimensional tiledImageOperation of image pixels
-     * @param nx      number of pixels in each row of the image
-     * @param ny      number of rows in the image
+     * @param  in                       a FloatBuffer or a DoubleBuffer instance. It is rewinded at return.
+     * 
+     * @throws IllegalArgumentException if the input buffer is not a FloatBuffer or DoubleBuffer instance.
      */
-    private void calculateNoise(double[] arrayIn, int nx, int ny) {
-        DoubleArrayPointer array = new DoubleArrayPointer(arrayIn);
+    @SuppressWarnings("null")
+    private void calculateNoise(Buffer in) throws IllegalArgumentException {
+        int origPos = in.position();
         initializeNoise();
 
-        if (nx < MINIMUM_PIXEL_WIDTH) {
-            // treat entire tiledImageOperation as an image with a single row
-            nx = nx * ny;
-            ny = 1;
-        }
-        if (calculateNoiseShortRow(array, nx, ny)) {
+        int nx = parameter.getTileWidth();
+        int ny = parameter.getTileHeight();
+
+        if (nx * ny < MINIMUM_PIXEL_WIDTH) {
+            calculateNoiseShortRow(in);
             return;
+        }
+
+        FloatBuffer fin = (in instanceof FloatBuffer) ? (FloatBuffer) in : null;
+        DoubleBuffer din = (in instanceof DoubleBuffer) ? (DoubleBuffer) in : null;
+
+        if (fin == null && din == null) {
+            throw new IllegalArgumentException("input buffer of type " + in.getClass().getName() + " is unsupported.");
         }
 
         int nrows = 0, nrows2 = 0;
@@ -172,13 +158,12 @@ public class Quantize {
 
         /* loop over each row of the image */
         for (int jj = 0; jj < ny; jj++) {
-            double[] v = new double[9];
-            DoubleArrayPointer rowpix = array.copy((long) jj * nx); /* point to first pixel in the row */
             int nvals = 0;
             int nvals2 = 0;
+            double[] v = new double[9];
 
             for (int ii = 0, k = 0; ii < nx; ii++) {
-                v[k] = rowpix.get(ii);
+                v[k] = fin == null ? din.get() : fin.get();
 
                 if (!parameter.isRegular(v[k])) {
                     continue;
@@ -245,32 +230,45 @@ public class Quantize {
             nrows++;
         } /* end of loop over rows */
 
+        in.position(origPos);
+
         computeMedianOfValuesEachRow(nrows, nrows2, diffs2, diffs3, diffs5);
         setNoiseResult(ngoodpix);
     }
 
-    private boolean calculateNoiseShortRow(DoubleArrayPointer array, int nx, int ny) {
-        /* rows must have at least 9 pixels */
-        if (nx < MINIMUM_PIXEL_WIDTH) {
-            int ngoodpix = 0;
-            for (int index = 0; index < nx; index++) {
-                if (isNull(array.get(index))) {
-                    continue;
-                }
+    @SuppressWarnings("null")
+    private void calculateNoiseShortRow(Buffer in) throws IllegalArgumentException {
+        int origPos = in.position();
 
-                if (array.get(index) < xminval) {
-                    xminval = array.get(index);
-                }
-                if (array.get(index) > xmaxval) {
-                    xmaxval = array.get(index);
-                }
+        FloatBuffer fin = (in instanceof FloatBuffer) ? (FloatBuffer) in : null;
+        DoubleBuffer din = (in instanceof DoubleBuffer) ? (DoubleBuffer) in : null;
 
-                ngoodpix++;
-            }
-            setNoiseResult(ngoodpix);
-            return true;
+        if (fin == null && din == null) {
+            throw new IllegalArgumentException("input buffer of type " + in.getClass().getName() + " is unsupported.");
         }
-        return false;
+
+        int n = parameter.getTileWidth() * parameter.getTileHeight();
+        int ngoodpix = 0;
+        for (int index = 0; index < n; index++) {
+            double x = fin == null ? din.get() : fin.get();
+
+            if (isNull(x)) {
+                continue;
+            }
+
+            if (x < xminval) {
+                xminval = x;
+            }
+            if (x > xmaxval) {
+                xmaxval = x;
+            }
+
+            ngoodpix++;
+        }
+
+        in.position(origPos);
+
+        setNoiseResult(ngoodpix);
     }
 
     @Deprecated
@@ -349,13 +347,31 @@ public class Quantize {
      * </p>
      * 
      * @param  fdata the data to quantinize
-     * @param  nxpix the image width
-     * @param  nypix the image hight
+     * @param  nxpix (unused) the image width -- the tile width of the initializing option is used instead.
+     * @param  nypix (unused) the image hight -- the tile height of the initializing option is used instead.
      * 
      * @return       true if the quantification was possible
      */
     @Deprecated
     public boolean quantize(double[] fdata, int nxpix, int nypix) {
+        DoubleBuffer buf = DoubleBuffer.wrap(fdata);
+        return guessQuantization(buf);
+    }
+
+    /**
+     * Guesses the quantization scaling and zero offset parameters based on the noise distribution in the data.
+     * 
+     * @param  fdata                    Input FloatBuffer or DoubleBuffer instance containing the floating-point data.
+     *                                      On return the buffer is restored to its initial position.
+     * 
+     * @return                          <code>true</code> if the quantization was successful, otherwise
+     *                                      <code>false</code>.
+     * 
+     * @throws IllegalArgumentException if the input buffer is not a FloatBuffer or DoubleBuffer instance.
+     * 
+     * @since                           1.23
+     */
+    boolean guessQuantization(Buffer fdata) throws IllegalArgumentException {
         // MAD 2nd, 3rd, and 5th order noise values
         double stdev;
         double bScale; /* bscale, 1 in intdata = delta in fdata */
@@ -364,13 +380,13 @@ public class Quantize {
         parameter.setBScale(1.);
         parameter.setBZero(0.);
 
-        long nx = (long) nxpix * (long) nypix;
+        long nx = (long) parameter.getTileWidth() * (long) parameter.getTileHeight();
         if (nx <= 1L) {
             return false;
         }
         if (parameter.getQLevel() >= 0.) {
             /* estimate background noise using MAD pixel differences */
-            calculateNoise(fdata, nxpix, nypix);
+            calculateNoise(fdata);
             // special case of an image filled with Nulls
             if (ngood == 0) {
                 /* set parameters to dummy values, which are not used */
@@ -401,7 +417,7 @@ public class Quantize {
             /* negative value represents the absolute quantization level */
             bScale = -parameter.getQLevel();
             /* only need to calculate the min and max values */
-            calculateNoise(fdata, nxpix, nypix);
+            calculateNoise(fdata);
         }
         /* check that the range of quantized levels is not > range of int */
         if ((maxValue - minValue) / bScale > 2. * MAX_INT_AS_DOUBLE - N_RESERVED_VALUES) {
@@ -491,10 +507,10 @@ public class Quantize {
         noise5 = NOISE_5_MULTIPLICATOR * xnoise5;
     }
 
-    private void swapElements(double[] array, int one, int second) {
-        double value = array[one];
-        array[one] = array[second];
-        array[second] = value;
+    private void swapElements(double[] array, int i, int j) {
+        double value = array[i];
+        array[i] = array[j];
+        array[j] = value;
     }
 
 }

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
@@ -119,9 +119,9 @@ public class Quantize {
     /* returned 5th order MAD of all non-null pixels */
     private double noise5;
 
-    private double xmaxval;
+    private double xmaxval = Double.NEGATIVE_INFINITY;
 
-    private double xminval;
+    private double xminval = Double.POSITIVE_INFINITY;
 
     private double xnoise2;
 
@@ -149,6 +149,7 @@ public class Quantize {
     private void calculateNoise(double[] arrayIn, int nx, int ny) {
         DoubleArrayPointer array = new DoubleArrayPointer(arrayIn);
         initializeNoise();
+
         if (nx < MINIMUM_PIXEL_WIDTH) {
             // treat entire tiledImageOperation as an image with a single row
             nx = nx * ny;
@@ -157,9 +158,10 @@ public class Quantize {
         if (calculateNoiseShortRow(array, nx, ny)) {
             return;
         }
-        DoubleArrayPointer rowpix;
+
         int nrows = 0, nrows2 = 0;
         long ngoodpix = 0;
+
         /* allocate arrays used to compute the median and noise estimates */
         double[] differences2 = new double[nx];
         double[] differences3 = new double[nx];
@@ -167,97 +169,62 @@ public class Quantize {
         double[] diffs2 = new double[ny];
         double[] diffs3 = new double[ny];
         double[] diffs5 = new double[ny];
+
         /* loop over each row of the image */
         for (int jj = 0; jj < ny; jj++) {
-            rowpix = array.copy((long) jj * nx); /* point to first pixel in the row */
-            int ii = 0;
-            ii = findNextValidPixelWithNullCheck(nx, rowpix, ii);
-            if (ii == nx) {
-                continue; /* hit end of row */
-            }
-            double v1 = getNextPixelAndCheckMinMax(rowpix, ii);
-            ngoodpix++;
-            ii = findNextValidPixelWithNullCheck(nx, rowpix, ++ii);
-            if (ii == nx) {
-                continue; /* hit end of row */
-            }
-            double v2 = getNextPixelAndCheckMinMax(rowpix, ii);
-            ngoodpix++;
-            ii = findNextValidPixelWithNullCheck(nx, rowpix, ++ii);
-            if (ii == nx) {
-                continue; /* hit end of row */
-            }
-            double v3 = getNextPixelAndCheckMinMax(rowpix, ii);
-            ngoodpix++;
-            ii = findNextValidPixelWithNullCheck(nx, rowpix, ++ii);
-            if (ii == nx) {
-                continue; /* hit end of row */
-            }
-            double v4 = getNextPixelAndCheckMinMax(rowpix, ii);
-            ngoodpix++;
-            ii = findNextValidPixelWithNullCheck(nx, rowpix, ++ii);
-            if (ii == nx) {
-                continue; /* hit end of row */
-            }
-            double v5 = getNextPixelAndCheckMinMax(rowpix, ii);
-            ngoodpix++;
-            ii = findNextValidPixelWithNullCheck(nx, rowpix, ++ii);
-            if (ii == nx) {
-                continue; /* hit end of row */
-            }
-            double v6 = getNextPixelAndCheckMinMax(rowpix, ii);
-            ngoodpix++;
-            ii = findNextValidPixelWithNullCheck(nx, rowpix, ++ii);
-            if (ii == nx) {
-                continue; /* hit end of row */
-            }
-            double v7 = getNextPixelAndCheckMinMax(rowpix, ii);
-            ngoodpix++;
-            ii = findNextValidPixelWithNullCheck(nx, rowpix, ++ii);
-            if (ii == nx) {
-                continue; /* hit end of row */
-            }
-            double v8 = getNextPixelAndCheckMinMax(rowpix, ii);
-            ngoodpix++;
-            // now populate the differences arrays for the remaining pixels in
-            // the row */
+            double[] v = new double[9];
+            DoubleArrayPointer rowpix = array.copy((long) jj * nx); /* point to first pixel in the row */
             int nvals = 0;
             int nvals2 = 0;
-            for (ii++; ii < nx; ii++) {
-                ii = findNextValidPixelWithNullCheck(nx, rowpix, ii);
-                if (ii == nx) {
-                    continue; /* hit end of row */
+
+            for (int ii = 0, k = 0; ii < nx; ii++) {
+                v[k] = rowpix.get(ii);
+
+                if (!parameter.isRegular(v[k])) {
+                    continue;
                 }
-                double v9 = getNextPixelAndCheckMinMax(rowpix, ii);
+
+                if (v[k] < xminval) {
+                    xminval = v[k];
+                }
+
+                if (v[k] > xmaxval) {
+                    xmaxval = v[k];
+                }
+
+                ngoodpix++;
+
+                if (k + 1 < v.length) {
+                    k++;
+                    continue; // Wait until first 8 elements are filled before processing...
+                }
+
                 /* construct tiledImageOperation of absolute differences */
-                if (!(v5 == v6 && v6 == v7)) {
-                    differences2[nvals2] = Math.abs(v5 - v7);
+                if (!(v[4] == v[5] && v[5] == v[6])) {
+                    differences2[nvals2] = Math.abs(v[4] - v[6]);
                     nvals2++;
                 }
-                if (!(v3 == v4 && v4 == v5 && v5 == v6 && v6 == v7)) {
-                    differences3[nvals] = Math.abs(2 * v5 - v3 - v7);
-                    differences5[nvals] = Math.abs(N6 * v5 - N4 * v3 - N4 * v7 + v1 + v9);
+                if (!(v[2] == v[3] && v[3] == v[4] && v[4] == v[5] && v[5] == v[6])) {
+                    differences3[nvals] = Math.abs(2 * v[4] - v[2] - v[6]);
+                    differences5[nvals] = Math.abs(N6 * v[4] - N4 * v[2] - N4 * v[6] + v[0] + v[8]);
                     nvals++;
                 } else {
                     /* ignore constant background regions */
                     ngoodpix++;
                 }
+
                 /* shift over 1 pixel */
-                v1 = v2;
-                v2 = v3;
-                v3 = v4;
-                v4 = v5;
-                v5 = v6;
-                v6 = v7;
-                v7 = v8;
-                v8 = v9;
+                System.arraycopy(v, 1, v, 0, v.length - 1);
             } /* end of loop over pixels in the row */
+
             // compute the median diffs Note that there are 8 more pixel values
             // than there are diffs values.
             ngoodpix += nvals;
+
             if (nvals == 0) {
                 continue; /* cannot compute medians on this row */
             }
+
             if (nvals == 1) {
                 if (nvals2 == 1) {
                     diffs2[nrows2] = differences2[0];
@@ -274,8 +241,10 @@ public class Quantize {
                 diffs3[nrows] = quickSelect(differences3, nvals);
                 diffs5[nrows] = quickSelect(differences5, nvals);
             }
+
             nrows++;
         } /* end of loop over rows */
+
         computeMedianOfValuesEachRow(nrows, nrows2, diffs2, diffs3, diffs5);
         setNoiseResult(ngoodpix);
     }
@@ -328,22 +297,6 @@ public class Quantize {
     }
 
     @Deprecated
-    protected int findNextValidPixelWithNullCheck(int nx, DoubleArrayPointer rowpix, int ii) {
-        return ii;
-    }
-
-    private double getNextPixelAndCheckMinMax(DoubleArrayPointer rowpix, int ii) {
-        double pixelValue = rowpix.get(ii); /* store the good pixel value */
-        if (pixelValue < xminval) {
-            xminval = pixelValue;
-        }
-        if (pixelValue > xmaxval) {
-            xmaxval = pixelValue;
-        }
-        return pixelValue;
-    }
-
-    @Deprecated
     protected double getNoise2() {
         return noise2;
     }
@@ -362,8 +315,8 @@ public class Quantize {
         xnoise2 = 0;
         xnoise3 = 0;
         xnoise5 = 0;
-        xminval = Double.MAX_VALUE;
-        xmaxval = Double.MIN_VALUE;
+        xminval = Double.POSITIVE_INFINITY;
+        xmaxval = Double.NEGATIVE_INFINITY;
     }
 
     @Deprecated
@@ -405,32 +358,35 @@ public class Quantize {
         double stdev;
         double bScale; /* bscale, 1 in intdata = delta in fdata */
 
+        // AK: defaults
+        parameter.setBScale(1.);
+        parameter.setBZero(0.);
+
         long nx = (long) nxpix * (long) nypix;
         if (nx <= 1L) {
-            parameter.setBScale(1.);
-            parameter.setBZero(0.);
             return false;
         }
         if (parameter.getQLevel() >= 0.) {
             /* estimate background noise using MAD pixel differences */
             calculateNoise(fdata, nxpix, nypix);
             // special case of an image filled with Nulls
-            if (parameter.isCheckNull() && ngood == 0) {
+            if (ngood == 0) {
                 /* set parameters to dummy values, which are not used */
-                minValue = 0.;
-                maxValue = 1.;
-                stdev = 1;
-            } else {
-                // use the minimum of noise2, noise3, and noise5 as the best
-                // noise value
-                stdev = noise3;
-                if (noise2 != 0. && noise2 < stdev) {
-                    stdev = noise2;
-                }
-                if (noise5 != 0. && noise5 < stdev) {
-                    stdev = noise5;
-                }
+                parameter.setMinValue(0.0);
+                parameter.setMaxValue(1.0);
+                return false;
             }
+
+            // use the minimum of noise2, noise3, and noise5 as the best
+            // noise value
+            stdev = noise3;
+            if (noise2 != 0. && noise2 < stdev) {
+                stdev = noise2;
+            }
+            if (noise5 != 0. && noise5 < stdev) {
+                stdev = noise5;
+            }
+
             if (parameter.getQLevel() == 0.) {
                 bScale = stdev / DEFAULT_QUANT_LEVEL; /* default quantization */
             } else {
@@ -442,7 +398,7 @@ public class Quantize {
         } else {
             /* negative value represents the absolute quantization level */
             bScale = -parameter.getQLevel();
-            /* only nned to calculate the min and max values */
+            /* only need to calculate the min and max values */
             calculateNoise(fdata, nxpix, nypix);
         }
         /* check that the range of quantized levels is not > range of int */
@@ -453,7 +409,8 @@ public class Quantize {
         parameter.setBScale(bScale);
         parameter.setMinValue(minValue);
         parameter.setMaxValue(maxValue);
-        parameter.setCheckNull(parameter.isCheckNull() && ngood != nx);
+        parameter.updateBZeroAndIntLimits();
+
         return true; /* yes, data have been quantized */
     }
 
@@ -524,8 +481,8 @@ public class Quantize {
     }
 
     private void setNoiseResult(long ngoodpix) {
-        minValue = xminval;
-        maxValue = xmaxval;
+        minValue = Double.isFinite(xminval) ? xminval : 0.0;
+        maxValue = Double.isFinite(xmaxval) ? xmaxval : 0.0;
         ngood = ngoodpix;
         noise2 = NOISE_2_MULTIPLICATOR * xnoise2;
         noise3 = NOISE_3_MULTIPLICATOR * xnoise3;

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
@@ -257,12 +257,14 @@ public class Quantize {
                 if (isNull(array.get(index))) {
                     continue;
                 }
+
                 if (array.get(index) < xminval) {
                     xminval = array.get(index);
                 }
                 if (array.get(index) > xmaxval) {
                     xmaxval = array.get(index);
                 }
+
                 ngoodpix++;
             }
             setNoiseResult(ngoodpix);
@@ -321,7 +323,7 @@ public class Quantize {
 
     @Deprecated
     protected boolean isNull(double d) {
-        return false;
+        return !parameter.isRegular(d);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -55,6 +55,8 @@ public class QuantizeOption implements ICompressOption {
      */
     private static final int NULL_VALUE = Integer.MIN_VALUE;
 
+    private static boolean useFMA = false;
+
     /** Shared configuration across copies */
     private Config config;
 
@@ -836,7 +838,7 @@ public class QuantizeOption implements ICompressOption {
             d -= nextDither();
         }
 
-        return d * bScale + bZero;
+        return useFMA ? Math.fma(d, bScale, bZero) : d * bScale + bZero;
     }
 
     void updateBZeroAndIntLimits() {
@@ -867,6 +869,34 @@ public class QuantizeOption implements ICompressOption {
         // shift the range to be close to the value used to represent null
         // values
         return minValue - bScale * (Integer.MIN_VALUE + N_RESERVED_VALUES + 1);
+    }
+
+    /**
+     * Selects whether {@link Math#fma(double, double, double)} should be used when converting quantized integers back
+     * to doubles. Othwerwise normal arithmetic is used, which is the default. CFITSIO and astropy both rely on
+     * <code>fma()</code>, which has better precision, but is not supported on some (older) architectures. When hardware
+     * support is lacking, you may expect a significant performance hit from the software implementation.
+     * 
+     * @param value <code>true</code> to use <code>fma()</code>, or else <code>false</code> to use regular arithmetics.
+     * 
+     * @see         #isUseFMA()
+     * 
+     * @since       1.23
+     */
+    public static void useFMA(boolean value) {
+        useFMA = value;
+    }
+
+    /**
+     * Checks whether {@link Math#fma(double, double, double)} is used for converting quantized integers back to
+     * doubles.
+     * 
+     * @return <code>true</code> if using <code>fma()</code>, or else <code>false</code> is using regular arithmetics.
+     * 
+     * @since  1.23
+     */
+    public static final boolean isUseFMA() {
+        return useFMA;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -836,8 +836,7 @@ public class QuantizeOption implements ICompressOption {
             d -= nextDither();
         }
 
-        return d * bScale + bZero;
-
+        return Math.fma(d, bScale, bZero);
     }
 
     void updateBZeroAndIntLimits() {

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -836,7 +836,7 @@ public class QuantizeOption implements ICompressOption {
             d -= nextDither();
         }
 
-        return Math.fma(d, bScale, bZero);
+        return d * bScale + bZero;
     }
 
     void updateBZeroAndIntLimits() {

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -764,10 +764,7 @@ public class QuantizeOption implements ICompressOption {
         nextRandom++;
 
         if (nextRandom >= RandomSequence.length()) {
-            iseed++;
-            if (iseed >= RandomSequence.length()) {
-                iseed = 0;
-            }
+            iseed = (iseed + 1) % RandomSequence.length();
             initI1();
         }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -53,7 +53,7 @@ public class QuantizeOption implements ICompressOption {
      * for the compressed values to slightly exceed the range of the actual (lossless) values so we must reserve a
      * little more space value used to represent undefined pixels
      */
-    private static final int NULL_VALUE = Integer.MIN_VALUE + 1;
+    private static final int NULL_VALUE = Integer.MIN_VALUE;
 
     /** Shared configuration across copies */
     private Config config;
@@ -86,6 +86,28 @@ public class QuantizeOption implements ICompressOption {
     private int tileHeight;
 
     private int tileWidth;
+
+    private static final double MAX_INT_AS_DOUBLE = Integer.MAX_VALUE;
+
+    /** Quantization constant */
+    private static final int RANDOM_MULTIPLICATOR = 500;
+
+    private static final double DITHER_HALF = 0.5;
+
+    /**
+     * number of reserved values, starting with
+     */
+    private static final long N_RESERVED_VALUES = 10;
+
+    /**
+     * Dither random seed value
+     */
+    private int iseed;
+
+    /**
+     * Next random dither value
+     */
+    private int nextRandom;
 
     QuantizeOption() {
         this(null);
@@ -484,7 +506,7 @@ public class QuantizeOption implements ICompressOption {
     @Deprecated
     public QuantizeOption setCheckNull(boolean value) {
         checkNull = value;
-        if (nullValueIndicator == null) {
+        if (value && nullValueIndicator == null) {
             nullValueIndicator = NULL_VALUE;
         }
         return this;
@@ -716,6 +738,139 @@ public class QuantizeOption implements ICompressOption {
             }
         }
         return null;
+    }
+
+    /**
+     * value used to represent zero-valued pixels
+     */
+    private static final int ZERO_VALUE = Integer.MIN_VALUE + 2;
+
+    /**
+     * Re-initialize the dither sequence.
+     */
+    void initDither() {
+        if (isDither() || isDither2()) {
+            iseed = (int) ((getSeed() + tileIndex - 1) % RandomSequence.length());
+            initI1();
+        }
+    }
+
+    private void initI1() {
+        nextRandom = (int) (RandomSequence.get(iseed) * RANDOM_MULTIPLICATOR);
+    }
+
+    private double nextDither() {
+        double d = RandomSequence.get(nextRandom) - DITHER_HALF;
+        nextRandom++;
+
+        if (nextRandom >= RandomSequence.length()) {
+            iseed++;
+            if (iseed >= RandomSequence.length()) {
+                iseed = 0;
+            }
+            initI1();
+        }
+
+        return d;
+    }
+
+    boolean isRegular(double x) {
+        if (!Double.isFinite(x)) {
+            return false;
+        }
+        if (checkNull && x == nullValue) {
+            return false;
+        }
+        if (isCheckZero() && x == 0.0) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Converts a floating point value to a quantized integer
+     * 
+     * @param  d a floating point value
+     * 
+     * @return   the equivalent quantized integer representation
+     * 
+     * @since    1.23
+     */
+    int toInt(double d) {
+        if (Double.isNaN(d) || (checkNull && d == nullValue)) {
+            if (nullValueIndicator == null) {
+                nullValueIndicator = NULL_VALUE;
+            }
+            return nullValueIndicator;
+        }
+
+        if (isCheckZero() && d == 0.0) {
+            return ZERO_VALUE;
+        }
+
+        d -= bZero;
+        d /= bScale;
+        if (isDither() || isDither2()) {
+            d += nextDither();
+        }
+        return (int) Math.round(d);
+    }
+
+    /**
+     * Converts a quantized integer value back to it's floating-point equivalent
+     * 
+     * @param  i a quantized integer value
+     * 
+     * @return   the equivalent floating point value
+     * 
+     * @since    1.23
+     */
+    double toDouble(int i) {
+        if (isCheckZero() && i == ZERO_VALUE) {
+            return 0.0;
+        }
+
+        if (checkNull && i == nullValueIndicator) {
+            return nullValue;
+        }
+
+        double d = i;
+        if (isDither() || isDither2()) {
+            d -= nextDither();
+        }
+
+        return d * bScale + bZero;
+
+    }
+
+    void updateBZeroAndIntLimits() {
+        setBZero(findBZero());
+        setIntMinValue((int) Math.floor((minValue - bZero) / bScale));
+        setIntMaxValue((int) Math.ceil((maxValue - bZero) / bScale));
+    }
+
+    double findBZero() {
+        if (!checkNull && !isCenterOnZero()) {
+            // don't have to check for nulls
+            // return all positive values, if possible since some compression
+            // algorithms either only work for positive integers, or are more
+            // efficient.
+            if ((maxValue - minValue) / bScale < MAX_INT_AS_DOUBLE - N_RESERVED_VALUES) {
+                // fudge the zero point so it is an integer multiple of bScale
+                // This helps to ensure the same scaling will be performed if
+                // the file undergoes multiple fpack/funpack cycles
+                // AK: round to multiple of bScale.
+                return minValue - Math.IEEEremainder(minValue, bScale);
+            }
+
+            /* center the quantized levels around zero */
+            return (minValue + maxValue) / 2.;
+        }
+
+        // data contains null values or has be forced to center on zero
+        // shift the range to be close to the value used to represent null
+        // values
+        return minValue - bScale * (Integer.MIN_VALUE + N_RESERVED_VALUES + 1);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeProcessor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeProcessor.java
@@ -1,5 +1,8 @@
 package nom.tam.fits.compression.algorithm.quant;
 
+import java.nio.Buffer;
+import java.nio.BufferOverflowException;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -45,33 +48,18 @@ import nom.tam.fits.compression.algorithm.api.ICompressor;
 public class QuantizeProcessor {
 
     public static class DoubleQuantCompressor extends QuantizeProcessor implements ICompressor<DoubleBuffer> {
-
-        private final ICompressor<IntBuffer> postCompressor;
-
         public DoubleQuantCompressor(QuantizeOption quantizeOption, ICompressor<IntBuffer> compressor) {
-            super(quantizeOption);
-            postCompressor = compressor;
+            super(quantizeOption, compressor);
         }
 
         @Override
         public boolean compress(DoubleBuffer buffer, ByteBuffer compressed) {
-            IntBuffer intData = IntBuffer.wrap(new int[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()]);
-            double[] doubles = new double[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()];
-            buffer.get(doubles);
-            if (!this.quantize(doubles, intData)) {
-                return false;
-            }
-            intData.rewind();
-            postCompressor.compress(intData, compressed);
-            return true;
+            return super.compressGeneric(buffer, compressed);
         }
 
         @Override
         public void decompress(ByteBuffer compressed, DoubleBuffer buffer) {
-            IntBuffer intData = IntBuffer.wrap(new int[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()]);
-            postCompressor.decompress(compressed, intData);
-            intData.rewind();
-            unquantize(intData, buffer);
+            super.decompressGeneric(compressed, buffer);
         }
     }
 
@@ -79,42 +67,18 @@ public class QuantizeProcessor {
      * TODO this is done very inefficient and should be refactored!
      */
     public static class FloatQuantCompressor extends QuantizeProcessor implements ICompressor<FloatBuffer> {
-
-        private final ICompressor<IntBuffer> postCompressor;
-
-        public FloatQuantCompressor(QuantizeOption quantizeOption, ICompressor<IntBuffer> postCompressor) {
-            super(quantizeOption);
-            this.postCompressor = postCompressor;
+        public FloatQuantCompressor(QuantizeOption quantizeOption, ICompressor<IntBuffer> compressor) {
+            super(quantizeOption, compressor);
         }
 
         @Override
         public boolean compress(FloatBuffer buffer, ByteBuffer compressed) {
-            float[] floats = new float[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()];
-            double[] doubles = new double[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()];
-            buffer.get(floats);
-            for (int index = 0; index < doubles.length; index++) {
-                doubles[index] = floats[index];
-            }
-            IntBuffer intData = IntBuffer.wrap(new int[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()]);
-            if (!this.quantize(doubles, intData)) {
-                return false;
-            }
-            intData.rewind();
-            postCompressor.compress(intData, compressed);
-            return true;
+            return super.compressGeneric(buffer, compressed);
         }
 
         @Override
         public void decompress(ByteBuffer compressed, FloatBuffer buffer) {
-            IntBuffer intData = IntBuffer.wrap(new int[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()]);
-            postCompressor.decompress(compressed, intData);
-            intData.rewind();
-            double[] doubles = new double[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()];
-            DoubleBuffer doubleBuffer = DoubleBuffer.wrap(doubles);
-            unquantize(intData, doubleBuffer);
-            for (double d : doubles) {
-                buffer.put((float) d);
-            }
+            super.decompressGeneric(compressed, buffer);
         }
     }
 
@@ -122,8 +86,11 @@ public class QuantizeProcessor {
 
     protected final QuantizeOption quantizeOption;
 
-    public QuantizeProcessor(QuantizeOption quantizeOption) {
+    private final ICompressor<IntBuffer> postCompressor;
+
+    public QuantizeProcessor(QuantizeOption quantizeOption, ICompressor<IntBuffer> compressor) {
         this.quantizeOption = quantizeOption;
+        this.postCompressor = compressor;
 
         if (quantizeOption.isDither2()) {
             quantizeOption.setCenterOnZero(true);
@@ -132,29 +99,147 @@ public class QuantizeProcessor {
         quantize = new Quantize(quantizeOption);
     }
 
+    protected QuantizeProcessor(QuantizeOption quantizeOption) {
+        this(quantizeOption, null);
+    }
+
     public Quantize getQuantize() {
         return quantize;
     }
 
-    public boolean quantize(double[] doubles, IntBuffer quants) {
-        boolean success = quantize.quantize(doubles, quantizeOption.getTileWidth(), quantizeOption.getTileHeight());
+    protected boolean compressGeneric(Buffer buffer, ByteBuffer compressed) throws BufferOverflowException {
+        IntBuffer intData = IntBuffer.wrap(new int[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()]);
+        if (!autoQuantize(buffer, intData)) {
+            return false;
+        }
+        intData.rewind();
+        postCompressor.compress(intData, compressed);
+        return true;
+    }
+
+    protected <BufferType extends Buffer> void decompressGeneric(ByteBuffer compressed, BufferType buffer)
+            throws BufferOverflowException {
+        IntBuffer intData = IntBuffer.wrap(new int[quantizeOption.getTileHeight() * quantizeOption.getTileWidth()]);
+        postCompressor.decompress(compressed, intData);
+        intData.rewind();
+        unquantizeGeneric(intData, buffer);
+    }
+
+    /**
+     * Quantizes floating-point data into integer representation. The quantization parameters are determined
+     * automatically based on the noise distribution of the input, and are stored in the qunatization options associated
+     * to this class.
+     * 
+     * @param  floating floating-point input
+     * @param  quants   quantized output
+     * 
+     * @return          <code>true</code> if quantization parameters were determined, otherwise <code>false</code>.
+     * 
+     * @since           1.23
+     */
+    protected boolean autoQuantize(Buffer floating, IntBuffer quants) {
+        boolean success = quantize.guessQuantization(floating);
         if (quants != null) {
-            quantize(DoubleBuffer.wrap(doubles, 0, quantizeOption.getTileWidth() * quantizeOption.getTileHeight()), quants);
+            quantizeGeneric(floating, quants);
         }
         return success;
     }
 
-    public void quantize(final DoubleBuffer fdata, final IntBuffer intData) {
+    /**
+     * @deprecated         use {@link #autoQuantize(DoubleBuffer, IntBuffer)} instead.
+     * 
+     * @param      doubles input array of doubles
+     * @param      quants  output array of integer quantized data
+     * 
+     * @return             <code>true</code> if successful, or else <code>false</code>.
+     */
+    @Deprecated
+    public boolean quantize(double[] doubles, IntBuffer quants) {
+        return autoQuantize(DoubleBuffer.wrap(doubles, 0, quantizeOption.getTileWidth() * quantizeOption.getTileHeight()),
+                quants);
+    }
+
+    private void quantizeGeneric(final Buffer fdata, final IntBuffer intData) throws BufferOverflowException {
+        if (fdata instanceof FloatBuffer) {
+            quantize((FloatBuffer) fdata, intData);
+        } else {
+            quantize((DoubleBuffer) fdata, intData);
+        }
+    }
+
+    private void unquantizeGeneric(final IntBuffer intData, final Buffer fdata) throws BufferOverflowException {
+        if (fdata instanceof FloatBuffer) {
+            unquantize(intData, (FloatBuffer) fdata);
+        } else {
+            unquantize(intData, (DoubleBuffer) fdata);
+        }
+    }
+
+    /**
+     * Converts floating point values into quantized integer representation.
+     * 
+     * @param  fdata                   floating-point input
+     * @param  intData                 quantized integer output
+     * 
+     * @throws BufferOverflowException if the output buffer is smaller than the input buffer.
+     * 
+     * @since                          1.23
+     */
+    protected void quantize(final FloatBuffer fdata, final IntBuffer intData) throws BufferOverflowException {
         quantizeOption.initDither();
         while (fdata.hasRemaining()) {
             intData.put(quantizeOption.toInt(fdata.get()));
         }
     }
 
-    public void unquantize(final IntBuffer intData, final DoubleBuffer fdata) {
+    /**
+     * Converts quantized integers back into the floating point values they represent.
+     * 
+     * @param  intData                 quantized integer input
+     * @param  fdata                   floating-point output
+     * 
+     * @throws BufferOverflowException if the output buffer is smaller than the input buffer.
+     * 
+     * @since                          1.23
+     */
+    protected void unquantize(final IntBuffer intData, final DoubleBuffer fdata) throws BufferOverflowException {
         quantizeOption.initDither();
         while (fdata.hasRemaining()) {
-            fdata.put(quantizeOption.toDouble(intData.get()));
+            fdata.put((float) quantizeOption.toDouble(intData.get()));
+        }
+    }
+
+    /**
+     * Converts floating point values into quantized integer representation.
+     * 
+     * @param  fdata                   floating-point input
+     * @param  intData                 quantized integer output
+     * 
+     * @throws BufferOverflowException if the output buffer is smaller than the input buffer.
+     * 
+     * @since                          1.23
+     */
+    protected void quantize(final DoubleBuffer fdata, final IntBuffer intData) throws BufferOverflowException {
+        quantizeOption.initDither();
+        while (fdata.hasRemaining()) {
+            intData.put(quantizeOption.toInt(fdata.get()));
+        }
+    }
+
+    /**
+     * Converts quantized integers back into the floating point values they represent.
+     * 
+     * @param  intData                 quantized integer input
+     * @param  fdata                   floating-point output
+     * 
+     * @throws BufferOverflowException if the output buffer is smaller than the input buffer.
+     * 
+     * @since                          1.23
+     */
+    protected void unquantize(final IntBuffer intData, final FloatBuffer fdata) throws BufferOverflowException {
+        quantizeOption.initDither();
+        while (fdata.hasRemaining()) {
+            fdata.put((float) quantizeOption.toDouble(intData.get()));
         }
     }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeProcessor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeProcessor.java
@@ -118,223 +118,18 @@ public class QuantizeProcessor {
         }
     }
 
-    private class BaseFilter extends PixelFilter {
-
-        BaseFilter() {
-            super(null);
-        }
-
-        @Override
-        protected void nextPixel() {
-        }
-
-        @Override
-        protected double toDouble(int pixel) {
-            return (pixel + ROUNDING_HALF) * bScale + bZero;
-        }
-
-        @Override
-        protected int toInt(double pixel) {
-            return nint((pixel - bZero) / bScale + ROUNDING_HALF);
-        }
-    }
-
-    private class DitherFilter extends PixelFilter {
-
-        private static final int RANDOM_MULTIPLICATOR = 500;
-
-        private int iseed = 0;
-
-        private int nextRandom = 0;
-
-        DitherFilter(long seed) {
-            super(null);
-            initialize(seed);
-        }
-
-        public void initialize(long ditherSeed) {
-            iseed = (int) ((ditherSeed - 1) % RandomSequence.length());
-            initI1();
-        }
-
-        private void initI1() {
-            nextRandom = (int) (RandomSequence.get(iseed) * RANDOM_MULTIPLICATOR);
-        }
-
-        public double nextRandom() {
-            return RandomSequence.get(nextRandom);
-        }
-
-        @Override
-        protected void nextPixel() {
-            nextRandom++;
-            if (nextRandom >= RandomSequence.length()) {
-                iseed++;
-                if (iseed >= RandomSequence.length()) {
-                    iseed = 0;
-                }
-                initI1();
-            }
-        }
-
-        @Override
-        protected double toDouble(int pixel) {
-            return (pixel - nextRandom() + ROUNDING_HALF) * bScale + bZero;
-        }
-
-        @Override
-        protected int toInt(double pixel) {
-            return nint((pixel - bZero) / bScale + nextRandom() - ROUNDING_HALF);
-        }
-    }
-
-    private static class NullFilter extends PixelFilter {
-
-        private final double nullValue;
-
-        private final boolean isNaN;
-
-        private final int nullValueIndicator;
-
-        NullFilter(double nullValue, int nullValueIndicator, PixelFilter next) {
-            super(next);
-            this.nullValue = nullValue;
-            isNaN = Double.isNaN(this.nullValue);
-            this.nullValueIndicator = nullValueIndicator;
-        }
-
-        public final boolean isNull(double pixel) {
-            return isNaN ? Double.isNaN(pixel) : nullValue == pixel;
-        }
-
-        @Override
-        protected double toDouble(int pixel) {
-            if (pixel == nullValueIndicator) {
-                return nullValue;
-            }
-            return super.toDouble(pixel);
-        }
-
-        @Override
-        protected int toInt(double pixel) {
-            if (isNull(pixel)) {
-                return nullValueIndicator;
-            }
-            return super.toInt(pixel);
-        }
-    }
-
-    private static class PixelFilter {
-
-        private final PixelFilter next;
-
-        protected PixelFilter(PixelFilter next) {
-            this.next = next;
-        }
-
-        protected void nextPixel() {
-            next.nextPixel();
-        }
-
-        protected double toDouble(int pixel) {
-            return next.toDouble(pixel);
-        }
-
-        protected int toInt(double pixel) {
-            return next.toInt(pixel);
-        }
-    }
-
-    private static class ZeroFilter extends PixelFilter {
-
-        ZeroFilter(PixelFilter next) {
-            super(next);
-        }
-
-        @Override
-        protected double toDouble(int pixel) {
-            if (pixel == ZERO_VALUE) {
-                return 0.0;
-            }
-            return super.toDouble(pixel);
-        }
-
-        @Override
-        protected int toInt(double pixel) {
-            if (pixel == 0.0) {
-                return ZERO_VALUE;
-            }
-            return super.toInt(pixel);
-        }
-    }
-
-    private static final double MAX_INT_AS_DOUBLE = Integer.MAX_VALUE;
-
-    /**
-     * number of reserved values, starting with
-     */
-    private static final long N_RESERVED_VALUES = 10;
-
-    private static final double ROUNDING_HALF = 0.5;
-
-    /**
-     * value used to represent zero-valued pixels
-     */
-    private static final int ZERO_VALUE = Integer.MIN_VALUE + 2;
-
-    private final boolean centerOnZero;
-
-    private final PixelFilter pixelFilter;
-
-    private double bScale;
-
-    private double bZero;
-
     private Quantize quantize;
 
     protected final QuantizeOption quantizeOption;
 
     public QuantizeProcessor(QuantizeOption quantizeOption) {
         this.quantizeOption = quantizeOption;
-        bScale = quantizeOption.getBScale();
-        bZero = quantizeOption.getBZero();
-        PixelFilter filter = null;
-        boolean localCenterOnZero = quantizeOption.isCenterOnZero();
+
         if (quantizeOption.isDither2()) {
-            filter = new DitherFilter(quantizeOption.getSeed() + quantizeOption.getTileIndex());
-            localCenterOnZero = true;
+            quantizeOption.setCenterOnZero(true);
             quantizeOption.setCheckZero(true);
-        } else if (quantizeOption.isDither()) {
-            filter = new DitherFilter(quantizeOption.getSeed() + quantizeOption.getTileIndex());
-        } else {
-            filter = new BaseFilter();
         }
-        if (quantizeOption.isCheckZero()) {
-            filter = new ZeroFilter(filter);
-        }
-        if (quantizeOption.isCheckNull()) {
-            final NullFilter nullFilter = new NullFilter(quantizeOption.getNullValue(), quantizeOption.getBNull(), filter);
-            filter = nullFilter;
-            quantize = new Quantize(quantizeOption) {
-
-                @Override
-                protected int findNextValidPixelWithNullCheck(int nx, DoubleArrayPointer rowpix, int ii) {
-                    while (ii < nx && nullFilter.isNull(rowpix.get(ii))) {
-                        ii++;
-                    }
-                    return ii;
-                }
-
-                @Override
-                protected boolean isNull(double d) {
-                    return nullFilter.isNull(d);
-                }
-            };
-        } else {
-            quantize = new Quantize(quantizeOption);
-        }
-        pixelFilter = filter;
-        centerOnZero = localCenterOnZero;
+        quantize = new Quantize(quantizeOption);
     }
 
     public Quantize getQuantize() {
@@ -343,65 +138,24 @@ public class QuantizeProcessor {
 
     public boolean quantize(double[] doubles, IntBuffer quants) {
         boolean success = quantize.quantize(doubles, quantizeOption.getTileWidth(), quantizeOption.getTileHeight());
-        if (success) {
-            calculateBZeroAndBscale();
+        if (quants != null) {
             quantize(DoubleBuffer.wrap(doubles, 0, quantizeOption.getTileWidth() * quantizeOption.getTileHeight()), quants);
         }
         return success;
     }
 
     public void quantize(final DoubleBuffer fdata, final IntBuffer intData) {
+        quantizeOption.initDither();
         while (fdata.hasRemaining()) {
-            intData.put(pixelFilter.toInt(fdata.get()));
-            pixelFilter.nextPixel();
+            intData.put(quantizeOption.toInt(fdata.get()));
         }
     }
 
     public void unquantize(final IntBuffer intData, final DoubleBuffer fdata) {
+        quantizeOption.initDither();
         while (fdata.hasRemaining()) {
-            fdata.put(pixelFilter.toDouble(intData.get()));
-            pixelFilter.nextPixel();
+            fdata.put(quantizeOption.toDouble(intData.get()));
         }
     }
 
-    private void calculateBZeroAndBscale() {
-        bScale = quantizeOption.getBScale();
-        bZero = zeroCenter();
-        quantizeOption.setIntMinValue(nint((quantizeOption.getMinValue() - bZero) / bScale));
-        quantizeOption.setIntMaxValue(nint((quantizeOption.getMaxValue() - bZero) / bScale));
-        quantizeOption.setBZero(bZero);
-    }
-
-    private int nint(double x) {
-        return x >= 0. ? (int) (x + ROUNDING_HALF) : (int) (x - ROUNDING_HALF);
-    }
-
-    private double zeroCenter() {
-        final double minValue = quantizeOption.getMinValue();
-        final double maxValue = quantizeOption.getMaxValue();
-        double evaluatedBZero;
-        if (!quantizeOption.isCheckNull() && !centerOnZero) {
-            // don't have to check for nulls
-            // return all positive values, if possible since some compression
-            // algorithms either only work for positive integers, or are more
-            // efficient.
-            if ((maxValue - minValue) / bScale < MAX_INT_AS_DOUBLE - N_RESERVED_VALUES) {
-                evaluatedBZero = minValue;
-                // fudge the zero point so it is an integer multiple of bScale
-                // This helps to ensure the same scaling will be performed if
-                // the file undergoes multiple fpack/funpack cycles
-                long iqfactor = (long) (evaluatedBZero / bScale + ROUNDING_HALF);
-                evaluatedBZero = iqfactor * bScale;
-            } else {
-                /* center the quantized levels around zero */
-                evaluatedBZero = (minValue + maxValue) / 2.;
-            }
-        } else {
-            // data contains null values or has be forced to center on zero
-            // shift the range to be close to the value used to represent null
-            // values
-            evaluatedBZero = minValue - bScale * (Integer.MIN_VALUE + N_RESERVED_VALUES + 1);
-        }
-        return evaluatedBZero;
-    }
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressColumnParameter.java
@@ -95,7 +95,7 @@ public interface ICompressColumnParameter extends ICompressParameter {
      * @see               #getColumnData()
      * 
      * @deprecated        Use {@link #setColumnData(Object)} or {@link #createColumnData(int)} or
-     *                        {@link #ensureColumnData(int)} instead.
+     *                        {@link #setColumnSize(int)} instead.
      */
     @Deprecated
     void setColumnData(Object column, int size);
@@ -114,12 +114,12 @@ public interface ICompressColumnParameter extends ICompressParameter {
 
     /**
      * Creates new data for this column parameter. All parameters in the new column data will be initialized to its
-     * default value.
+     * default value, and all previously defined column parameters will be discarded.
      *
      * @param size The number of compressed rows in the table. It it is zero or negative, any prior column data will be
      *                 discarded and <code>null</code> will be set.
      * 
-     * @see        #ensureColumnData(int)
+     * @see        #setColumnSize(int)
      * @see        #getColumnData()
      * 
      * @since      1.23
@@ -139,7 +139,7 @@ public interface ICompressColumnParameter extends ICompressParameter {
      * 
      * @since      1.23
      */
-    void ensureColumnData(int size);
+    void setColumnSize(int size);
 
     /**
      * @deprecated        Provided for back compatibility only. Use {@link #setColumnData(Object, int)} instead.

--- a/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/api/ICompressColumnParameter.java
@@ -69,9 +69,12 @@ public interface ICompressColumnParameter extends ICompressParameter {
     }
 
     /**
-     * @deprecated Provided for back compatibility only. Use {@link #getColumnData()} instead.
-     *
-     * @return     The array that contains the data for each compressed row.
+     * @deprecated Provided for back compatibility only. Use {@link #getColumnData()} instead. Returns the existing
+     *                 columm data for this parameter, or if there is no data specified yet, it returns the freshly
+     *                 created column data initialized to the default value of this parameters.
+     * 
+     * @return     a valid instance of the column data, either as previously specified, or initialized with the default
+     *                 values.
      */
     @Deprecated
     default Object initializedColumn() {
@@ -83,15 +86,60 @@ public interface ICompressColumnParameter extends ICompressParameter {
      * compressed table. To discard prior column data with no replacement, you can call this as
      * <code>setColumnData(null, 0)</code>.
      *
-     * @param column The array that contains the data for each compressed row. If not <code>null</code> the
-     *                   <code>size</code> parameter is ignored, and the size of the array is used instead.
-     * @param size   The number of compressed rows in the table, if the <code>column</code> argument is
-     *                   <code>null</code>. If <code>size</code> is zero or negative, any prior column data will be
-     *                   discarded and <code>null</code> will be set.
-     *
-     * @see          #getColumnData()
+     * @param      column The array that contains the data for each compressed row. If not <code>null</code> the
+     *                        <code>size</code> parameter is ignored, and the size of the array is used instead.
+     * @param      size   The number of compressed rows in the table, if the <code>column</code> argument is
+     *                        <code>null</code>. If <code>size</code> is zero or negative, any prior column data will be
+     *                        discarded and <code>null</code> will be set.
+     * 
+     * @see               #getColumnData()
+     * 
+     * @deprecated        Use {@link #setColumnData(Object)} or {@link #createColumnData(int)} or
+     *                        {@link #ensureColumnData(int)} instead.
      */
+    @Deprecated
     void setColumnData(Object column, int size);
+
+    /**
+     * Sets new parameter data for each compressed row to be stored along as a separate parameter column in the
+     * compressed table.
+     *
+     * @param data The array that contains the data for each compressed row or <code>null</code> to discard prior data.
+     * 
+     * @see        #getColumnData()
+     * 
+     * @since      1.23
+     */
+    void setColumnData(Object data);
+
+    /**
+     * Creates new data for this column parameter. All parameters in the new column data will be initialized to its
+     * default value.
+     *
+     * @param size The number of compressed rows in the table. It it is zero or negative, any prior column data will be
+     *                 discarded and <code>null</code> will be set.
+     * 
+     * @see        #ensureColumnData(int)
+     * @see        #getColumnData()
+     * 
+     * @since      1.23
+     */
+    void createColumnData(int size);
+
+    /**
+     * Ensures that the column has the right number of parameters, creating new data or resizing the existing data as
+     * necessary. If the column data is resized, the existing elements will be preserved up to the new size. Any
+     * parameters that were not previously present will be initialized to their default value.
+     *
+     * @param size The number of compressed rows in the table. It it is zero or negative, any prior column data will be
+     *                 discarded and <code>null</code> will be set.
+     * 
+     * @see        #createColumnData(int)
+     * @see        #getColumnData()
+     * 
+     * @since      1.23
+     */
+    void ensureColumnData(int size);
 
     /**
      * @deprecated        Provided for back compatibility only. Use {@link #setColumnData(Object, int)} instead.

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/BundledParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/BundledParameters.java
@@ -129,6 +129,33 @@ public class BundledParameters extends CompressParameters {
     }
 
     @Override
+    protected ICompressColumnParameter[] activeColumnParameters() {
+        ArrayList<ICompressColumnParameter> list = new ArrayList<>();
+
+        for (ICompressParameters parms : bundle) {
+            for (ICompressColumnParameter p : ((CompressParameters) parms).activeColumnParameters()) {
+                list.add(p);
+            }
+        }
+
+        ICompressColumnParameter[] array = new ICompressColumnParameter[list.size()];
+        return list.toArray(array);
+    }
+
+    @Override
+    protected ICompressHeaderParameter[] activeHeaderParameters() {
+        ArrayList<ICompressHeaderParameter> list = new ArrayList<>();
+        for (ICompressParameters parms : bundle) {
+            for (ICompressHeaderParameter p : ((CompressParameters) parms).activeHeaderParameters()) {
+                list.add(p);
+            }
+        }
+
+        ICompressHeaderParameter[] array = new ICompressHeaderParameter[list.size()];
+        return list.toArray(array);
+    }
+
+    @Override
     public void setTileIndex(int index) {
         for (ICompressParameters parms : bundle) {
             parms.setTileIndex(index);

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
@@ -50,7 +50,8 @@ import nom.tam.fits.compression.provider.param.api.ICompressColumnParameter;
  * @author          Attila Kovacs
  *
  * @param  <T>      The generic array type that contains the individual parameters for each tile as a table column.
- * @param  <OPTION> The generic type of compression option that is associated with these parameters
+ * @param  <OPTION> The generic type of compression option that is associated with these parameters. It should not be
+ *                      <code>null</code>.
  */
 public abstract class CompressColumnParameter<T, OPTION> extends CompressParameter<OPTION>
         implements ICompressColumnParameter {
@@ -63,7 +64,7 @@ public abstract class CompressColumnParameter<T, OPTION> extends CompressParamet
      * Creates a new compression parameter, which stores a per-tile value for a compression option in a table column.
      * 
      * @param name   the FITS parameter name, that is the column name which stores the values
-     * @param option the compression option that uses the parameter value
+     * @param option the compression option that uses the parameter value. It should not be <code>null</code>.
      * @param type   the Java class of the parameter, such as {@link java.lang.Integer} or {@link java.lang.String}.
      */
     protected CompressColumnParameter(String name, OPTION option, Class<T> type) {

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
@@ -102,7 +102,7 @@ public abstract class CompressColumnParameter<T, OPTION> extends CompressParamet
     }
 
     @Override
-    public void ensureColumnData(int size) {
+    public void setColumnSize(int size) {
         T data = getColumnData();
 
         if (data == null) {

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressColumnParameter.java
@@ -56,7 +56,7 @@ public abstract class CompressColumnParameter<T, OPTION> extends CompressParamet
         implements ICompressColumnParameter {
 
     private Data column;
-
+    private Object lock = new Object();
     private final Class<T> type;
 
     /**
@@ -74,17 +74,60 @@ public abstract class CompressColumnParameter<T, OPTION> extends CompressParamet
 
     @Override
     public T getColumnData() {
-        synchronized (column) {
+        synchronized (lock) {
             return column.getValues();
         }
     }
 
     @Override
+    @Deprecated
     public void setColumnData(Object columnValue, int sizeValue) {
-        synchronized (column) {
-            column.create(columnValue, sizeValue);
+        synchronized (lock) {
+            if (columnValue != null) {
+                setColumnData(columnValue);
+            } else {
+                createColumnData(sizeValue);
+            }
         }
     }
+
+    @Override
+    public void setColumnData(Object data) {
+        column.set(data);
+    }
+
+    @Override
+    public void createColumnData(int size) {
+        column.create(size);
+    }
+
+    @Override
+    public void ensureColumnData(int size) {
+        T data = getColumnData();
+
+        if (data == null) {
+            column.create(size);
+        } else if (Array.getLength(data) != size) {
+            T next = column.create(size);
+
+            // Copy over the existing elements...
+            int to = Math.min(Array.getLength(data), size);
+            for (int i = 0; i < to; i++) {
+                Array.set(next, i, Array.get(data, i));
+            }
+        }
+    }
+
+    /**
+     * The default value that new column data should be initialized with.
+     * 
+     * @return the default value for this parameter, until specified otherwise.
+     * 
+     * @since  1.23
+     * 
+     * @see    #createColumnData(int)
+     */
+    protected abstract Object getInitValue();
 
     /**
      * The shared column data across all copies and the original column parameter.
@@ -100,15 +143,20 @@ public abstract class CompressColumnParameter<T, OPTION> extends CompressParamet
             return values;
         }
 
-        private void create(Object columnValue, int sizeValue) {
-            if (sizeValue <= 0) {
-                values = null;
-            } else {
-                if (columnValue == null) {
-                    columnValue = Array.newInstance(type.getComponentType(), sizeValue);
+        private void set(Object columnValue) {
+            values = type.cast(columnValue);
+        }
+
+        private T create(int size) {
+            if (size > 0) {
+                values = type.cast(Array.newInstance(type.getComponentType(), size));
+                for (int i = 0; i < size; i++) {
+                    Array.set(values, i, getInitValue());
                 }
-                values = type.cast(columnValue);
+            } else {
+                values = null;
             }
+            return values;
         }
     }
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressHeaderParameter.java
@@ -49,6 +49,12 @@ import static nom.tam.fits.header.Compression.ZVALn;
 public abstract class CompressHeaderParameter<OPTION> extends CompressParameter<OPTION>
         implements ICompressHeaderParameter {
 
+    /**
+     * Instantiates a new compression parameter associated to a header value.
+     * 
+     * @param name   the FITS parameter name, that is the column name which stores the values
+     * @param option the compression option that uses the parameter value. It should not be <code>null</code>.
+     */
     protected CompressHeaderParameter(String name, OPTION option) {
         super(name, option);
     }

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameter.java
@@ -53,7 +53,8 @@ public class CompressParameter<OPTION> implements Cloneable {
      * be linked with.
      * 
      * @param name   the FITS header keyword or binary table column name that records this parameter in the FITS.
-     * @param option the compression option instance that this parameter is linked to.
+     * @param option the compression option instance that this parameter is linked to. It should not be
+     *                   <code>null</code>.
      */
     protected CompressParameter(String name, OPTION option) {
         this.name = name;

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
@@ -53,7 +53,7 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
 
     @Override
     public void addColumnsToTable(BinaryTableHDU hdu) throws FitsException {
-        for (ICompressColumnParameter parameter : columnParameters()) {
+        for (ICompressColumnParameter parameter : activeColumnParameters()) {
             Object column = parameter.getColumnData();
             if (column != null) {
                 hdu.setColumnName(hdu.addColumn(column) - 1, parameter.getName(), null);
@@ -99,7 +99,7 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
     @Override
     public void initializeColumns(int size) {
         for (ICompressColumnParameter parameter : columnParameters()) {
-            parameter.ensureColumnData(size);
+            parameter.setColumnSize(size);
         }
     }
 
@@ -112,7 +112,7 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
 
     @Override
     public void setValuesInHeader(Header header) throws HeaderCardException {
-        for (ICompressHeaderParameter parameter : headerParameters()) {
+        for (ICompressHeaderParameter parameter : activeHeaderParameters()) {
             parameter.setValueInHeader(header);
         }
     }
@@ -131,11 +131,12 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
     }
 
     /**
-     * Retuens the subset of parameters from within, which are recorded in compressed table columns along with the
-     * compressed data.
+     * Returns the complete subset of parameters from within, which are recorded in compressed table columns along with
+     * the compressed data.
      * 
      * @return the subset of parameters that are recorded in compressed table columns.
      * 
+     * @see    #activeColumnParameters()
      * @see    #headerParameters()
      */
     protected ICompressColumnParameter[] columnParameters() {
@@ -143,11 +144,42 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
     }
 
     /**
-     * Returns the subset of parameters from within, which are recorded in the header of the compressed HDU.
+     * Returns the complete subset of parameters from within, which are recorded in the header of the compressed HDU.
      * 
      * @return the subset of parameters that are recorded in the compressed HDU's header.
      * 
+     * @see    #activeHeaderParameters()
      * @see    #columnParameters()
      */
     protected abstract ICompressHeaderParameter[] headerParameters();
+
+    /**
+     * Returns the subset of active parameters from within, which should be recorded in compressed table columns along
+     * with the compressed data.
+     * 
+     * @return the subset of parameters that are recorded in compressed table columns.
+     * 
+     * @see    #columnParameters()
+     * @see    #activeHeaderParameters()
+     * 
+     * @since  1.23
+     */
+    protected ICompressColumnParameter[] activeColumnParameters() {
+        return columnParameters();
+    }
+
+    /**
+     * Returns the subset of active parameters from within, which should be recorded in the header of the compressed
+     * HDU.
+     * 
+     * @return the subset of parameters that are recorded in the compressed HDU's header.
+     * 
+     * @see    #headerParameters()
+     * @see    #activeColumnParameters()
+     * 
+     * @since  1.23
+     */
+    protected ICompressHeaderParameter[] activeHeaderParameters() {
+        return headerParameters();
+    }
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/base/CompressParameters.java
@@ -92,14 +92,14 @@ public abstract class CompressParameters implements ICompressParameters, Cloneab
     public void initializeColumns(Header header, BinaryTable binaryTable, int size)
             throws HeaderCardException, FitsException {
         for (ICompressColumnParameter parameter : columnParameters()) {
-            parameter.setColumnData(getNullableColumn(header, binaryTable, parameter.getName()), size);
+            parameter.setColumnData(getNullableColumn(header, binaryTable, parameter.getName()));
         }
     }
 
     @Override
     public void initializeColumns(int size) {
         for (ICompressColumnParameter parameter : columnParameters()) {
-            parameter.setColumnData(null, size);
+            parameter.ensureColumnData(size);
         }
     }
 

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
@@ -78,7 +78,7 @@ public class QuantizeParameters extends CompressParameters {
     }
 
     private Integer getCurrentZBlank() {
-        return options == null ? null : options.getBNull();
+        return options.getBNull();
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
@@ -58,6 +58,8 @@ public class QuantizeParameters extends CompressParameters {
 
     private ZScaleColumnParameter scale;
 
+    private QuantizeOption options;
+
     /**
      * Creates a set of compression parameters used for quantization of floating point data. Quantization is the process
      * of representing floating-point values by integers.
@@ -66,12 +68,17 @@ public class QuantizeParameters extends CompressParameters {
      */
     @SuppressWarnings("deprecation")
     public QuantizeParameters(QuantizeOption option) {
+        options = option;
         quantz = new ZQuantizeParameter(option);
         blank = new ZBlankParameter(option);
         seed = new ZDither0Parameter(option);
         blankColumn = new ZBlankColumnParameter(option);
         zero = new ZZeroColumnParameter(option);
         scale = new ZScaleColumnParameter(option);
+    }
+
+    private Integer getCurrentZBlank() {
+        return options == null ? null : options.getBNull();
     }
 
     @Override
@@ -81,6 +88,26 @@ public class QuantizeParameters extends CompressParameters {
 
     @Override
     protected ICompressHeaderParameter[] headerParameters() {
+        return new ICompressHeaderParameter[] {quantz, blank, seed};
+    }
+
+    @Override
+    protected ICompressColumnParameter[] activeColumnParameters() {
+        if (blankColumn.differsFrom(getCurrentZBlank())) {
+            // We have per-tile blanking values
+            return new ICompressColumnParameter[] {blankColumn, zero, scale};
+        }
+        return new ICompressColumnParameter[] {zero, scale};
+    }
+
+    @Override
+    protected ICompressHeaderParameter[] activeHeaderParameters() {
+        Integer zblank = getCurrentZBlank();
+
+        if (zblank == null || blankColumn.differsFrom(zblank)) {
+            // We have per-tile blanking values
+            return new ICompressHeaderParameter[] {quantz, seed};
+        }
         return new ICompressHeaderParameter[] {quantz, blank, seed};
     }
 

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
@@ -60,16 +60,36 @@ public final class ZBlankColumnParameter extends CompressColumnParameter<int[], 
 
     @Override
     public void setValueInColumn(int index) {
-        Integer blankValue = Integer.MIN_VALUE;
-
-        if (getOption().getBNull() != null) {
-            blankValue = getOption().getBNull();
-        }
-
         int[] col = getColumnData();
         if (col != null) {
-            col[index] = blankValue;
+            Integer blankValue = getOption().getBNull();
+            col[index] = blankValue == null ? getInitValue() : blankValue;
         }
+    }
+
+    /**
+     * Checks if any of the column entries differs from the specified 'standard' value.
+     * 
+     * @param  value the 'standard' value
+     * 
+     * @return       <code>true</code> if any column entry differs from the specified value. Otherwise
+     *                   <code>false</code>.
+     * 
+     * @since        1.23
+     */
+    boolean differsFrom(Integer value) {
+        int[] col = getColumnData();
+        if (col != null) {
+            if (value == null) {
+                return true;
+            }
+            for (int entry : col) {
+                if (entry != value) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
@@ -52,14 +52,10 @@ public final class ZBlankColumnParameter extends CompressColumnParameter<int[], 
 
     @Override
     public void getValueFromColumn(int index) {
-        if (getOption().isCheckNull()) {
-            int[] col = getColumnData();
-            if (col != null) {
-                getOption().setBNull(col[index]);
-                return;
-            }
+        int[] col = getColumnData();
+        if (col != null) {
+            getOption().setBNull(col[index]);
         }
-        getOption().setBNull(null);
     }
 
     @Override
@@ -74,5 +70,10 @@ public final class ZBlankColumnParameter extends CompressColumnParameter<int[], 
         if (col != null) {
             col[index] = blankValue;
         }
+    }
+
+    @Override
+    protected Integer getInitValue() {
+        return Integer.MIN_VALUE;
     }
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
@@ -59,7 +59,7 @@ public final class ZBlankColumnParameter extends CompressColumnParameter<int[], 
     }
 
     @Override
-    public void setValueInColumn(int index) {
+    public void setValueInColumn(int index) throws IndexOutOfBoundsException {
         int[] col = getColumnData();
         if (col != null) {
             Integer blankValue = getOption().getBNull();

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankParameter.java
@@ -56,7 +56,7 @@ final class ZBlankParameter extends CompressHeaderParameter<QuantizeOption> {
 
         HeaderCard card = header.getCard(getName());
         if (card != null) {
-            getOption().setBNull(card.getValue(Integer.class, getOption().getBNull()));
+            getOption().setBNull(card.getValue(Integer.class, null));
         }
     }
 

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankParameter.java
@@ -50,10 +50,6 @@ final class ZBlankParameter extends CompressHeaderParameter<QuantizeOption> {
 
     @Override
     public void getValueFromHeader(Header header) throws HeaderCardException {
-        if (getOption() == null) {
-            return;
-        }
-
         HeaderCard card = header.getCard(getName());
         if (card != null) {
             getOption().setBNull(card.getValue(Integer.class, null));
@@ -62,10 +58,6 @@ final class ZBlankParameter extends CompressHeaderParameter<QuantizeOption> {
 
     @Override
     public void setValueInHeader(Header header) throws HeaderCardException {
-        if (getOption() == null) {
-            return;
-        }
-
         Integer blank = getOption().getBNull();
         if (blank != null) {
             header.addValue(Compression.ZBLANK, blank);

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZDither0Parameter.java
@@ -84,20 +84,12 @@ final class ZDither0Parameter extends CompressHeaderParameter<QuantizeOption> {
 
     @Override
     public void getValueFromHeader(Header header) throws HeaderCardException {
-        if (getOption() == null) {
-            return;
-        }
-
         HeaderCard card = header.getCard(Compression.ZDITHER0);
         getOption().setSeed(card == null ? 1L : card.getValue(Long.class, 1L));
     }
 
     @Override
     public void setValueInHeader(Header header) throws HeaderCardException {
-        if (getOption() == null) {
-            return;
-        }
-
         header.addValue(Compression.ZDITHER0, (int) getOption().getSeed());
     }
 

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZQuantizeParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZQuantizeParameter.java
@@ -50,10 +50,6 @@ final class ZQuantizeParameter extends CompressHeaderParameter<QuantizeOption> {
 
     @Override
     public void getValueFromHeader(Header header) throws HeaderCardException {
-        if (getOption() == null) {
-            return;
-        }
-
         HeaderCard card = header.getCard(getName());
         String value = card != null ? card.getValue() : null;
 
@@ -70,10 +66,6 @@ final class ZQuantizeParameter extends CompressHeaderParameter<QuantizeOption> {
 
     @Override
     public void setValueInHeader(Header header) throws HeaderCardException {
-        if (getOption() == null) {
-            return;
-        }
-
         String value;
 
         if (getOption().isDither2()) {

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZScaleColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZScaleColumnParameter.java
@@ -51,13 +51,14 @@ final class ZScaleColumnParameter extends CompressColumnParameter<double[], Quan
 
     @Override
     public void setValueInColumn(int index) {
-        if (getColumnData() == null) {
-            return;
-        }
-
         if (!Double.isNaN(getOption().getBScale())) {
             getColumnData()[index] = getOption().getBScale();
         }
+    }
+
+    @Override
+    protected Double getInitValue() {
+        return 1.0;
     }
 
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZZeroColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZZeroColumnParameter.java
@@ -51,10 +51,6 @@ final class ZZeroColumnParameter extends CompressColumnParameter<double[], Quant
 
     @Override
     public void setValueInColumn(int index) {
-        if (getColumnData() == null) {
-            return;
-        }
-
         if (!Double.isNaN(getOption().getBZero())) {
             getColumnData()[index] = getOption().getBZero();
         }
@@ -62,7 +58,6 @@ final class ZZeroColumnParameter extends CompressColumnParameter<double[], Quant
 
     @Override
     protected Double getInitValue() {
-        return 0.0;
+        return Double.NaN;
     }
-
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZZeroColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZZeroColumnParameter.java
@@ -60,4 +60,9 @@ final class ZZeroColumnParameter extends CompressColumnParameter<double[], Quant
         }
     }
 
+    @Override
+    protected Double getInitValue() {
+        return 0.0;
+    }
+
 }

--- a/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
+++ b/src/main/java/nom/tam/fits/utilities/FitsCheckSum.java
@@ -413,7 +413,7 @@ public final class FitsCheckSum {
      *
      * @param  checksum The calculated 32-bit (unsigned) checksum
      * @param  compl    If <code>true</code> the complement of the specified value will be encoded. Otherwise, the value
-     *                      as is will be encoded. (FITS normally uses the complemenyed value).
+     *                      as is will be encoded. (FITS normally uses the complemented value).
      *
      * @return          The encoded checksum, suitably encoded for use with the CHECKSUM header
      *

--- a/src/main/java/nom/tam/image/compression/tile/TileCompressor.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileCompressor.java
@@ -89,6 +89,7 @@ public class TileCompressor extends TileCompressionOperation {
     private void compress() {
         synchronized (lock) {
             initTileOptions();
+            getTiledImageOperation().ensureColumnParameters();
 
             compressedData.limit(getTileBuffer().getPixelSize() * getBaseType().size());
             compressionType = TileCompressionType.COMPRESSED;

--- a/src/main/java/nom/tam/image/compression/tile/TileDecompressorInitialisation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TileDecompressorInitialisation.java
@@ -82,6 +82,6 @@ final class TileDecompressorInitialisation implements ITileOperationInitialisati
     @Override
     public void tileCount(int tileCount) throws FitsException {
         imageTilesOperation.compressOptions().getCompressionParameters().initializeColumns(header,
-                imageTilesOperation.getBinaryTable(), tileCount);
+                imageTilesOperation.getBinaryTable(), 0);
     }
 }

--- a/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
+++ b/src/main/java/nom/tam/image/compression/tile/TiledImageCompressionOperation.java
@@ -154,10 +154,14 @@ public class TiledImageCompressionOperation extends AbstractTiledImageOperation<
                     h.addLine(HeaderCard.create(ZQUANTIZ, quantAlgorithm));
                     compressOptions.getCompressionParameters().getValuesFromHeader(h);
                 }
-                compressOptions.getCompressionParameters().initializeColumns(getNumberOfTileOperations());
             }
             return compressOptions;
         }
+    }
+
+    @Override
+    public void ensureColumnParameters() {
+        compressOptions.getCompressionParameters().initializeColumns(getNumberOfTileOperations());
     }
 
     public Buffer decompress() {

--- a/src/main/java/nom/tam/image/tile/operation/ITiledImageOperation.java
+++ b/src/main/java/nom/tam/image/tile/operation/ITiledImageOperation.java
@@ -47,11 +47,18 @@ import nom.tam.util.type.ElementType;
  */
 public interface ITiledImageOperation {
     /**
-     * Retuers the tile compression options to use for tile compressing or uncompressing images.
+     * Returns the tile compression options to use for tile compressing or uncompressing images.
      * 
      * @return the tile compression options
      */
     ICompressOption compressOptions();
+
+    /**
+     * Ensure that per-tile compression parameters exists, and contain reasonable data for every tile.
+     * 
+     * @since 1.23
+     */
+    void ensureColumnParameters();
 
     /**
      * Returns the element type of the image (and hence tile).

--- a/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
+++ b/src/test/java/nom/tam/fits/compression/ReadWriteProvidedCompressedImageTest.java
@@ -61,11 +61,6 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.WindowConstants;
 
-import nom.tam.fits.HeaderCardException;
-import nom.tam.fits.header.DataDescription;
-import nom.tam.image.StreamingTileImageData;
-import nom.tam.image.compression.CompressedImageTiler;
-import nom.tam.util.FitsInputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,18 +71,23 @@ import nom.tam.fits.FitsException;
 import nom.tam.fits.FitsFactory;
 import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
+import nom.tam.fits.HeaderCardException;
 import nom.tam.fits.ImageData;
 import nom.tam.fits.ImageHDU;
 import nom.tam.fits.compression.algorithm.hcompress.HCompressorOption;
 import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
 import nom.tam.fits.compression.algorithm.rice.RiceCompressOption;
 import nom.tam.fits.header.Compression;
+import nom.tam.fits.header.DataDescription;
 import nom.tam.fits.header.Standard;
 import nom.tam.fits.util.BlackBoxImages;
 import nom.tam.image.StandardImageTiler;
+import nom.tam.image.StreamingTileImageData;
+import nom.tam.image.compression.CompressedImageTiler;
 import nom.tam.image.compression.hdu.CompressedImageHDU;
 import nom.tam.util.ArrayDataOutput;
 import nom.tam.util.ArrayFuncs;
+import nom.tam.util.FitsInputStream;
 import nom.tam.util.FitsOutputStream;
 import nom.tam.util.SafeClose;
 
@@ -151,7 +151,7 @@ public class ReadWriteProvidedCompressedImageTest {
     private void assertArrayEquals(float[][] expected, float[][] actual, float delta) {
         Assertions.assertEquals(expected.length, actual.length);
         for (int index = 0; index < actual.length; index++) {
-            Assertions.assertArrayEquals(expected[index], actual[index], delta);
+            Assertions.assertArrayEquals(expected[index], actual[index], delta, "index " + index);
         }
     }
 
@@ -243,50 +243,58 @@ public class ReadWriteProvidedCompressedImageTest {
     @Test
     public void blackboxTest_c4s_060126_182642_zri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("c4s_060126_182642_zri.fits.fz"), //
-                resolveLocalOrRemoteFileName("c4s_060126_182642_zri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
+                resolveLocalOrRemoteFileName("c4s_060126_182642_zri.fits"), short[][].class,
+                (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_c4s_060127_070751_cri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("c4s_060127_070751_cri.fits.fz"), //
-                resolveLocalOrRemoteFileName("c4s_060127_070751_cri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
+                resolveLocalOrRemoteFileName("c4s_060127_070751_cri.fits"), short[][].class,
+                (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_kwi_041217_212603_fri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("kwi_041217_212603_fri.fits.fz"), //
-                resolveLocalOrRemoteFileName("kwi_041217_212603_fri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
+                resolveLocalOrRemoteFileName("kwi_041217_212603_fri.fits"), short[][].class,
+                (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_kwi_041217_213100_fri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("kwi_041217_213100_fri.fits.fz"), //
-                resolveLocalOrRemoteFileName("kwi_041217_213100_fri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
+                resolveLocalOrRemoteFileName("kwi_041217_213100_fri.fits"), short[][].class,
+                (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_psa_140305_191552_zri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("psa_140305_191552_zri.fits.fz"), //
-                resolveLocalOrRemoteFileName("psa_140305_191552_zri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
+                resolveLocalOrRemoteFileName("psa_140305_191552_zri.fits"), short[][].class,
+                (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_psa_140305_194520_fri() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("psa_140305_194520_fri.fits.fz"), //
-                resolveLocalOrRemoteFileName("psa_140305_194520_fri.fits"), short[][].class, (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
+                resolveLocalOrRemoteFileName("psa_140305_194520_fri.fits"), short[][].class,
+                (IHDUAsserter<short[][]>) (expected, actual) -> assert_short_image(actual, expected));
     }
 
     @Test
     public void blackboxTest_tu1134529() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("tu1134529.fits.fz"), //
-                resolveLocalOrRemoteFileName("tu1134529.fits"), int[][].class, (IHDUAsserter<int[][]>) (expected, actual) -> assert_int_image(actual, expected));
+                resolveLocalOrRemoteFileName("tu1134529.fits"), int[][].class,
+                (IHDUAsserter<int[][]>) (expected, actual) -> assert_int_image(actual, expected));
 
     }
 
     @Test
     public void blackboxTest_tu1134531() throws Exception {
         assertCompressedToUncompressedImage(resolveLocalOrRemoteFileName("tu1134531.fits.fz"), //
-                resolveLocalOrRemoteFileName("tu1134531.fits"), float[][].class, (IHDUAsserter<float[][]>) (expected, actual) -> assert_float_image(actual, expected, 15f));
+                resolveLocalOrRemoteFileName("tu1134531.fits"), float[][].class,
+                (IHDUAsserter<float[][]>) (expected, actual) -> assert_float_image(actual, expected, 15f));
     }
 
     @Test
@@ -967,11 +975,10 @@ public class ReadWriteProvidedCompressedImageTest {
     }
 
     /**
-     * Tiles that are stored losslessly in the GZIP_COMPRESSED_DATA column and whose uncompressed size exceeds the
-     * 64 kB internal buffer of the GZIP decompressor. cfitsio produces this layout on its own whenever quantization
-     * fails for a tile, which is how such files reach the reader in practice. The pixel values are noise, so that
-     * gzip barely compresses them and the inflater delivers the tile in chunks that do not align with the 4-byte
-     * pixel boundaries.
+     * Tiles that are stored losslessly in the GZIP_COMPRESSED_DATA column and whose uncompressed size exceeds the 64 kB
+     * internal buffer of the GZIP decompressor. cfitsio produces this layout on its own whenever quantization fails for
+     * a tile, which is how such files reach the reader in practice. The pixel values are noise, so that gzip barely
+     * compresses them and the inflater delivers the tile in chunks that do not align with the 4-byte pixel boundaries.
      */
     @Test
     public void writeRiceFloatWithForceNoLossTileLargerThanGzipBuffer() throws Exception {
@@ -1182,18 +1189,33 @@ public class ReadWriteProvidedCompressedImageTest {
     }
 
     @Test
+    public void testFireflyRiceQuant() throws Exception {
+        try (Fits fits = new Fits("../blackbox-images/firefly_zblank_nan_test.fits")) {
+            fits.readHDU();
+            ImageHDU orig = (ImageHDU) fits.readHDU();
+            ImageHDU compressed = ((CompressedImageHDU) fits.readHDU()).asImageHDU();
+
+            Fits f = new Fits();
+            f.addHDU(compressed);
+            f.write("target/firefly1.fits");
+
+            assertArrayEquals((float[][]) orig.getData().getData(), (float[][]) compressed.getData().getData(), 3.0f);
+        }
+    }
+
+    @Test
     public void writeCutoutFromCompressed() throws Exception {
         final File tempFile = File.createTempFile("temp", ".fits");
-        // This is a larger (256MB) file.  Don't read it in entirely.
+        // This is a larger (256MB) file. Don't read it in entirely.
         final Path filePath = Path.of(resolveLocalOrRemoteFileName("tu1134531.fits.fz"));
         final int[] corners = new int[] {1, 230};
         final int[] lengths = new int[] {464, 225};
         byte[] expectedCutout;
 
         try (final FitsInputStream fitsInputStream = new FitsInputStream(new FileInputStream(filePath.toFile()));
-             final Fits fits = new Fits(fitsInputStream);
-             final Fits fitsOutput = new Fits(tempFile);
-             final FitsOutputStream fitsOutputStream = new FitsOutputStream(new FileOutputStream(tempFile))) {
+                final Fits fits = new Fits(fitsInputStream);
+                final Fits fitsOutput = new Fits(tempFile);
+                final FitsOutputStream fitsOutputStream = new FitsOutputStream(new FileOutputStream(tempFile))) {
 
             final BasicHDU<?> hdu = fits.getHDU(5);
             Assertions.assertInstanceOf(CompressedImageHDU.class, hdu, "Incorrect type of HDU at index 5");
@@ -1201,8 +1223,8 @@ public class ReadWriteProvidedCompressedImageTest {
             expectedCutout = getCutoutBytes(compressedImageHDU, corners, lengths);
             final Header header = ReadWriteProvidedCompressedImageTest.copyHeader(compressedImageHDU.getHeader());
             ReadWriteProvidedCompressedImageTest.adjustHeader(header);
-            ReadWriteProvidedCompressedImageTest.addCutoutFromCompressed(compressedImageHDU, header, fitsOutput,
-                    corners, lengths);
+            ReadWriteProvidedCompressedImageTest.addCutoutFromCompressed(compressedImageHDU, header, fitsOutput, corners,
+                    lengths);
 
             fitsOutput.write(fitsOutputStream);
         }
@@ -1215,8 +1237,7 @@ public class ReadWriteProvidedCompressedImageTest {
     }
 
     static void addCutoutFromCompressed(final CompressedImageHDU compressedImageHDU, final Header adjustedHeader,
-                                        final Fits fitsOutput, final int[] corners, final int[] lengths)
-            throws HeaderCardException {
+            final Fits fitsOutput, final int[] corners, final int[] lengths) throws HeaderCardException {
         ReadWriteProvidedCompressedImageTest.adjustCutoutHeader(adjustedHeader, lengths);
         final CompressedImageTiler compressedImageTiler = new CompressedImageTiler(compressedImageHDU);
         final StreamingTileImageData streamingTileImageData = new StreamingTileImageData(adjustedHeader,
@@ -1252,14 +1273,10 @@ public class ReadWriteProvidedCompressedImageTest {
         try (final Fits fits = new Fits(outputFile)) {
             final ImageHDU imageHdu = (ImageHDU) fits.getHDU(hduIndex);
             final Header header = imageHdu.getHeader();
-            Assertions.assertEquals(lengths[1], header.getIntValue(Standard.NAXISn.n(1)),
-                    "NAXIS1 at HDU " + hduIndex);
-            Assertions.assertEquals(lengths[0], header.getIntValue(Standard.NAXISn.n(2)),
-                    "NAXIS2 at HDU " + hduIndex);
-            Assertions.assertArrayEquals(expectedAxes, imageHdu.getAxes(),
-                    "cutout NAXIS dimensions at HDU " + hduIndex);
-            Assertions.assertArrayEquals(expectedAxes,
-                    ArrayFuncs.getDimensions(imageHdu.getData().getData()),
+            Assertions.assertEquals(lengths[1], header.getIntValue(Standard.NAXISn.n(1)), "NAXIS1 at HDU " + hduIndex);
+            Assertions.assertEquals(lengths[0], header.getIntValue(Standard.NAXISn.n(2)), "NAXIS2 at HDU " + hduIndex);
+            Assertions.assertArrayEquals(expectedAxes, imageHdu.getAxes(), "cutout NAXIS dimensions at HDU " + hduIndex);
+            Assertions.assertArrayEquals(expectedAxes, ArrayFuncs.getDimensions(imageHdu.getData().getData()),
                     "Java array dimensions at HDU " + hduIndex);
             final Class<?> arrayType = ArrayFuncs.getBaseClass(imageHdu.getData().getData());
             final ByteBuffer expectedPixels = java.nio.ByteBuffer.wrap(expected);
@@ -1269,7 +1286,7 @@ public class ReadWriteProvidedCompressedImageTest {
     }
 
     private static void writeExpectedCutoutBytes(final ByteBuffer expectedPixels, final ImageHDU imageHdu,
-                                                 final int[] lengths, final int hduIndex, final Class<?> arrayType) {
+            final int[] lengths, final int hduIndex, final Class<?> arrayType) {
         if (arrayType == short.class) {
             final ShortBuffer expectedShortPixels = expectedPixels.asShortBuffer();
             final short[][] data = (short[][]) imageHdu.getData().getData();
@@ -1303,7 +1320,7 @@ public class ReadWriteProvidedCompressedImageTest {
                     index++;
                 }
             }
-        }  else if (arrayType == int.class) {
+        } else if (arrayType == int.class) {
             final IntBuffer expectedIntPixels = expectedPixels.asIntBuffer();
             final int[][] data = (int[][]) imageHdu.getData().getData();
             int index = 0;
@@ -1360,9 +1377,9 @@ public class ReadWriteProvidedCompressedImageTest {
         header.addValue(Standard.GCOUNT, 1);
     }
 
-    private static Header copyHeader(final Header source) throws HeaderCardException {
+    private static Header copyHeader(final Header source) throws NumberFormatException, HeaderCardException {
         final Header destination = new Header();
-        for (final Iterator<HeaderCard> headerCardIterator = source.iterator(); headerCardIterator.hasNext(); ) {
+        for (final Iterator<HeaderCard> headerCardIterator = source.iterator(); headerCardIterator.hasNext();) {
             final HeaderCard headerCard = headerCardIterator.next();
             final String headerCardKey = headerCard.getKey();
             final Class<?> valueType = headerCard.valueType();
@@ -1381,20 +1398,15 @@ public class ReadWriteProvidedCompressedImageTest {
                     destination.addValue(headerCardKey, Boolean.parseBoolean(headerCard.getValue()),
                             headerCard.getComment());
                 } else if (valueType == Integer.class || valueType == BigInteger.class) {
-                    destination.addValue(headerCardKey, new BigInteger(headerCard.getValue()),
-                            headerCard.getComment());
+                    destination.addValue(headerCardKey, new BigInteger(headerCard.getValue()), headerCard.getComment());
                 } else if (valueType == Long.class) {
-                    destination.addValue(headerCardKey, Long.parseLong(headerCard.getValue()),
-                            headerCard.getComment());
+                    destination.addValue(headerCardKey, Long.parseLong(headerCard.getValue()), headerCard.getComment());
                 } else if (valueType == Double.class) {
-                    destination.addValue(headerCardKey, Double.parseDouble(headerCard.getValue()),
-                            headerCard.getComment());
+                    destination.addValue(headerCardKey, Double.parseDouble(headerCard.getValue()), headerCard.getComment());
                 } else if (valueType == BigDecimal.class) {
-                    destination.addValue(headerCardKey, new BigDecimal(headerCard.getValue()),
-                            headerCard.getComment());
+                    destination.addValue(headerCardKey, new BigDecimal(headerCard.getValue()), headerCard.getComment());
                 } else if (valueType == Float.class) {
-                    destination.addValue(headerCardKey, Float.parseFloat(headerCard.getValue()),
-                            headerCard.getComment());
+                    destination.addValue(headerCardKey, Float.parseFloat(headerCard.getValue()), headerCard.getComment());
                 }
             }
         }

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -942,4 +942,22 @@ public class QuantizeTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> q.guessQuantization(ints));
     }
 
+    @Test
+    public void testUseFMA() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+
+        o.setBScale(1e6);
+        o.setBZero(1e-3);
+
+        QuantizeOption.useFMA(true);
+        Assertions.assertTrue(QuantizeOption.isUseFMA());
+        double fma = o.toDouble(123456);
+
+        QuantizeOption.useFMA(false);
+        Assertions.assertFalse(QuantizeOption.isUseFMA());
+        double base = o.toDouble(123456);
+
+        Assertions.assertEquals(fma, base, 1e-15);
+    }
+
 }

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -71,7 +71,6 @@ public class QuantizeTest {
 
         public QuantizeTestParameters(QuantizeOption option) {
             super(option);
-
         }
 
         @Override
@@ -594,23 +593,6 @@ public class QuantizeTest {
     }
 
     @Test
-    public void testHeaderBlankParameterNoOption() throws Exception {
-        QuantizeParameters q = new QuantizeParameters(null);
-        Header h = new Header();
-
-        h.addValue(Compression.ZQUANTIZ, "UNKNOWN");
-        h.addValue(Compression.ZBLANK, -999);
-
-        q.getValuesFromHeader(new HeaderAccess(h));
-
-        Header h2 = new Header();
-        q.setValuesInHeader(new HeaderAccess(h2));
-
-        Assertions.assertEquals(null, h2.getStringValue(Compression.ZQUANTIZ));
-        Assertions.assertEquals(0, h2.getIntValue(Compression.ZBLANK));
-    }
-
-    @Test
     public void testColumnParameterCreateData() throws Exception {
         QuantizeOption o = new QuantizeOption();
         ZBlankColumnParameter p = new ZBlankColumnParameter(o);
@@ -718,5 +700,193 @@ public class QuantizeTest {
         final double LAST_RANDOM_VALUE = 1043618065.0 / Integer.MAX_VALUE;
 
         Assertions.assertEquals(RandomSequence.get(RandomSequence.length() - 1), LAST_RANDOM_VALUE, 0.1);
+    }
+
+    @Test
+    public void testSetNullValue() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+
+        Assertions.assertFalse(o.isCheckNull());
+        Assertions.assertNull(o.getBNull());
+
+        o.setCheckNull(false);
+        Assertions.assertNull(o.getBNull());
+
+        o.setCheckNull(true);
+        Assertions.assertTrue(o.isCheckNull());
+        Assertions.assertNotNull(o.getBNull());
+
+        o.setCheckNull(true);
+        Assertions.assertTrue(o.isCheckNull());
+        Assertions.assertNotNull(o.getBNull());
+
+        o.setCheckNull(false);
+        Assertions.assertFalse(o.isCheckNull());
+        Assertions.assertNotNull(o.getBNull());
+
+        o.setCheckNull(false);
+        Assertions.assertFalse(o.isCheckNull());
+        Assertions.assertNotNull(o.getBNull());
+    }
+
+    @Test
+    public void testAutoBNull() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+        Assertions.assertNull(o.getBNull());
+        Assertions.assertEquals(Integer.MIN_VALUE, o.toInt(Double.NaN));
+        Assertions.assertNotNull(o.getBNull());
+    }
+
+    @Test
+    public void testInitDither() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+        o.setBScale(1.0);
+        o.setBZero(0.0);
+        Assertions.assertEquals(0, o.toInt(0.0));
+        Assertions.assertEquals(1, o.toInt(0.5));
+        Assertions.assertEquals(0.0, o.toDouble(0), 0.5);
+        Assertions.assertEquals(0.5, o.toDouble(1), 0.5);
+
+        o.initDither();
+        Assertions.assertEquals(0, o.toInt(0.0));
+        Assertions.assertEquals(1, o.toInt(0.5));
+        Assertions.assertEquals(0.0, o.toDouble(0), 0.5);
+        Assertions.assertEquals(0.5, o.toDouble(1), 0.5);
+
+        o.setDither(true);
+        o.initDither();
+        Assertions.assertEquals(0, o.toInt(0.0));
+        Assertions.assertEquals(0, o.toInt(0.5));
+        Assertions.assertEquals(0.0, o.toDouble(0), 0.5);
+        Assertions.assertEquals(0.5, o.toDouble(0), 0.5);
+
+        o.setDither2(true);
+        o.initDither();
+        Assertions.assertEquals(0, o.toInt(0.0));
+        Assertions.assertEquals(0, o.toInt(0.5));
+        Assertions.assertEquals(0.0, o.toDouble(0), 0.5);
+        Assertions.assertEquals(0.5, o.toDouble(0), 0.5);
+
+        o.setDither(false);
+        o.initDither();
+        Assertions.assertEquals(0, o.toInt(0.0));
+        Assertions.assertEquals(0, o.toInt(0.5));
+        Assertions.assertEquals(0.0, o.toDouble(0), 0.5);
+        Assertions.assertEquals(0.5, o.toDouble(0), 0.5);
+
+        o.setDither2(false);
+        o.initDither();
+        Assertions.assertEquals(0, o.toInt(0.0));
+        Assertions.assertEquals(1, o.toInt(0.5));
+        Assertions.assertEquals(0.0, o.toDouble(0), 0.5);
+        Assertions.assertEquals(0.5, o.toDouble(1), 0.5);
+    }
+
+    @Test
+    public void testDindBero() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+        o.setBScale(1.0);
+        o.setBZero(0.0);
+
+        Assertions.assertFalse(o.isCheckNull());
+        Assertions.assertFalse(o.isCenterOnZero());
+
+        o.setMaxValue(1000.0);
+        o.setMinValue(0.0);
+        Assertions.assertEquals(0.0, o.findBZero(), 1e-6);
+
+        o.setMaxValue(Integer.MAX_VALUE);
+        Assertions.assertEquals(0.5 * Integer.MAX_VALUE, o.findBZero(), 1e-6);
+
+        o.setCheckNull(true);
+        Assertions.assertEquals(2.147483637E9, o.findBZero(), 1e-6);
+    }
+
+    @Test
+    public void testSeedWrap() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+        o.setTileIndex(1);
+        o.setDither(true);
+        o.initDither();
+
+        double d0 = o.toDouble(0);
+
+        o.setSeed(RandomSequence.length());
+        o.initDither();
+        Assertions.assertEquals(d0, o.toDouble(0));
+    }
+
+    @Test
+    public void testGetSetOptions() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+
+        o.setTileIndex(11);
+        Assertions.assertEquals(11, o.getTileIndex());
+
+        o.setTileHeight(14);
+        Assertions.assertEquals(14, o.getTileHeight());
+
+        o.setTileWidth(42);
+        Assertions.assertEquals(42, o.getTileWidth());
+
+        o.setBNull(null);
+        Assertions.assertNull(o.getBNull());
+        Assertions.assertFalse(o.isCheckNull());
+
+        o.setBNull(-999);
+        Assertions.assertEquals(-999, o.getBNull());
+        Assertions.assertTrue(o.isCheckNull());
+
+        o.setBScale(3.3);
+        Assertions.assertEquals(3.3, o.getBScale());
+
+        o.setBZero(-1.2);
+        Assertions.assertEquals(-1.2, o.getBZero());
+
+        o.setCheckNull(false);
+        Assertions.assertFalse(o.isCheckNull());
+        o.setCheckNull(true);
+        Assertions.assertTrue(o.isCheckNull());
+
+        o.setCheckZero(false);
+        Assertions.assertFalse(o.isCheckZero());
+        o.setCheckZero(true);
+        Assertions.assertTrue(o.isCheckZero());
+
+        o.setCenterOnZero(false);
+        Assertions.assertFalse(o.isCenterOnZero());
+        o.setCenterOnZero(true);
+        Assertions.assertTrue(o.isCenterOnZero());
+
+        o.setDither(false);
+        Assertions.assertFalse(o.isDither());
+        o.setDither(true);
+        Assertions.assertTrue(o.isDither());
+
+        o.setDither2(false);
+        Assertions.assertFalse(o.isDither2());
+        o.setDither2(true);
+        Assertions.assertTrue(o.isDither2());
+
+        o.setIntMinValue(-999);
+        Assertions.assertEquals(-999, o.getIntMinValue());
+
+        o.setIntMaxValue(-101);
+        Assertions.assertEquals(-101, o.getIntMaxValue());
+
+        o.setMinValue(-999.0);
+        Assertions.assertEquals(-999.0, o.getMinValue(), 1e-12);
+
+        o.setMaxValue(-101.0);
+        Assertions.assertEquals(-101.0, o.getMaxValue(), 1e-12);
+
+        o.setNullValue(0.33);
+        Assertions.assertEquals(0.33, o.getNullValue());
+
+        o.setSeed(33);
+        Assertions.assertEquals(33, o.getSeed());
+
+        o.setQlevel(3.5);
+        Assertions.assertEquals(3.5, o.getQLevel(), 1e-12);
     }
 }

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -32,6 +32,7 @@ package nom.tam.fits.compression.algorithm.quant;
  */
 
 import java.io.RandomAccessFile;
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
@@ -474,8 +475,8 @@ public class QuantizeTest {
     public void testQuant1FloatFail() throws Exception {
         QuantizeOption quantizeOption = new QuantizeOption();
         FloatQuantCompressor floatQuantCompressor = new FloatQuantCompressor(quantizeOption, null);
-        Assertions
-                .assertFalse(floatQuantCompressor.compress(FloatBuffer.wrap(new float[4]), ByteBuffer.wrap(new byte[100])));
+        Assertions.assertThrows(BufferOverflowException.class,
+                () -> floatQuantCompressor.compress(FloatBuffer.wrap(new float[4]), ByteBuffer.wrap(new byte[100])));
     }
 
     @Test
@@ -889,4 +890,56 @@ public class QuantizeTest {
         o.setQlevel(3.5);
         Assertions.assertEquals(3.5, o.getQLevel(), 1e-12);
     }
+
+    @Test
+    public void testQuantizeTypes() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+        Quantize q = new Quantize(o);
+
+        FloatBuffer fdata = FloatBuffer.wrap(new float[100]);
+        DoubleBuffer ddata = DoubleBuffer.wrap(new double[100]);
+
+        o.setTileWidth(8);
+        o.setTileHeight(1);
+        Assertions.assertTrue(q.guessQuantization(fdata));
+        Assertions.assertTrue(q.guessQuantization(ddata));
+
+        o.setTileWidth(16);
+        o.setTileHeight(6);
+        Assertions.assertTrue(q.guessQuantization(fdata));
+        Assertions.assertTrue(q.guessQuantization(ddata));
+    }
+
+    @Test
+    public void testQuantizeDeprecated() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+        Quantize q = new Quantize(o);
+
+        double[] doubles = new double[100];
+
+        o.setTileWidth(8);
+        o.setTileHeight(1);
+        Assertions.assertTrue(q.quantize(doubles, 0, 0));
+
+        o.setTileWidth(16);
+        o.setTileHeight(5);
+        Assertions.assertTrue(q.quantize(doubles, 0, 0));
+    }
+
+    @Test
+    public void testQuantizeExceptions() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+        Quantize q = new Quantize(o);
+
+        IntBuffer ints = IntBuffer.wrap(new int[10]);
+
+        o.setTileWidth(8);
+        o.setTileHeight(1);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> q.guessQuantization(ints));
+
+        o.setTileWidth(16);
+        o.setTileHeight(6);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> q.guessQuantization(ints));
+    }
+
 }

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -32,8 +32,6 @@ package nom.tam.fits.compression.algorithm.quant;
  */
 
 import java.io.RandomAccessFile;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
@@ -93,11 +91,13 @@ public class QuantizeTest {
     private void checkRequantedValues(QuantizeProcessor quantize, IntBuffer buffer, double[] doubles, QuantizeOption option,
             boolean check) {
         double[] output = new double[option.getTileWidth() * option.getTileHeight()];
+
         quantize.unquantize(buffer, DoubleBuffer.wrap(output));
         if (check) {
             double[] expected = new double[output.length];
             System.arraycopy(doubles, 0, expected, 0, expected.length);
-            Assertions.assertArrayEquals(expected, output, option.getBScale() * 1.5);
+            Assertions.assertArrayEquals(expected, output,
+                    Double.isNaN(option.getBScale()) ? 1e-10 : option.getBScale() * 1.5);
         }
     }
 
@@ -113,48 +113,9 @@ public class QuantizeTest {
     public void manyDifferentNullCases() {
         final int xsize = 12;
         final int ysize = 2;
-        double[] matrix;
-        int[][] expectedData = {
-                {-2147483646, -2139144306, -2130805810, -2122468981, -2114134654, -2105803661, -2097476837, -2089155012,
-                        -2147483647, -2147483647, -2147483647, -2147483647, -2047650006, -2039375639, -2031112082,
-                        -2022860162, -2014620704, -2006394533, -1998182470, -1989985337, -1981803954, -1973639139,
-                        -1965491708, -1957362476},
-                {-2147483637, -2139144306, -2130805810, -2122468981, -2114134654, -2105803661, -2097476837, -2147483647,
-                        -2147483647, -2147483647, -2147483647, -2147483647, -2047650006, -2039375639, -2031112082,
-                        -2022860162, -2014620704, -2006394533, -1998182470, -1989985337, -1981803954, -1973639139,
-                        -1965491708, -1957362476},
-                {-2147483646, -2139144306, -2130805810, -2122468981, -2114134654, -2105803661, -2147483647, -2147483647,
-                        -2147483647, -2147483647, -2147483647, -2147483647, -2047650006, -2039375639, -2031112082,
-                        -2022860162, -2014620704, -2006394533, -1998182470, -1989985337, -1981803954, -1973639139,
-                        -1965491708, -1957362476},
-                {-2147483637, -2139144306, -2130805810, -2122468981, -2114134654, -2147483647, -2147483647, -2147483647,
-                        -2147483647, -2147483647, -2147483647, -2147483647, -2047650006, -2039375639, -2031112082,
-                        -2022860162, -2014620704, -2006394533, -1998182470, -1989985337, -1981803954, -1973639139,
-                        -1965491708, -1957362476},
-                {-2147483646, -2139144306, -2130805810, -2122468981, -2147483647, -2147483647, -2147483647, -2147483647,
-                        -2147483647, -2147483647, -2147483647, -2147483647, -2047650006, -2039375639, -2031112082,
-                        -2022860162, -2014620704, -2006394533, -1998182470, -1989985337, -1981803954, -1973639139,
-                        -1965491708, -1957362476},
-                {-2147483637, -2139144306, -2130805810, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647,
-                        -2147483647, -2147483647, -2147483647, -2147483647, -2047650006, -2039375639, -2031112082,
-                        -2022860162, -2014620704, -2006394533, -1998182470, -1989985337, -1981803954, -1973639139,
-                        -1965491708, -1957362476},
-                {-2147483646, -2139144306, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647,
-                        -2147483647, -2147483647, -2147483647, -2147483647, -2047650006, -2039375639, -2031112082,
-                        -2022860162, -2014620704, -2006394533, -1998182470, -1989985337, -1981803954, -1973639139,
-                        -1965491708, -1957362476},
-                {-2147483637, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647,
-                        -2147483647, -2147483647, -2147483647, -2147483647, -2047650006, -2039375639, -2031112082,
-                        -2022860162, -2014620704, -2006394533, -1998182470, -1989985337, -1981803954, -1973639139,
-                        -1965491708, -1957362476}};
-        int expectedIndex = 0;
+
         for (int index = 8; index > 0; index--) {
-            // quantize =
-            // new Quantize(nullCheckValue().set(IDither.class, (index % 2 == 1
-            // ? new SubtractiveDither(3942L) : new
-            // SubtractiveDither2(3942L))).set(
-            // quantizeParameter.setQLevel(4)));
-            matrix = initMatrix();
+            double[] matrix = initMatrix();
             Arrays.fill(matrix, index, xsize, NULL_VALUE);
 
             QuantizeOption option;
@@ -171,18 +132,14 @@ public class QuantizeTest {
             quantProcessor.quantize(matrix, quants);
             quants.rewind();
 
-            checkRequantedValues(quantProcessor, quants, matrix, option, false);
+            for (int i = 0; i < xsize; i++) {
+                int q = quants.get();
+                if (matrix[i] == NULL_VALUE) {
+                    Assertions.assertEquals(option.getNullValueIndicator(), q, "index " + index + "," + i);
+                }
+            }
 
-            // Assertions.assertions.assertTrue(quantize.quantize(matrix, xsize, ysize));
-            Assertions.assertArrayEquals(expectedData[expectedIndex], quants.array());
-
-            Assertions.assertEquals(1.19911703788955035348e-06, option.getBScale(), 1e-20);
-            Assertions.assertEquals(2.57508421771571829595e+03, option.getBZero(), 1e-20);
             Assertions.assertEquals(-2147483637, option.getIntMinValue());
-            Assertions.assertEquals(-1957362476, option.getIntMaxValue());
-            // checkRequantedValues(quantize, matrix);
-
-            expectedIndex++;
         }
     }
 
@@ -263,16 +220,15 @@ public class QuantizeTest {
 
         checkRequantedValues(quantProcessor, quants, matrix, option, false);
 
-        Assertions.assertArrayEquals(new int[] {-2147483646, -2147483634, -2147483632, -2147483629, -2147483627,
-                -2147483625, -2147483622, -2147483619, -2147483617, -2147483615, -2147483612, -2147483609, -2147483607,
-                -2147483604, -2147483602, -2147483599, -2147483597, -2147483595, -2147483593, -2147483590, -2147483587,
-                -2147483585, -2147483582, -2147483580
+        Assertions.assertArrayEquals(new int[] {-2147483646, -2147483637, -2147483634, -2147483632, -2147483629,
+                -2147483627, -2147483625, -2147483622, -2147483619, -2147483617, -2147483615, -2147483612, -2147483609,
+                -2147483607, -2147483604, -2147483602, -2147483599, -2147483597, -2147483595, -2147483593, -2147483590,
+                -2147483587, -2147483585, -2147483582}, quants.array());
 
-        }, quants.array());
         Assertions.assertEquals(4.000000e+00, option.getBScale(), 1e-20);
-        Assertions.assertEquals(8.589934548e+09, option.getBZero(), 1e-20);
+        Assertions.assertEquals(8.589934557999833E9, option.getBZero(), 1e-20);
         Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-2147483580, option.getIntMaxValue());
+        Assertions.assertEquals(-2147483582, option.getIntMaxValue());
     }
 
     @Test
@@ -297,10 +253,10 @@ public class QuantizeTest {
 
         checkRequantedValues(quantProcessor, quants, matrix, option, false);
 
-        Assertions.assertEquals(6.01121812296506193330e-07, option.getBScale(), 1e-20);
-        Assertions.assertEquals(1.29089925575053234752e+03, option.getBZero(), 1e-20);
+        Assertions.assertEquals(9.18810439811682E-7, option.getBScale(), 1e-20);
+        Assertions.assertEquals(1983.130218334527, option.getBZero(), 1e-10);
         Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-1866039268, option.getIntMaxValue());
+        Assertions.assertEquals(-1974235153, option.getIntMaxValue());
     }
 
     @Test
@@ -322,6 +278,7 @@ public class QuantizeTest {
                 .setTileWidth(xsize)//
                 .setTileHeight(ysize));
         IntBuffer quants = IntBuffer.wrap(new int[xsize * ysize]);
+
         quantProcessor.quantize(matrix, quants);
         quants.rewind();
 
@@ -330,9 +287,9 @@ public class QuantizeTest {
         Assertions.assertEquals(xsize * ysize, quants.limit());
 
         Assertions.assertEquals(8.11574856349585578526e-07, option.getBScale(), 1e-20);
-        Assertions.assertEquals(1.74284372421136049525e+03, option.getBZero(), 1e-20);
+        Assertions.assertEquals(1.74284372421136049525e+03, option.getBZero(), 1e-10);
         Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-1866576064, option.getIntMaxValue());
+        Assertions.assertEquals(-1866576063, option.getIntMaxValue());
     }
 
     @Test
@@ -359,9 +316,9 @@ public class QuantizeTest {
         checkRequantedValues(quantProcessor, quants, matrix, option, false);
 
         Assertions.assertEquals(8.11574856349585578526e-07, option.getBScale(), 1e-20);
-        Assertions.assertEquals(1.74284372421136049525e+03, option.getBZero(), 1e-20);
+        Assertions.assertEquals(1.74284372421136049525e+03, option.getBZero(), 1e-10);
         Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-1866576064, option.getIntMaxValue());
+        Assertions.assertEquals(-1866576063, option.getIntMaxValue());
     }
 
     @Test
@@ -382,22 +339,21 @@ public class QuantizeTest {
                 .setTileWidth(xsize)//
                 .setTileHeight(ysize));
         IntBuffer quants = IntBuffer.wrap(new int[xsize * ysize]);
+
         quantProcessor.quantize(matrix, quants);
         quants.rewind();
 
+        Assertions.assertArrayEquals(new int[] {-2147483648, -2147483648, -2147483648, -2147483648, -2147483648,
+                -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648,
+                -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648,
+                -2147483648, -2147483648, -2147483648}, quants.array());
+
+        Assertions.assertEquals(1.0, option.getBScale(), 1e-15);
+        Assertions.assertEquals(0.0, option.getBZero(), 1e-20);
+        Assertions.assertEquals(0, option.getIntMinValue());
+        Assertions.assertEquals(0, option.getIntMaxValue());
+
         checkRequantedValues(quantProcessor, quants, matrix, option, true);
-
-        Assertions.assertArrayEquals(new int[] {-2147483647, -2147483647, -2147483647, -2147483647, -2147483647,
-                -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647,
-                -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647, -2147483647,
-                -2147483647, -2147483647, -2147483647
-
-        }, quants.array());
-        Assertions.assertEquals(2.50000000000000000000e-01, option.getBScale(), 1e-20);
-        Assertions.assertEquals(5.36870909250000000000e+08, option.getBZero(), 1e-20);
-        Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-2147483633, option.getIntMaxValue());
-
     }
 
     @Test
@@ -465,7 +421,7 @@ public class QuantizeTest {
             Assertions.assertEquals(2412784644004.5762, option.getBScale(), 1e-19);
             Assertions.assertEquals(0d, option.getBZero(), 1e-19);
             Assertions.assertEquals(0, option.getIntMinValue());
-            Assertions.assertEquals(1911354, option.getIntMaxValue());
+            Assertions.assertEquals(1911355, option.getIntMaxValue());
         } finally {
             SafeClose.close(file);
         }
@@ -549,7 +505,7 @@ public class QuantizeTest {
         BinaryTableHDU hdu = (BinaryTableHDU) FitsFactory.hduFactory(new Object[] {new int[2], new int[2][2]});
         base.addColumnsToTable(hdu);
         int[] column = (int[]) hdu.getColumn(Compression.ZBLANK_COLUMN);
-        Assertions.assertArrayEquals(new int[] {99, 0}, column);
+        Assertions.assertArrayEquals(new int[] {99, Integer.MIN_VALUE}, column);
 
         baseOption.setDither(false);
         base.setValuesInHeader(new HeaderAccess(hdu.getHeader()));
@@ -560,38 +516,6 @@ public class QuantizeTest {
         base.setValuesInHeader(new HeaderAccess(hdu.getHeader()));
         Assertions.assertEquals(Compression.ZQUANTIZ_SUBTRACTIVE_DITHER_1,
                 hdu.getHeader().getStringValue(Compression.ZQUANTIZ));
-    }
-
-    @Test
-    public void testQuantProcessor() throws Exception {
-        QuantizeOption baseOption = new QuantizeOption();
-        baseOption.setDither(true);
-        baseOption.setDither2(false);
-
-        QuantizeProcessor processor = new QuantizeProcessor(baseOption);
-        Field declaredField = QuantizeProcessor.class.getDeclaredField("pixelFilter");
-        declaredField.setAccessible(true);
-        Object filter = declaredField.get(processor);
-        Method nextPixel = filter.getClass().getDeclaredMethod("nextPixel");
-
-        declaredField = filter.getClass().getDeclaredField("iseed");
-        declaredField.setAccessible(true);
-        declaredField.set(filter, 10000);
-
-        declaredField = filter.getClass().getDeclaredField("nextRandom");
-        declaredField.setAccessible(true);
-        declaredField.set(filter, 10000);
-
-        nextPixel.invoke(filter);
-
-        declaredField = filter.getClass().getDeclaredField("iseed");
-        declaredField.setAccessible(true);
-        Assertions.assertEquals(Integer.valueOf(0), declaredField.get(filter));
-
-        declaredField = filter.getClass().getDeclaredField("nextRandom");
-        declaredField.setAccessible(true);
-        Assertions.assertEquals(Integer.valueOf(0), declaredField.get(filter));
-
     }
 
     @Test
@@ -714,6 +638,7 @@ public class QuantizeTest {
         Assertions.assertEquals(1.0, o.getBScale(), 1e-6);
         Assertions.assertEquals(0.0, o.getBZero(), 1e-6);
 
+        p.initializeColumns(10);
         p.setValuesInColumn(0);
         p.setValueInColumn(0); // deprecated old form...
     }
@@ -730,8 +655,8 @@ public class QuantizeTest {
         ZBlankColumnParameter p = new ZBlankColumnParameter(o);
 
         p.column(null, 10);
-        Assertions.assertEquals(10, ((int[]) p.column()).length);
         Assertions.assertEquals(10, ((int[]) p.initializedColumn()).length);
+        Assertions.assertEquals(10, ((int[]) p.column()).length);
 
         o.setBNull(-999);
         p.setValueFromColumn(0);

--- a/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/rice/RiceCompressTest.java
@@ -418,7 +418,7 @@ public class RiceCompressTest {
     }
 
     @Test
-    public void testRiceQuantizeCompressIption() {
+    public void testRiceQuantizeCompressIption() throws Exception {
         RiceCompressOption c = new RiceCompressOption();
         RiceQuantizeCompressOption o = new RiceQuantizeCompressOption(c);
         Assertions.assertEquals(c, o.getRiceCompressOption());

--- a/src/test/java/nom/tam/fits/compression/provider/param/quant/QuantColumnParameterTest.java
+++ b/src/test/java/nom/tam/fits/compression/provider/param/quant/QuantColumnParameterTest.java
@@ -1,0 +1,99 @@
+package nom.tam.fits.compression.provider.param.quant;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
+
+/*
+ * #%L
+ * nom.tam FITS library
+ * %%
+ * Copyright (C) 1996 - 2024 nom-tam-fits
+ * %%
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ * #L%
+ */
+
+@SuppressWarnings({"javadoc", "deprecation"})
+public class QuantColumnParameterTest {
+
+    @Test
+    public void testInit() {
+        QuantizeOption o = new QuantizeOption(null);
+        ZScaleColumnParameter z = new ZScaleColumnParameter(o);
+
+        Assertions.assertNull(z.getColumnData());
+
+        z.setColumnSize(10);
+        Assertions.assertEquals(10, z.getColumnData().length);
+        Assertions.assertTrue(Double.isNaN(z.getColumnData()[0]));
+
+        double[] data = new double[] {2.0, 3.0, 4.0};
+        z.setColumnData(data);
+        Assertions.assertEquals(3, z.getColumnData().length);
+        Assertions.assertEquals(2.0, z.getColumnData()[0], 1e-12);
+
+        z.setColumnSize(10);
+        Assertions.assertEquals(10, z.getColumnData().length);
+        Assertions.assertEquals(2.0, z.getColumnData()[0], 1e-12);
+        Assertions.assertTrue(Double.isNaN(z.getColumnData()[3]));
+
+        z.createColumnData(10);
+        Assertions.assertEquals(10, z.getColumnData().length);
+        Assertions.assertTrue(Double.isNaN(z.getColumnData()[0]));
+        Assertions.assertTrue(Double.isNaN(z.getColumnData()[3]));
+    }
+
+    @Test
+    public void testSetColumnDataOld() {
+        QuantizeOption o = new QuantizeOption(null);
+        ZScaleColumnParameter z = new ZScaleColumnParameter(o);
+
+        Assertions.assertNull(z.getColumnData());
+
+        z.setColumnData(null, 10);
+        Assertions.assertEquals(10, z.getColumnData().length);
+        Assertions.assertTrue(Double.isNaN(z.getColumnData()[0]));
+
+        double[] data = new double[] {2.0, 3.0, 4.0};
+        z.setColumnData(data, 0);
+        Assertions.assertEquals(3, z.getColumnData().length);
+        Assertions.assertEquals(2.0, z.getColumnData()[0], 1e-12);
+
+        z.setColumnData(null, 10);
+        Assertions.assertEquals(10, z.getColumnData().length);
+        Assertions.assertTrue(Double.isNaN(z.getColumnData()[0]));
+        Assertions.assertTrue(Double.isNaN(z.getColumnData()[3]));
+    }
+
+    @Test
+    public void testSetValueInColumnEmpty() {
+        QuantizeOption o = new QuantizeOption(null);
+        ZBlankColumnParameter blank = new ZBlankColumnParameter(o);
+
+        blank.setValueInColumn(0);
+        Assertions.assertNull(blank.getColumnData());
+    }
+}

--- a/src/test/java/nom/tam/fits/compression/provider/param/quant/QuantParameterTest.java
+++ b/src/test/java/nom/tam/fits/compression/provider/param/quant/QuantParameterTest.java
@@ -1,5 +1,12 @@
 package nom.tam.fits.compression.provider.param.quant;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import nom.tam.fits.Header;
+import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
+import nom.tam.fits.header.Compression;
+
 /*
  * #%L
  * nom.tam FITS library
@@ -31,33 +38,22 @@ package nom.tam.fits.compression.provider.param.quant;
  * #L%
  */
 
-import nom.tam.fits.compression.algorithm.quant.QuantizeOption;
-import nom.tam.fits.compression.provider.param.base.CompressColumnParameter;
-import nom.tam.fits.header.Compression;
+@SuppressWarnings("javadoc")
+public class QuantParameterTest {
 
-/**
- * (<i>for internal use</i>) The quantization scale value as recorded in a FITS compressed table column.
- */
-final class ZScaleColumnParameter extends CompressColumnParameter<double[], QuantizeOption> {
+    @Test
+    public void testZBlank() {
+        QuantizeOption o = new QuantizeOption(null);
+        ZBlankParameter blank = new ZBlankParameter(o);
+        Header h = new Header();
 
-    ZScaleColumnParameter(QuantizeOption quantizeOption) {
-        super(Compression.ZSCALE_COLUMN, quantizeOption, double[].class);
+        o.setBNull(null);
+        blank.setValueInHeader(h);
+        Assertions.assertFalse(h.containsKey(Compression.ZBLANK));
+
+        o.setBNull(-999);
+        blank.setValueInHeader(h);
+        Assertions.assertEquals(-999, h.getIntValue(Compression.ZBLANK));
     }
 
-    @Override
-    public void getValueFromColumn(int index) {
-        getOption().setBScale(getColumnData() == null ? 1.0 : getColumnData()[index]);
-    }
-
-    @Override
-    public void setValueInColumn(int index) {
-        if (!Double.isNaN(getOption().getBScale())) {
-            getColumnData()[index] = getOption().getBScale();
-        }
-    }
-
-    @Override
-    protected Double getInitValue() {
-        return Double.NaN;
-    }
 }

--- a/src/test/java/nom/tam/util/test/BufferedFileTest.java
+++ b/src/test/java/nom/tam/util/test/BufferedFileTest.java
@@ -458,8 +458,7 @@ public class BufferedFileTest {
             for (int i = 0; i < iter; i++) {
                 f.readLArray(fl2);
             }
-            System.out.println(
-                    "  BDS\"Bool error at \" + i Flt read:  " + (1e-6 * Float.BYTES * dim * iter / deltaTime()) + " MB/s");
+            System.out.println("  BDS Flt read:  " + (1e-6 * Float.BYTES * dim * iter / deltaTime()) + " MB/s");
             for (int i = 0; i < iter; i++) {
                 f.readLArray(in2);
             }


### PR DESCRIPTION
### Fixed

 - Fixed header `ZBLANK` value not being used in decompression, when the compressed FITS does not provide per-tile blanking values in a column otherwise. (thanks to @robyww)
 
 - `QuantizeProcessor` had extraneous rounding by half, and sometimes in the wrong direction. Fixed to conform to the FITS specification more completely.
 
 -  Fixed PLIO decompression of 32-bit integer data to restore the upper 2 bytes also.

### Added

 - Added `setColumnData(Object)`, `createColumnData(int)`, and `setColumnSize(int)` methods to `ICompressColumnParameter`.

 - Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression.

 -  `QuantizeOption.useFMA()` method can select whether `Math.fma()` should be used instead of regular arithmetics (default) when converting quantized integers back to their floating-point values. The use of `fma()` matches cfistio / funpack and astropy more closely, but may be very slow on platforms without hardware support. (thanks to @keastrid)

### Changed

 - Quantization in HDU compression has been overhauled, and much simplified. Many strenuous internal classes have been eliminated in favor of simpler, easier to follow, logic.

-  `QuantizeProcessor` integer min/max ranges to use floor / ceil to accommodate dither.
 
 - `QuantizeProcessor` defaults to `ZSCALE` 1.0 and `ZZERO` 0.0 if there are no quantizable valid data (only null or explicit zero values).

 - `Quantize.calculateNoise()` changed to use only regular data, excluding special values like NaNs, infinities, null and zero indicators.
 
 - `Quantize.quantize()` changed to set default values (`ZSCALE` -> 1.0, `ZZERO` -> 0.0, int min/max -> 0) when there is no valid data to quantize.

 - Fully disentangled initialization of compression quantization column data for compression (where prior data may not exist) and decompression (where existing data must be provided).
 
 - Quantized compression to either add `ZBLANK` header value or per-tile column data, but not both, and possibly neither -- as necessary.

 - The default null-value indicator in compressed HDUs is changed to -2147483648, as recommended by the FITS standard.
 
 - Removed `null` options checks from compression parameter methods, and instead commented on the constructors that the parameters should not be instantiated with `null` option parameter. Under the normal behavior of the library the parameters are always created with valid option arguments, so it would take a deliberate effort by the user to do otherwise.

 - Speed up compression / decompression by eliminating extraneous arrays / buffers from the processing. (thanks to @keastrid)

 - `QuantizeOption.toDouble()` method now uses `Math.fma()` to match cfistio / funpack more closely. (thanks to @keastrid)


### Deprecated

 - Deprecated `ICompressColumnParameter.setColumnData(Object, int)`. Its dual functionality has been split into separate `.setColumnData(Object)`, `createColumnData(int)` and `ensureColumnData(int)` methods.

