### PR TITLE
Fixes to `SUBTRACTIVE_DITHER_2` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ Upcoming feature release, likely around 15 September 2026. Many fixes and improv
  - [#885] `QuantizeProcessor` had extraneous rounding by half, and sometimes in the wrong direction. Fixed to conform to the FITS specification more completely. (by @attipaci)
  
  - [#887] Fixed PLIO decompression of 32-bit integer data to restore the upper 2 bytes also.
- 
- - [#891] `QuantizeOption.setDither2()` should not enable/disable zero leveling (it was), or dithering itself. Instead, needs only to enable or disable the special treatment of 0.0 values, as per the FITS specification. Fixed to conform to standard more closely, and updated the Javadoc to reflect its proper usage.
   
  - [#892] When `SUBTRACTIVE_DITHER_2` was used (via `QuantizeOption.setDither()` and `.setDither2()`), the library used the wrong 0.0 value indicator (-2147483646), instead of the value -2147483647 desginated by the standard. Fixed by switching to the standard indicator value. (by @attipaci)
  
@@ -31,7 +29,7 @@ Upcoming feature release, likely around 15 September 2026. Many fixes and improv
  
  - [#884] Added `CompressParameters.activeHeaderParameters()` / `.activeColumnParameters()` to selectively return only those parameters that are necessary for describing the tile compression. (by @attipaci)
  
- - [#885] Added `QuantizeOption.toInt(double)` and `.toDouble(int)` methods which actually perform the conversion. The `.toDouble()` method now uses `Math.fma()` to match cfistion / funpack more closely (thanks to @keastrid). (by @attipaci)
+ - [#885] Added `QuantizeOption.toInt(double)` and `.toDouble(int)` methods which actually perform the conversion. The `.toDouble()` method now uses `Math.fma()` to match cfistio / funpack more closely (thanks to @keastrid). (by @attipaci)
  
  - [#885] `QuantizeOption.useFMA()` method can select whether `Math.fma()` should be used instead of regular arithmetics (default) when converting quantized integers back to their floating-point values. The use of `fma()` matches cfistio / funpack and astropy more closely, but may be very slow on platforms without hardware support. (by @attipaci, thanks to @keastrid)
  
@@ -67,11 +65,13 @@ Upcoming feature release, likely around 15 September 2026. Many fixes and improv
  
  - [#885] Speed up compression / decompression by eliminating extraneous arrays / buffers from the processing. (by @attipaci, thanks to @keastrid)
  
- - [#891] `QuantizeProcessor` constructor no longer calls `QuantizeOption.setCenterOnZero(true)` when dither method 2 (`SUBTRACTIVE_DITHER_2`) is used. While the old behavior was not particularly troublesome, but it was an unnecessary quirk of the implementation. (by @attipaci)
+ - [#891] `QuantizeOption.setDither2()` should not force setting `ZZERO` to 0.0 (it was), or enable dithering itself. Instead, it needs only to enable or disable the special treatment of 0.0 values, as per the FITS specification. Fixed to conform to standard more closely, and updated the Javadoc to reflect its proper usage. The old behavior was not particularly troublesome, but it was an unnecessary quirk of the implementation. (by @attipaci)
  
  - [#891] `QuantizeOption.setCenterOnZero()` did not produce the advertised behavior of keeping ZZERO at 0.0. Changed implementation to match the contract of this method. As such when `ZZERO` is not forced to be 0.0, it will be chosen to try quantize with positive integers only, which can make compression more efficient in some cases. (by @attipaci)
  
  - [#891] Automatic quantization for the compression of floating-point data as integers (via `Quantize.quantize()`) returned `false` (failure to quantize) in more cases than needed. Quantized representation is not possible only if the quantized range exceeds the 32-bit integer data range available, exclusing the special values). The change improves the compression of data. (by @attipaci) 
+ 
+ - [#891] `TableHDU.getColumn(String)` changed to return `null` when there is no column with the specified name. Previously, it threw an `IndexOutOfBoundsException`. (by @attipaci)
  
  - The latest build and runtime Maven dependencies. (by @attipaci)
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to the nom.tam.fits library will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.23.0-rc1] - 2026-08-28
+## [Unreleased]
 
-Upcoming feature release, likely around 15 September 2026.
+Upcoming feature release, likely around 15 September 2026. Many fixes and improvements to the handling of integer-compressed floating point data (with or without dithering).
 
 ### Fixed
 
@@ -21,7 +21,7 @@ Upcoming feature release, likely around 15 September 2026.
  
  - [#891] `QuantizeOption.setDither2()` should not enable/disable zero leveling (it was), or dithering itself. Instead, needs only to enable or disable the special treatment of 0.0 values, as per the FITS specification. Fixed to conform to standard more closely, and updated the Javadoc to reflect its proper usage.
   
- - [#892] When `SUBTRACTIVE_DITHER_2` was used (via `QuantizeOption.setDither()` and `.setDither2()`), the library used the wrong 0 value indicator (-2147483646), instead of the value -2147483647 desginated by the standard. Fixed by switching to the standard indicator value. (by @attipaci)
+ - [#892] When `SUBTRACTIVE_DITHER_2` was used (via `QuantizeOption.setDither()` and `.setDither2()`), the library used the wrong 0.0 value indicator (-2147483646), instead of the value -2147483647 desginated by the standard. Fixed by switching to the standard indicator value. (by @attipaci)
 
 ### Added
 
@@ -36,7 +36,7 @@ Upcoming feature release, likely around 15 September 2026.
  - [#885] `QuantizeOption.useFMA()` method can select whether `Math.fma()` should be used instead of regular arithmetics (default) when converting quantized integers back to their floating-point values. The use of `fma()` matches cfistio / funpack and astropy more closely, but may be very slow on platforms without hardware support. (by @attipaci, thanks to @keastrid)
  
  - [#893] `setup-java` action Java distribution bumped to openJDK 27.
-
+  
 ### Changed
 
  - [#879] Simplified GZIP2 decompression code. (by @attipaci)
@@ -75,7 +75,7 @@ Upcoming feature release, likely around 15 September 2026.
 
  - [#884] Deprecated `ICompressColumnParameter.setColumnData(Object, int)`. Its dual functionality has been split into separate `.setColumnData(Object)`, `createColumnData(int)` and `ensureColumnData(int)` methods. (by @attipaci)
  
- - [#891] Deprecated `QuantizeOption.setCheckZero()` and `.isCheckZero()` methods. They are identical to the `setDither2()` and `isDither2()` methods respectively. (by @attipaci)
+ - [#891] Deprecated `QuantizeOption.setCheckZero()` and `.isCheckZero()` methods. They duplicate the `setDither2()` and `isDither2()` methods respectively. Meanwhile, `.setCheckNull()` and `.isCheckNull()` methods are deprecated as checking for NaN values is automatic when integer compressing floating-point values. (by @attipaci)
  
 
 ## [1.22.2] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Upcoming feature release, likely around 15 September 2026. Many fixes and improv
  - [#891] `QuantizeOption.setDither2()` should not enable/disable zero leveling (it was), or dithering itself. Instead, needs only to enable or disable the special treatment of 0.0 values, as per the FITS specification. Fixed to conform to standard more closely, and updated the Javadoc to reflect its proper usage.
   
  - [#892] When `SUBTRACTIVE_DITHER_2` was used (via `QuantizeOption.setDither()` and `.setDither2()`), the library used the wrong 0.0 value indicator (-2147483646), instead of the value -2147483647 desginated by the standard. Fixed by switching to the standard indicator value. (by @attipaci)
-
+ 
 ### Added
 
  - [#883] Added `TableHDU.getColumnMeta(int, IFitsHeader)` to support standard keyword enums beside the existing string keyword form. (by @attipaci)
@@ -67,7 +67,9 @@ Upcoming feature release, likely around 15 September 2026. Many fixes and improv
  
  - [#885] Speed up compression / decompression by eliminating extraneous arrays / buffers from the processing. (by @attipaci, thanks to @keastrid)
  
- - [#891] `QuantizeProcessor` constructor does not enable centering on zero when dither method 2 (`SUBTRACTIVE_DITHER_2`) is used. It was not particularly troublesome, but it was an unnecessary quirk of the implementation. (by @attipaci)
+ - [#891] `QuantizeProcessor` constructor no longer calls `QuantizeOption.setCenterOnZero(true)` when dither method 2 (`SUBTRACTIVE_DITHER_2`) is used. While the old behavior was not particularly troublesome, but it was an unnecessary quirk of the implementation. (by @attipaci)
+ 
+ - [#891] `QuantizeOption.setCenterOnZero()` did not produce the advertised behavior of keeping ZZERO at 0.0. Changed implementation to match the contract of this method. As such when `ZZERO` is not forced to be 0.0, it will be chosen to try quantize with positive integers only, which can make compression more efficient in some cases. (by @attipaci)
  
  - The latest build and runtime Maven dependencies. (by @attipaci)
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Upcoming feature release, likely around 15 September 2026.
  - [#885] `QuantizeProcessor` had extraneous rounding by half, and sometimes in the wrong direction. Fixed to conform to the FITS specification more completely. (by @attipaci)
  
  - [#887] Fixed PLIO decompression of 32-bit integer data to restore the upper 2 bytes also.
+ 
+ - [#891] `QuantizeOption.setDither2()` should not enable/disable zero leveling (it was), or dithering itself. Instead, needs only to enable or disable the special treatment of 0.0 values, as per the FITS specification. Fixed to conform to standard more closely, and updated the Javadoc to reflect its proper usage.
+  
+ - [#892] When `SUBTRACTIVE_DITHER_2` was used (via `QuantizeOption.setDither()` and `.setDither2()`), the library used the wrong 0 value indicator (-2147483646), instead of the value -2147483647 desginated by the standard. Fixed by switching to the standard indicator value. (by @attipaci)
 
 ### Added
 
@@ -63,11 +67,15 @@ Upcoming feature release, likely around 15 September 2026.
  
  - [#885] Speed up compression / decompression by eliminating extraneous arrays / buffers from the processing. (by @attipaci, thanks to @keastrid)
  
+ - [#891] `QuantizeProcessor` constructor does not enable centering on zero when dither method 2 (`SUBTRACTIVE_DITHER_2`) is used. It was not particularly troublesome, but it was an unnecessary quirk of the implementation. (by @attipaci)
+ 
  - The latest build and runtime Maven dependencies. (by @attipaci)
  
 ### Deprecated
 
  - [#884] Deprecated `ICompressColumnParameter.setColumnData(Object, int)`. Its dual functionality has been split into separate `.setColumnData(Object)`, `createColumnData(int)` and `ensureColumnData(int)` methods. (by @attipaci)
+ 
+ - [#891] Deprecated `QuantizeOption.setCheckZero()` and `.isCheckZero()` methods. They are identical to the `setDither2()` and `isDither2()` methods respectively. (by @attipaci)
  
 
 ## [1.22.2] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Upcoming feature release, likely around 15 September 2026. Many fixes and improv
  
  - [#891] `QuantizeOption.setCenterOnZero()` did not produce the advertised behavior of keeping ZZERO at 0.0. Changed implementation to match the contract of this method. As such when `ZZERO` is not forced to be 0.0, it will be chosen to try quantize with positive integers only, which can make compression more efficient in some cases. (by @attipaci)
  
+ - [#891] Automatic quantization for the compression of floating-point data as integers (via `Quantize.quantize()`) returned `false` (failure to quantize) in more cases than needed. Quantized representation is not possible only if the quantized range exceeds the 32-bit integer data range available, exclusing the special values). The change improves the compression of data. (by @attipaci) 
+ 
  - The latest build and runtime Maven dependencies. (by @attipaci)
  
 ### Deprecated

--- a/src/main/java/nom/tam/fits/TableHDU.java
+++ b/src/main/java/nom/tam/fits/TableHDU.java
@@ -330,7 +330,7 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
      *                           keyword.
      * 
      * @return               an array of primitives (for scalar columns), or else an <code>Object[]</code> array, or
-     *                           possibly <code>null</code>
+     *                           <code>null</code> if there is no column by that name.
      * 
      * @throws FitsException if the table could not be accessed
      *
@@ -340,7 +340,8 @@ public abstract class TableHDU<T extends AbstractTableData> extends BasicHDU<T> 
      * @see                  #getNCols()
      */
     public Object getColumn(String colName) throws FitsException {
-        return getColumn(findColumn(colName));
+        int col = findColumn(colName);
+        return col < 0 ? null : getColumn(col);
     }
 
     /**

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
@@ -88,7 +88,9 @@ public class Quantize {
      */
     private double noise3;
 
-    /* returned 5th order MAD of all non-null pixels */
+    /**
+     * returned 5th order MAD of all non-null pixels
+     */
     private double noise5;
 
     private double xmaxval = Double.NEGATIVE_INFINITY;
@@ -104,6 +106,48 @@ public class Quantize {
     @Deprecated
     public Quantize(QuantizeOption quantizeOption) {
         parameter = quantizeOption;
+    }
+
+    private void checkDataRange(Buffer in) throws IllegalArgumentException {
+        int n = parameter.getTileWidth() * parameter.getTileHeight();
+        int origpos = in.position();
+
+        xminval = Double.POSITIVE_INFINITY;
+        xmaxval = Double.NEGATIVE_INFINITY;
+        xnoise2 = 0.0;
+        xnoise3 = 0.0;
+        xnoise5 = 0.0;
+
+        int nval = 0;
+
+        FloatBuffer fin = (in instanceof FloatBuffer) ? (FloatBuffer) in : null;
+        DoubleBuffer din = (in instanceof DoubleBuffer) ? (DoubleBuffer) in : null;
+
+        if (fin == null && din == null) {
+            throw new IllegalArgumentException("input buffer of type " + in.getClass().getName() + " is unsupported.");
+        }
+
+        for (int i = 0; i < n; i++) {
+            double x = fin == null ? din.get() : fin.get();
+
+            if (!parameter.isRegular(x)) {
+                continue;
+            }
+
+            if (x < xminval) {
+                xminval = x;
+            }
+
+            if (x > xmaxval) {
+                xmaxval = x;
+            }
+
+            nval++;
+        }
+
+        in.position(origpos);
+
+        setNoiseResult(nval);
     }
 
     /**
@@ -352,6 +396,19 @@ public class Quantize {
         return guessQuantization(buf);
     }
 
+    private double getCharacteristicRMS() {
+        // use the minimum of noise2, noise3, and noise5 as the best
+        // noise value
+        double stdev = noise3;
+        if (noise2 != 0.0 && noise2 < stdev) {
+            stdev = noise2;
+        }
+        if (noise5 != 0.0 && noise5 < stdev) {
+            stdev = noise5;
+        }
+        return stdev;
+    }
+
     /**
      * Guesses the quantization scaling and zero offset parameters based on the noise distribution in the data.
      * 
@@ -366,63 +423,40 @@ public class Quantize {
      * @since                           1.23
      */
     boolean guessQuantization(Buffer fdata) throws IllegalArgumentException {
-        // MAD 2nd, 3rd, and 5th order noise values
-        double stdev;
-        double bScale; /* bscale, 1 in intdata = delta in fdata */
 
         // AK: defaults
-        parameter.setBScale(1.);
-        parameter.setBZero(0.);
+        parameter.setBScale(1.0);
+        parameter.setBZero(0.0);
 
-        long nx = (long) parameter.getTileWidth() * (long) parameter.getTileHeight();
-        if (nx <= 1L) {
-            return false;
+        // estimate background noise using MAD pixel differences
+        if (parameter.getQLevel() >= 0.0) {
+            calculateNoise(fdata);
+        } else {
+            checkDataRange(fdata);
         }
 
-        if (parameter.getQLevel() >= 0.) {
-            /* estimate background noise using MAD pixel differences */
-            calculateNoise(fdata);
-            // special case of an image filled with Nulls
-            if (ngood == 0) {
-                /* set parameters to dummy values, which are not used */
-                parameter.setMinValue(0.0);
-                parameter.setMaxValue(1.0);
-                return false;
-            }
-
-            // use the minimum of noise2, noise3, and noise5 as the best
-            // noise value
-            stdev = noise3;
-            if (noise2 != 0. && noise2 < stdev) {
-                stdev = noise2;
-            }
-            if (noise5 != 0. && noise5 < stdev) {
-                stdev = noise5;
-            }
-
-            if (parameter.getQLevel() == 0.) {
-                bScale = stdev / DEFAULT_QUANT_LEVEL; /* default quantization */
+        if (ngood > 0) {
+            if (parameter.getQLevel() >= 0.0) {
+                parameter.setBScale(getCharacteristicRMS()
+                        / (parameter.getQLevel() == 0.0 ? DEFAULT_QUANT_LEVEL : parameter.getQLevel()));
             } else {
-                bScale = stdev / parameter.getQLevel();
+                // negative Q value represents the absolute quantization level
+                parameter.setBScale(-parameter.getQLevel());
             }
-            if (bScale == 0.) {
-                return false; /* don't quantize */
-            }
+
+            parameter.setMinValue(minValue);
+            parameter.setMaxValue(maxValue);
         } else {
-            /* negative value represents the absolute quantization level */
-            bScale = -parameter.getQLevel();
-            /* only need to calculate the min and max values */
-            calculateNoise(fdata);
+            /* set parameters to dummy values, which are not used */
+            parameter.setMinValue(0.0);
+            parameter.setMaxValue(0.0);
         }
 
         /* check that the number of quantized levels does not exceed the range of regular integer values */
-        if (Math.ceil((maxValue - minValue) / bScale) >= 2.0 * Integer.MAX_VALUE) {
+        if (Math.ceil((maxValue - minValue) / parameter.getBScale()) >= 2.0 * Integer.MAX_VALUE) {
             return false; /* don't quantize */
         }
 
-        parameter.setBScale(bScale);
-        parameter.setMinValue(minValue);
-        parameter.setMaxValue(maxValue);
         parameter.updateBZeroAndIntLimits();
 
         return true; /* yes, data have been quantized */

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/Quantize.java
@@ -49,14 +49,7 @@ public class Quantize {
 
     private static final double DEFAULT_QUANT_LEVEL = 4.;
 
-    private static final double MAX_INT_AS_DOUBLE = Integer.MAX_VALUE;
-
     private static final int MINIMUM_PIXEL_WIDTH = 9;
-
-    /**
-     * number of reserved values, starting with
-     */
-    private static final long N_RESERVED_VALUES = 10;
 
     private static final int N4 = 4;
 
@@ -350,7 +343,8 @@ public class Quantize {
      * @param  nxpix (unused) the image width -- the tile width of the initializing option is used instead.
      * @param  nypix (unused) the image hight -- the tile height of the initializing option is used instead.
      * 
-     * @return       true if the quantification was possible
+     * @return       <code>true</code> if the quantification was possible, or else <code>false</code> if the tile cannot
+     *                   be quantized
      */
     @Deprecated
     public boolean quantize(double[] fdata, int nxpix, int nypix) {
@@ -384,6 +378,7 @@ public class Quantize {
         if (nx <= 1L) {
             return false;
         }
+
         if (parameter.getQLevel() >= 0.) {
             /* estimate background noise using MAD pixel differences */
             calculateNoise(fdata);
@@ -419,8 +414,9 @@ public class Quantize {
             /* only need to calculate the min and max values */
             calculateNoise(fdata);
         }
-        /* check that the range of quantized levels is not > range of int */
-        if ((maxValue - minValue) / bScale > 2. * MAX_INT_AS_DOUBLE - N_RESERVED_VALUES) {
+
+        /* check that the number of quantized levels does not exceed the range of regular integer values */
+        if (Math.ceil((maxValue - minValue) / bScale) >= 2.0 * Integer.MAX_VALUE) {
             return false; /* don't quantize */
         }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -76,7 +76,7 @@ public class QuantizeOption implements ICompressOption {
 
     private Integer nullValueIndicator;
 
-    private boolean checkNull;
+    private boolean checkNull; // tracked but not used
 
     private int intMaxValue;
 
@@ -92,17 +92,10 @@ public class QuantizeOption implements ICompressOption {
 
     private int tileWidth;
 
-    private static final double MAX_INT_AS_DOUBLE = Integer.MAX_VALUE;
-
     /** Quantization constant */
     private static final int RANDOM_MULTIPLICATOR = 500;
 
     private static final double DITHER_HALF = 0.5;
-
-    /**
-     * number of reserved values, starting with
-     */
-    private static final long N_RESERVED_VALUES = 10;
 
     /**
      * Dither random seed value
@@ -372,7 +365,7 @@ public class QuantizeOption implements ICompressOption {
      * Checks whether we force the integer quantized level 0 to correspond to a floating-point level 0.0, when using
      * automatic quantization.
      * 
-     * @return <code>true</code> if we want to keep `BZERO` at 0 when quantizing automatically.
+     * @return <code>true</code> if we want to keep `ZZERO` at 0.0 when quantizing automatically.
      * 
      * @see    #setCenterOnZero(boolean)
      */
@@ -459,12 +452,7 @@ public class QuantizeOption implements ICompressOption {
      * @see          #getBNull()
      */
     public ICompressOption setBNull(Integer blank) {
-        if (blank != null) {
-            nullValueIndicator = blank;
-            checkNull = true;
-        } else {
-            checkNull = false;
-        }
+        nullValueIndicator = blank;
         return this;
     }
 
@@ -506,9 +494,9 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Enabled or disables keeping `BZERO` at 0 when using automatic quantization.
+     * Enabled or disables keeping `ZZERO` at 0 when using automatic quantization.
      * 
-     * @param  value <code>true</code> to keep `BZERO` at 0 when quantizing automatically, that is keep the integer
+     * @param  value <code>true</code> to keep `ZZERO` at 0 when quantizing automatically, that is keep the integer
      *                   quantized level 0 correspond to floating-point level 0.0. Or, <code>false</code> to let the
      *                   automatic quantization algorithm determine the optimal quantization offset.
      * 
@@ -535,9 +523,6 @@ public class QuantizeOption implements ICompressOption {
     @Deprecated
     public QuantizeOption setCheckNull(boolean value) {
         checkNull = value;
-        if (value && nullValueIndicator == null) {
-            nullValueIndicator = RECOMMENDED_NAN_INDICATOR;
-        }
         return this;
     }
 
@@ -801,7 +786,7 @@ public class QuantizeOption implements ICompressOption {
         if (!Double.isFinite(x)) {
             return false;
         }
-        if (checkNull && x == nullValue) {
+        if (x == nullValue) {
             return false;
         }
         if (isCheckZero() && x == 0.0) {
@@ -872,27 +857,27 @@ public class QuantizeOption implements ICompressOption {
     }
 
     double findBZero() {
-        if (!checkNull && !isCenterOnZero()) {
-            // don't have to check for nulls
-            // return all positive values, if possible since some compression
-            // algorithms either only work for positive integers, or are more
-            // efficient.
-            if ((maxValue - minValue) / bScale < MAX_INT_AS_DOUBLE - N_RESERVED_VALUES) {
-                // fudge the zero point so it is an integer multiple of bScale
-                // This helps to ensure the same scaling will be performed if
-                // the file undergoes multiple fpack/funpack cycles
-                // AK: round to multiple of bScale.
-                return minValue - Math.IEEEremainder(minValue, bScale);
-            }
-
-            /* center the quantized levels around zero */
-            return (minValue + maxValue) / 2.;
+        if (isCenterOnZero()) {
+            // Force ZZERO to be 0.0, as requested
+            return 0.0;
         }
 
-        // data contains null values or has be forced to center on zero
-        // shift the range to be close to the value used to represent null
-        // values
-        return minValue - bScale * (Integer.MIN_VALUE + N_RESERVED_VALUES + 1);
+        // return all positive values, if possible since some compression
+        // algorithms are more efficient that way.
+        if (Math.ceil((maxValue - minValue) / bScale) < Integer.MAX_VALUE) {
+            // fudge the zero point so it is an integer multiple of bScale
+            // This helps to ensure the same scaling will be performed if
+            // the file undergoes multiple fpack/funpack cycles
+            // AK: round to multiple of bScale.
+            double rem = Math.IEEEremainder(minValue, bScale);
+            if (rem < 0.0) {
+                rem += bScale;
+            }
+            return minValue - rem;
+        }
+
+        // center the quantized levels around zero
+        return (minValue + maxValue) / 2.;
     }
 
     /**

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -48,12 +48,15 @@ import nom.tam.fits.compression.provider.param.quant.QuantizeParameters;
 public class QuantizeOption implements ICompressOption {
 
     /**
-     * and including NULL_VALUE. These values may not be used to represent the quantized and scaled floating point pixel
-     * values If lossy Hcompression is used, and the tiledImageOperation contains null values, then it is also possible
-     * for the compressed values to slightly exceed the range of the actual (lossless) values so we must reserve a
-     * little more space value used to represent undefined pixels
+     * The integer value recommeded by the FITS standard to represent NaN floating-point values in integer compressed
+     * data.
      */
-    private static final int NULL_VALUE = Integer.MIN_VALUE;
+    private static final int RECOMMENDED_NAN_INDICATOR = Integer.MIN_VALUE;
+
+    /**
+     * value used to represent zero-valued pixels when dither method 2 is used.
+     */
+    private static final int DITHER2_ZERO_INDICATOR = Integer.MIN_VALUE + 1;
 
     private static boolean useFMA = false;
 
@@ -143,9 +146,12 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Returns the integer value that represents missing (<code>null</code>) data in the quantized representation.
+     * Returns the integer value that represents missing (<code>null</code>) for integer compressed floating-point data.
+     * This funtion was named poorly as it sets the <code>ZBLANK</code> value in the header or in the equivalently named
+     * column.
      * 
-     * @return the integer blanking value (<code>null</code> value).
+     * @return the integer blanking value (for integer-compressed <code>NaN</code>s). If the returned value is
+     *             <code>null</code>, then the recommended value -2147483647 will be used as needed.
      * 
      * @see    #setBNull(Integer)
      */
@@ -154,7 +160,10 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Returns the quantization level.
+     * Returns the quantization level for integer compressed floating-point data. This funtion was named poorly as it
+     * sets the <code>ZSCALE</code> parameter value in the named column when compressing floating-point data with an
+     * algorithm that supports integers only. It has nothing to do with the <code>BSCALE</code> header value, which
+     * indicates the integer representation of floating-point data for the <i>uncompressed</i> data.
      * 
      * @return the floating-point difference between integer levels in the quantized data.
      * 
@@ -166,7 +175,10 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Returns the quantization offset.
+     * Returns the quantization offset for integer compressed floating-point data. This funtion was named poorly as it
+     * sets the <code>ZZERO</code> parameter value in the named column when compressing floating-point data with an
+     * algorithm that supports integers only. It has nothing to do with the <code>BZERO</code> header value, which
+     * indicates the integer representation of floating-point data for the <i>uncompressed</i> data.
      * 
      * @return the floating-point value corresponding to the integer level 0.
      * 
@@ -261,25 +273,27 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Returns the floating-point value that indicates a <code>null</code> datum in the image before quantization is
+     * Returns the floating-point value that indicates missing or invalid data in the image before quantization is
      * applied. Normally, the FITS standard is that NaN values indicate <code>null</code> values in floating-point
      * images. While this class allows using other values also, they are not recommended since they are not supported by
      * FITS in a standard way.
      * 
-     * @return the floating-point value that represents a <code>null</code> value (missing data) in the image before
-     *             quantization.
+     * @return     the floating-point value that represents a <code>null</code> value (missing data) in the image before
+     *                 quantization.
      * 
-     * @see    #setNullValue(double)
-     * @see    #getNullValueIndicator()
-     * @see    #isCheckNull()
+     * @see        #setNullValue(double)
+     * @see        #getBNull()
+     * 
+     * @deprecated The FITS standard allows only NaNs to indicate missing / invalid floating-point data.
      */
+    @Deprecated
     public double getNullValue() {
         return nullValue;
     }
 
     /**
-     * @deprecated use {@link #getBNull()} instead (duplicate method). Returns the integer value that represents missing
-     *                 data (<code>null</code>) in the quantized representation.
+     * @deprecated use {@link #getBNull()} instead (duplicate method). Returns the integer value that represents
+     *                 <code>NaN</code> values in integer-compressed floating-point data.
      * 
      * @return     the integer blanking value (<code>null</code> value).
      * 
@@ -369,11 +383,14 @@ public class QuantizeOption implements ICompressOption {
     /**
      * Whether the floating-point data may contain <code>null</code> values (normally NaNs).
      * 
-     * @return <code>true</code> if we should expect <code>null</code> in the floating-point data. This is automatically
-     *             <code>true</code> if {@link #setBNull(Integer)} was called with a non-null value.
+     * @return     <code>true</code> if we should expect <code>null</code> in the floating-point data. This is
+     *                 automatically <code>true</code> if {@link #setBNull(Integer)} was called with a non-null value.
      * 
-     * @see    #setBNull(Integer)
+     * @see        #setBNull(Integer)
+     * 
+     * @deprecated Use {@link #getBNull()} instead to see if a custom null-value indicator has been configured.
      */
+    @Deprecated
     public boolean isCheckNull() {
         return checkNull;
     }
@@ -411,15 +428,15 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Whether dither method 2 is used which treats 0.0 values as special.
+     * Whether dithering (when enabled) uses method 2, which treats 0.0 values as special.
      * 
-     * @return <code>true</code> if dither method 2 is used, or else <code>false</code>
+     * @return <code>true</code> if method 2 is used is used for dithering, or else <code>false</code>
      * 
      * @see    #setDither2(boolean)
      * @see    #isDither()
      */
     public boolean isDither2() {
-        return config.dither && config.checkZero;
+        return config.checkZero;
     }
 
     @Override
@@ -428,16 +445,18 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Sets the integer value that represents missing data (<code>null</code>) in the quantized representation.
+     * Sets the integer value that represents missing data (<code>null</code>) for integer compressed floating-point
+     * data. This funtion was named poorly as it sets the <code>ZBLANK</code> value in the header or in the equivalently
+     * named column.
      * 
-     * @param  blank the new integer blanking value (that is one that denotes a missing or <code>null</code> datum).
-     *                   Setting this option to <code>null</code> disables the treatment of issing or <code>null</code>
-     *                   data.
+     * @param  blank the new integer value that denotes <code>NaN</code> when floating-point data is compressed with an
+     *                   integer-only algorithm. Setting this option to <code>null</code> will set the header
+     *                   <code>ZBLANK</code> value, when the data contains NaNs, to -2147483647 (i.e., the value
+     *                   recommended by the FITS standard).
      * 
      * @return       itself
      * 
      * @see          #getBNull()
-     * @see          #isCheckNull()
      */
     public ICompressOption setBNull(Integer blank) {
         if (blank != null) {
@@ -450,7 +469,10 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Sets the quantization level.
+     * Sets the quantization level for integer compressed floating-point data. This funtion was named poorly as it sets
+     * the <code>ZZERO</code> parameter value in the named column when compressing floating-point data with an algorithm
+     * that supports integers only. It has nothing to do with the <code>BZERO</code> header value, which indicates the
+     * integer representation of floating-point data for the <i>uncompressed</i> data.
      * 
      * @param  value the new floating-point difference between integer levels in the quantized data.
      * 
@@ -466,7 +488,10 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Sets the quantization offset.
+     * Sets the quantization offset for integer compressed floating-point data. This funtion was named poorly as it sets
+     * the <code>ZZERO</code> parameter value in the named column when compressing floating-point data with an algorithm
+     * that supports integers only. It has nothing to do with the <code>BZERO</code> header value, which indicates the
+     * integer representation of floating-point data for the <i>uncompressed</i> data.
      * 
      * @param  value the new floating-point value corresponding to the integer level 0.
      * 
@@ -497,22 +522,21 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * @deprecated       {@link #setBNull(Integer)} controls this feature automatically as needed. Sets whether we
-     *                       should expect the floating-point data to contain <code>null</code> values (normally NaNs).
+     * Sets whether we should expect the floating-point data to contain <code>null</code> values (normally NaNs).
+     * 
+     * @deprecated       This feature is set automatically as needed.
      * 
      * @param      value <code>true</code> if the floating-point data may contain <code>null</code> values.
      * 
      * @return           itself
      * 
-     * @see              #setCheckNull(boolean)
      * @see              #setBNull(Integer)
-     * @see              #getNullValue()
      */
     @Deprecated
     public QuantizeOption setCheckNull(boolean value) {
         checkNull = value;
         if (value && nullValueIndicator == null) {
-            nullValueIndicator = NULL_VALUE;
+            nullValueIndicator = RECOMMENDED_NAN_INDICATOR;
         }
         return this;
     }
@@ -633,20 +657,21 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * @deprecated       The use of null values other than <code>NaN</code> for floating-point data types is not
-     *                       standard in FITS. You should therefore avoid using this method to change it. Returns the
-     *                       floating-point value that indicates a <code>null</code> datum in the image before
-     *                       quantization is applied. Normally, the FITS standard is that NaN values indicate
-     *                       <code>null</code> values in floating-point images. While this class allows using other
-     *                       values also, they are not recommended since they are not supported by FITS in a standard
-     *                       way.
+     * Sets the floating-point value that indicates missing data in the floating point image image before quantization
+     * is applied. Normally, the FITS standard is that NaN values indicate <code>null</code> values in floating-point
+     * images. While this class allows using other values also, they are not recommended since they are not supported by
+     * FITS in a standard way.
      * 
      * @param      value the new floating-point value that represents a <code>null</code> value (missing data) in the
      *                       image before quantization.
      * 
      * @return           itself
      * 
-     * @see              #setNullValue(double)
+     * @see              #getNullValue()
+     * @see              #setBNull(Integer)
+     * 
+     * @deprecated       The use of null values other than <code>NaN</code> for floating-point data types is not
+     *                       standard in FITS. You should therefore avoid using this method, in general.
      */
     @Deprecated
     public QuantizeOption setNullValue(double value) {
@@ -747,11 +772,6 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * value used to represent zero-valued pixels
-     */
-    private static final int ZERO_VALUE = Integer.MIN_VALUE + 1;
-
-    /**
      * Re-initialize the dither sequence.
      */
     void initDither() {
@@ -800,15 +820,15 @@ public class QuantizeOption implements ICompressOption {
      * @since    1.23
      */
     int toInt(double d) {
-        if (Double.isNaN(d) || (checkNull && d == nullValue)) {
+        if (Double.isNaN(d) || d == nullValue) {
             if (nullValueIndicator == null) {
-                nullValueIndicator = NULL_VALUE;
+                nullValueIndicator = RECOMMENDED_NAN_INDICATOR;
             }
             return nullValueIndicator;
         }
 
-        if (isDither2() && d == 0.0) {
-            return ZERO_VALUE;
+        if (isDither() && isDither2() && d == 0.0) {
+            return DITHER2_ZERO_INDICATOR;
         }
 
         d -= bZero;
@@ -829,11 +849,11 @@ public class QuantizeOption implements ICompressOption {
      * @since    1.23
      */
     double toDouble(int i) {
-        if (isDither2() && i == ZERO_VALUE) {
+        if (isDither() && isDither2() && i == DITHER2_ZERO_INDICATOR) {
             return 0.0;
         }
 
-        if (checkNull && i == nullValueIndicator) {
+        if (nullValueIndicator != null && i == nullValueIndicator) {
             return nullValue;
         }
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -51,7 +51,7 @@ public class QuantizeOption implements ICompressOption {
      * The integer value recommeded by the FITS standard to represent NaN floating-point values in integer compressed
      * data.
      */
-    private static final int RECOMMENDED_NAN_INDICATOR = Integer.MIN_VALUE;
+    public static final int RECOMMENDED_NAN_INDICATOR = Integer.MIN_VALUE;
 
     /**
      * value used to represent zero-valued pixels when dither method 2 is used.
@@ -374,8 +374,7 @@ public class QuantizeOption implements ICompressOption {
     /**
      * Whether the floating-point data may contain <code>null</code> values (normally NaNs).
      * 
-     * @return     <code>true</code> if we should expect <code>null</code> in the floating-point data. This is
-     *                 automatically <code>true</code> if {@link #setBNull(Integer)} was called with a non-null value.
+     * @return     <code>true</code> (always since 1.23).
      * 
      * @see        #setBNull(Integer)
      * 
@@ -509,11 +508,11 @@ public class QuantizeOption implements ICompressOption {
 
     /**
      * Obsolete method that used to set whether we should expect the floating-point data to contain <code>null</code>
-     * values (normally NaNs).
+     * values (NaNs).
      * 
      * @deprecated       This feature is set automatically as needed.
      * 
-     * @param      value (unused)
+     * @param      value (unused since 1.23)
      * 
      * @return           itself
      * 

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -379,18 +379,21 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Whether automatic quantization treats 0.0 as a special value. Normally values within the `BSCALE` quantization
-     * level around 0.0 will be assigned the same integer quanta, and will become indistinguishable in the quantized
-     * data. Some software may, in their misguided ways, assign exact zero values a special meaning (such as no data) in
-     * which case we may want to distinguish these as we apply quantization. However, it is generally not a good idea to
-     * use 0 as a special value.
+     * Whether automatic quantization treats 0.0 as a special value. The special treatment of 0.0 values is the
+     * distinguishing feature of dither method 2 over method 1.
      * 
-     * @return <code>true</code> to treat 0.0 (exact) as a special value, or <code>false</code> to treat is as any other
-     *             measured value (recommended).
+     * @deprecated Use {@link #isDither2()} instead. The special treatent of ero values is the distinghuishing feature
+     *                 of the <code>SUBTRACTIVE_DITHER_2</code> method, which is otherwise the same as
+     *                 <code>SUBTRACTIVE_DITHER_1</code>.
      * 
-     * @see    #setCheckZero(boolean)
-     * @see    #getBScale()
+     * @return     <code>true</code> to treat 0.0 (exact) as a special value, or <code>false</code> to treat is as any
+     *                 other measured value (recommended).
+     * 
+     * @see        #isDither2()
+     * @see        #setDither2(boolean)
+     * @see        #getBScale()
      */
+    @Deprecated
     public boolean isCheckZero() {
         return config.checkZero;
     }
@@ -408,7 +411,7 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Whether dither method 2 is used.
+     * Whether dither method 2 is used which treats 0.0 values as special.
      * 
      * @return <code>true</code> if dither method 2 is used, or else <code>false</code>
      * 
@@ -416,7 +419,7 @@ public class QuantizeOption implements ICompressOption {
      * @see    #isDither()
      */
     public boolean isDither2() {
-        return config.dither2;
+        return config.dither && config.checkZero;
     }
 
     @Override
@@ -515,27 +518,25 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Sets whether automatic quantization is to treat 0.0 as a special value. Normally values within the `BSCALE`
-     * quantization level around 0.0 will be assigned the same integer quanta, and will become indistinguishable in the
-     * quantized data. However some software may assign exact zero values a special meaning (such as no data) in which
-     * case we may want to distinguish these as we apply qunatization. However, it is generally not a good idea to use 0
-     * as a special value. To mark missing data, the FITS standard recognises only NaN as a special value -- while all
-     * other values should constitute valid measurements.
+     * Sets whether automatic quantization is to treat 0.0 as a special value. This is the same as
+     * {@link #setDither2(boolean)}. When enabled and dithering is used, then 0.0 values will be denoted with the
+     * special value −2147483647 in the quantized representation.
      * 
-     * @deprecated       It is strongly discouraged to treat 0.0 values as special. FITS only recognises NaN as a
-     *                       special floating-point value marking missing data. All other floating point values are
-     *                       considered valid measurements.
+     * @deprecated       Use {@link #setDither2(boolean)} instead if you want zero values to be special encoded. The
+     *                       representation of true zero values is the unique feature of the
+     *                       <code>SUBTRACTIVE_DITHER_2</code> method that sets it apart from
+     *                       <code>SUBTRACTIVE_DITHER_1</code>.
      * 
-     * @param      value whether to treat values around 0.0 as special.
+     * @param      value (unused) value whether to treat values around 0.0 as special.
      * 
      * @return           itself
      * 
-     * @see              #isCheckZero()
+     * @see              #setDither2(boolean)
+     * @see              #isDither2()
      */
     @Deprecated
     public QuantizeOption setCheckZero(boolean value) {
-        config.checkZero = value;
-        return this;
+        return setDither2(value);
     }
 
     /**
@@ -554,7 +555,10 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Sets whether dithering is to use method 2.
+     * Sets whether dithering is to use method 2, when dithering is enabled. It does not actually enable or disable
+     * dithering itself -- for that you must call {@link #setDither(boolean)}. When dither method 2 is used, then 0.0
+     * values will be denoted with the special value −2147483647 in the quantized representation, whereas dither method
+     * 1 treats 0.0 just like any other decomal value.
      * 
      * @param  value <code>true</code> to use dither method 2, or else <code>false</code> for method 1.
      * 
@@ -564,7 +568,7 @@ public class QuantizeOption implements ICompressOption {
      * @see          #setDither(boolean)
      */
     public QuantizeOption setDither2(boolean value) {
-        config.dither2 = value;
+        config.checkZero = value;
         return this;
     }
 
@@ -745,7 +749,7 @@ public class QuantizeOption implements ICompressOption {
     /**
      * value used to represent zero-valued pixels
      */
-    private static final int ZERO_VALUE = Integer.MIN_VALUE + 2;
+    private static final int ZERO_VALUE = Integer.MIN_VALUE + 1;
 
     /**
      * Re-initialize the dither sequence.
@@ -803,13 +807,13 @@ public class QuantizeOption implements ICompressOption {
             return nullValueIndicator;
         }
 
-        if (isCheckZero() && d == 0.0) {
+        if (isDither2() && d == 0.0) {
             return ZERO_VALUE;
         }
 
         d -= bZero;
         d /= bScale;
-        if (isDither() || isDither2()) {
+        if (isDither()) {
             d += nextDither();
         }
         return (int) Math.round(d);
@@ -825,7 +829,7 @@ public class QuantizeOption implements ICompressOption {
      * @since    1.23
      */
     double toDouble(int i) {
-        if (isCheckZero() && i == ZERO_VALUE) {
+        if (isDither2() && i == ZERO_VALUE) {
             return 0.0;
         }
 
@@ -834,7 +838,7 @@ public class QuantizeOption implements ICompressOption {
         }
 
         double d = i;
-        if (isDither() || isDither2()) {
+        if (isDither()) {
             d -= nextDither();
         }
 
@@ -910,11 +914,9 @@ public class QuantizeOption implements ICompressOption {
 
         private boolean centerOnZero;
 
-        private boolean checkZero;
-
         private boolean dither;
 
-        private boolean dither2;
+        private boolean checkZero;
 
         private double qlevel = Double.NaN;
 

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeOption.java
@@ -76,8 +76,6 @@ public class QuantizeOption implements ICompressOption {
 
     private Integer nullValueIndicator;
 
-    private boolean checkNull; // tracked but not used
-
     private int intMaxValue;
 
     private int intMinValue;
@@ -384,8 +382,8 @@ public class QuantizeOption implements ICompressOption {
      * @deprecated Use {@link #getBNull()} instead to see if a custom null-value indicator has been configured.
      */
     @Deprecated
-    public boolean isCheckNull() {
-        return checkNull;
+    public final boolean isCheckNull() {
+        return true;
     }
 
     /**
@@ -451,7 +449,7 @@ public class QuantizeOption implements ICompressOption {
      * 
      * @see          #getBNull()
      */
-    public ICompressOption setBNull(Integer blank) {
+    public QuantizeOption setBNull(Integer blank) {
         nullValueIndicator = blank;
         return this;
     }
@@ -510,11 +508,12 @@ public class QuantizeOption implements ICompressOption {
     }
 
     /**
-     * Sets whether we should expect the floating-point data to contain <code>null</code> values (normally NaNs).
+     * Obsolete method that used to set whether we should expect the floating-point data to contain <code>null</code>
+     * values (normally NaNs).
      * 
      * @deprecated       This feature is set automatically as needed.
      * 
-     * @param      value <code>true</code> if the floating-point data may contain <code>null</code> values.
+     * @param      value (unused)
      * 
      * @return           itself
      * 
@@ -522,7 +521,6 @@ public class QuantizeOption implements ICompressOption {
      */
     @Deprecated
     public QuantizeOption setCheckNull(boolean value) {
-        checkNull = value;
         return this;
     }
 
@@ -923,7 +921,7 @@ public class QuantizeOption implements ICompressOption {
 
         private boolean checkZero;
 
-        private double qlevel = Double.NaN;
+        private double qlevel = 4.0;
 
         private long seed = 1L;
     }

--- a/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeProcessor.java
+++ b/src/main/java/nom/tam/fits/compression/algorithm/quant/QuantizeProcessor.java
@@ -91,11 +91,6 @@ public class QuantizeProcessor {
     public QuantizeProcessor(QuantizeOption quantizeOption, ICompressor<IntBuffer> compressor) {
         this.quantizeOption = quantizeOption;
         this.postCompressor = compressor;
-
-        if (quantizeOption.isDither2()) {
-            quantizeOption.setCenterOnZero(true);
-            quantizeOption.setCheckZero(true);
-        }
         quantize = new Quantize(quantizeOption);
     }
 

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
@@ -93,18 +93,18 @@ public class QuantizeParameters extends CompressParameters {
 
     @Override
     protected ICompressColumnParameter[] activeColumnParameters() {
-        if (blankColumn.differsFrom(getCurrentZBlank())) {
-            // We have per-tile blanking values
-            return new ICompressColumnParameter[] {blankColumn, zero, scale};
+        if (blankColumn.isUniform()) {
+            return new ICompressColumnParameter[] {zero, scale};
         }
-        return new ICompressColumnParameter[] {zero, scale};
+        // We have per-tile blanking values
+        return new ICompressColumnParameter[] {blankColumn, zero, scale};
     }
 
     @Override
     protected ICompressHeaderParameter[] activeHeaderParameters() {
         Integer zblank = getCurrentZBlank();
 
-        if (zblank == null || blankColumn.differsFrom(zblank)) {
+        if (zblank == null || !blankColumn.isUniform()) {
             // We have per-tile blanking values
             return new ICompressHeaderParameter[] {quantz, seed};
         }

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZBlankColumnParameter.java
@@ -68,32 +68,28 @@ public final class ZBlankColumnParameter extends CompressColumnParameter<int[], 
     }
 
     /**
-     * Checks if any of the column entries differs from the specified 'standard' value.
+     * Checks if the column entries are all the same.
      * 
-     * @param  value the 'standard' value
+     * @return <code>true</code> if the entries in the column are all identical. Otherwise <code>false</code> if the
+     *             entries vary.
      * 
-     * @return       <code>true</code> if any column entry differs from the specified value. Otherwise
-     *                   <code>false</code>.
-     * 
-     * @since        1.23
+     * @since  1.23
      */
-    boolean differsFrom(Integer value) {
+    boolean isUniform() {
         int[] col = getColumnData();
         if (col != null) {
-            if (value == null) {
-                return true;
-            }
+            int value = col[0];
             for (int entry : col) {
                 if (entry != value) {
-                    return true;
+                    return false;
                 }
             }
         }
-        return false;
+        return true;
     }
 
     @Override
     protected Integer getInitValue() {
-        return Integer.MIN_VALUE;
+        return QuantizeOption.RECOMMENDED_NAN_INDICATOR;
     }
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZScaleColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZScaleColumnParameter.java
@@ -58,6 +58,6 @@ final class ZScaleColumnParameter extends CompressColumnParameter<double[], Quan
 
     @Override
     protected Double getInitValue() {
-        return Double.NaN;
+        return 1.0;
     }
 }

--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/ZZeroColumnParameter.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/ZZeroColumnParameter.java
@@ -58,6 +58,6 @@ final class ZZeroColumnParameter extends CompressColumnParameter<double[], Quant
 
     @Override
     protected Double getInitValue() {
-        return Double.NaN;
+        return 0.0;
     }
 }

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -139,7 +139,7 @@ public class QuantizeTest {
                 }
             }
 
-            Assertions.assertEquals(-2147483637, option.getIntMinValue());
+            Assertions.assertEquals(0, option.getIntMinValue());
         }
     }
 
@@ -220,15 +220,13 @@ public class QuantizeTest {
 
         checkRequantedValues(quantProcessor, quants, matrix, option, false);
 
-        Assertions.assertArrayEquals(new int[] {-2147483647, -2147483637, -2147483634, -2147483632, -2147483629,
-                -2147483627, -2147483625, -2147483622, -2147483619, -2147483617, -2147483615, -2147483612, -2147483609,
-                -2147483607, -2147483604, -2147483602, -2147483599, -2147483597, -2147483595, -2147483593, -2147483590,
-                -2147483587, -2147483585, -2147483582}, quants.array());
-
         Assertions.assertEquals(4.000000e+00, option.getBScale(), 1e-20);
-        Assertions.assertEquals(8.589934557999833E9, option.getBZero(), 1e-20);
-        Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-2147483582, option.getIntMaxValue());
+        Assertions.assertEquals(8.0, option.getBZero(), 1e-12);
+        Assertions.assertEquals(0, option.getIntMinValue());
+        Assertions.assertEquals(55, option.getIntMaxValue());
+
+        Assertions.assertArrayEquals(new int[] {-2147483647, 0, 3, 5, 8, 10, 13, 15, 18, 21, 23, 25, 28, 30, 33, 36, 38, 41,
+                42, 45, 47, 50, 53, 55}, quants.array());
     }
 
     @Test
@@ -251,12 +249,12 @@ public class QuantizeTest {
         quantProcessor.quantize(matrix, quants);
         quants.rewind();
 
-        checkRequantedValues(quantProcessor, quants, matrix, option, false);
-
         Assertions.assertEquals(9.18810439811682E-7, option.getBScale(), 1e-20);
-        Assertions.assertEquals(1983.130218334527, option.getBZero(), 1e-10);
-        Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-1974235153, option.getIntMaxValue());
+        Assertions.assertEquals(0.0, option.getBZero(), 1e-10);
+        Assertions.assertEquals(10883456, option.getIntMinValue());
+        Assertions.assertEquals(184131941, option.getIntMaxValue());
+
+        checkRequantedValues(quantProcessor, quants, matrix, option, false);
     }
 
     @Test
@@ -282,14 +280,14 @@ public class QuantizeTest {
         quantProcessor.quantize(matrix, quants);
         quants.rewind();
 
-        checkRequantedValues(quantProcessor, quants, matrix, option, false);
-
         Assertions.assertEquals(xsize * ysize, quants.limit());
 
         Assertions.assertEquals(8.11574856349585578526e-07, option.getBScale(), 1e-20);
-        Assertions.assertEquals(1.74284372421136049525e+03, option.getBZero(), 1e-10);
-        Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-1866576063, option.getIntMaxValue());
+        Assertions.assertEquals(0.0, option.getBZero(), 1e-10);
+        Assertions.assertEquals(0, option.getIntMinValue());
+        Assertions.assertEquals(280907574, option.getIntMaxValue());
+
+        checkRequantedValues(quantProcessor, quants, matrix, option, false);
     }
 
     @Test
@@ -313,12 +311,12 @@ public class QuantizeTest {
         quantProcessor.quantize(matrix, quants);
         quants.rewind();
 
-        checkRequantedValues(quantProcessor, quants, matrix, option, false);
-
         Assertions.assertEquals(8.11574856349585578526e-07, option.getBScale(), 1e-20);
-        Assertions.assertEquals(1.74284372421136049525e+03, option.getBZero(), 1e-10);
-        Assertions.assertEquals(-2147483637, option.getIntMinValue());
-        Assertions.assertEquals(-1866576063, option.getIntMaxValue());
+        Assertions.assertEquals(0.0, option.getBZero(), 1e-10);
+        Assertions.assertEquals(0, option.getIntMinValue());
+        Assertions.assertEquals(280907574, option.getIntMaxValue());
+
+        checkRequantedValues(quantProcessor, quants, matrix, option, false);
     }
 
     @Test
@@ -715,19 +713,12 @@ public class QuantizeTest {
 
         o.setCheckNull(true);
         Assertions.assertTrue(o.isCheckNull());
-        Assertions.assertNotNull(o.getBNull());
 
-        o.setCheckNull(true);
-        Assertions.assertTrue(o.isCheckNull());
-        Assertions.assertNotNull(o.getBNull());
+        o.setBNull(null);
+        Assertions.assertNull(o.getBNull());
 
-        o.setCheckNull(false);
-        Assertions.assertFalse(o.isCheckNull());
-        Assertions.assertNotNull(o.getBNull());
-
-        o.setCheckNull(false);
-        Assertions.assertFalse(o.isCheckNull());
-        Assertions.assertNotNull(o.getBNull());
+        o.setBNull(-999);
+        Assertions.assertEquals(-999, o.getBNull());
     }
 
     @Test
@@ -784,7 +775,7 @@ public class QuantizeTest {
     }
 
     @Test
-    public void testDindBero() throws Exception {
+    public void testFindBero() throws Exception {
         QuantizeOption o = new QuantizeOption();
         o.setBScale(1.0);
         o.setBZero(0.0);
@@ -799,8 +790,8 @@ public class QuantizeTest {
         o.setMaxValue(Integer.MAX_VALUE);
         Assertions.assertEquals(0.5 * Integer.MAX_VALUE, o.findBZero(), 1e-6);
 
-        o.setCheckNull(true);
-        Assertions.assertEquals(2.147483637E9, o.findBZero(), 1e-6);
+        o.setCenterOnZero(true);
+        Assertions.assertEquals(0.0, o.findBZero(), 0.5);
     }
 
     @Test
@@ -832,11 +823,9 @@ public class QuantizeTest {
 
         o.setBNull(null);
         Assertions.assertNull(o.getBNull());
-        Assertions.assertFalse(o.isCheckNull());
 
         o.setBNull(-999);
         Assertions.assertEquals(-999, o.getBNull());
-        Assertions.assertTrue(o.isCheckNull());
 
         o.setBScale(3.3);
         Assertions.assertEquals(3.3, o.getBScale());

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import nom.tam.fits.BinaryTable;
 import nom.tam.fits.BinaryTableHDU;
 import nom.tam.fits.FitsFactory;
 import nom.tam.fits.Header;
@@ -147,11 +148,12 @@ public class QuantizeTest {
     public void testDifferentfailQuantCases() {
         double[] matrix = initMatrix();
 
+        matrix[0] = Double.NaN;
+
         QuantizeProcessor quantProcessor = new QuantizeProcessor(new QuantizeOption()//
                 .setDither(false)//
                 .setDither2(false)//
                 .setQlevel(4.)//
-                .setCheckNull(false)//
                 .setNullValue(NULL_VALUE)//
                 .setTileWidth(3)//
                 .setTileHeight(2));
@@ -606,10 +608,40 @@ public class QuantizeTest {
         Assertions.assertNull(o.getBNull());
         Assertions.assertEquals(1.0, o.getBScale(), 1e-6);
         Assertions.assertEquals(0.0, o.getBZero(), 1e-6);
+    }
+
+    public void testSetColumnData() throws Exception {
+        QuantizeOption o = new QuantizeOption();
+        QuantizeParameters p = new QuantizeParameters(o);
 
         p.initializeColumns(10);
-        p.setValuesInColumn(0);
-        p.setValueInColumn(0); // deprecated old form...
+
+        BinaryTable tab = new BinaryTable();
+        BinaryTableHDU hdu = tab.toHDU();
+        p.addColumnsToTable(hdu);
+        Assertions.assertEquals(2, tab.getNCols());
+        Assertions.assertNull(hdu.getColumn("ZBLANK")); // no ZBLANK column
+
+        o.setBNull(-999);
+        o.setBScale(2.0);
+        o.setBZero(-1.0);
+        p.setValueInColumn(1); // just calls setValuesInColumn()
+
+        tab = new BinaryTable();
+        hdu = tab.toHDU();
+        p.addColumnsToTable(hdu);
+        Assertions.assertEquals(3, tab.getNCols());
+        Assertions.assertNotNull(hdu.getColumn("ZBLANK")); // has ZBLANK column
+
+        p.getValuesFromColumn(0);
+        Assertions.assertNull(o.getBNull());
+        Assertions.assertEquals(1.0, o.getBScale(), 1e-6);
+        Assertions.assertEquals(0.0, o.getBZero(), 1e-6);
+
+        p.getValuesFromColumn(1);
+        Assertions.assertEquals(-999, o.getBNull());
+        Assertions.assertEquals(2.0, o.getBScale(), 1e-6);
+        Assertions.assertEquals(-1.0, o.getBZero(), 1e-6);
     }
 
     @Test
@@ -693,7 +725,7 @@ public class QuantizeTest {
     public void testSetNullValue() throws Exception {
         QuantizeOption o = new QuantizeOption();
 
-        Assertions.assertFalse(o.isCheckNull());
+        Assertions.assertTrue(o.isCheckNull());
         Assertions.assertNull(o.getBNull());
 
         o.setCheckNull(false);
@@ -763,12 +795,11 @@ public class QuantizeTest {
     }
 
     @Test
-    public void testFindBero() throws Exception {
+    public void testFindBZero() throws Exception {
         QuantizeOption o = new QuantizeOption();
         o.setBScale(1.0);
         o.setBZero(0.0);
 
-        Assertions.assertFalse(o.isCheckNull());
         Assertions.assertFalse(o.isCenterOnZero());
 
         o.setMaxValue(1000.0);
@@ -822,7 +853,7 @@ public class QuantizeTest {
         Assertions.assertEquals(-1.2, o.getBZero());
 
         o.setCheckNull(false);
-        Assertions.assertFalse(o.isCheckNull());
+        Assertions.assertTrue(o.isCheckNull());
         o.setCheckNull(true);
         Assertions.assertTrue(o.isCheckNull());
 
@@ -885,6 +916,10 @@ public class QuantizeTest {
         o.setTileHeight(6);
         Assertions.assertTrue(q.guessQuantization(fdata));
         Assertions.assertTrue(q.guessQuantization(ddata));
+
+        o.setQlevel(-1.0);
+        Assertions.assertTrue(q.guessQuantization(fdata));
+        Assertions.assertTrue(q.guessQuantization(ddata));
     }
 
     @Test
@@ -916,6 +951,13 @@ public class QuantizeTest {
 
         o.setTileWidth(16);
         o.setTileHeight(6);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> q.guessQuantization(ints));
+
+        o.setQlevel(-1.0);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> q.guessQuantization(ints));
+
+        o.setTileWidth(8);
+        o.setTileHeight(1);
         Assertions.assertThrows(IllegalArgumentException.class, () -> q.guessQuantization(ints));
     }
 

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -220,7 +220,7 @@ public class QuantizeTest {
 
         checkRequantedValues(quantProcessor, quants, matrix, option, false);
 
-        Assertions.assertArrayEquals(new int[] {-2147483646, -2147483637, -2147483634, -2147483632, -2147483629,
+        Assertions.assertArrayEquals(new int[] {-2147483647, -2147483637, -2147483634, -2147483632, -2147483629,
                 -2147483627, -2147483625, -2147483622, -2147483619, -2147483617, -2147483615, -2147483612, -2147483609,
                 -2147483607, -2147483604, -2147483602, -2147483599, -2147483597, -2147483595, -2147483593, -2147483590,
                 -2147483587, -2147483585, -2147483582}, quants.array());
@@ -763,15 +763,15 @@ public class QuantizeTest {
 
         o.setDither2(true);
         o.initDither();
-        Assertions.assertEquals(0, o.toInt(0.0));
+        Assertions.assertEquals(-2147483647, o.toInt(0.0)); // special marker for 0.0
         Assertions.assertEquals(0, o.toInt(0.5));
-        Assertions.assertEquals(0.0, o.toDouble(0), 0.5);
+        Assertions.assertEquals(0.0, o.toDouble(-2147483647), 0.5);
         Assertions.assertEquals(0.5, o.toDouble(0), 0.5);
 
         o.setDither(false);
         o.initDither();
         Assertions.assertEquals(0, o.toInt(0.0));
-        Assertions.assertEquals(0, o.toInt(0.5));
+        Assertions.assertEquals(1, o.toInt(0.5));
         Assertions.assertEquals(0.0, o.toDouble(0), 0.5);
         Assertions.assertEquals(0.5, o.toDouble(0), 0.5);
 

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -610,6 +610,7 @@ public class QuantizeTest {
         Assertions.assertEquals(0.0, o.getBZero(), 1e-6);
     }
 
+    @Test
     public void testSetColumnData() throws Exception {
         QuantizeOption o = new QuantizeOption();
         QuantizeParameters p = new QuantizeParameters(o);
@@ -634,7 +635,7 @@ public class QuantizeTest {
         Assertions.assertNotNull(hdu.getColumn("ZBLANK")); // has ZBLANK column
 
         p.getValuesFromColumn(0);
-        Assertions.assertNull(o.getBNull());
+        Assertions.assertEquals(Integer.MIN_VALUE, o.getBNull());
         Assertions.assertEquals(1.0, o.getBScale(), 1e-6);
         Assertions.assertEquals(0.0, o.getBZero(), 1e-6);
 

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -156,18 +156,6 @@ public class QuantizeTest {
                 .setTileWidth(3)//
                 .setTileHeight(2));
         Assertions.assertFalse(quantProcessor.quantize(matrix, null));
-
-        // test very small image
-        matrix = initMatrix();
-        quantProcessor = new QuantizeProcessor(new QuantizeOption()//
-                .setDither(false)//
-                .setDither2(false)//
-                .setQlevel(4.)//
-                .setCheckNull(true)//
-                .setNullValue(NULL_VALUE)//
-                .setTileWidth(1)//
-                .setTileHeight(1));
-        Assertions.assertFalse(quantProcessor.quantize(matrix, null));
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/compression/provider/param/quant/QuantColumnParameterTest.java
+++ b/src/test/java/nom/tam/fits/compression/provider/param/quant/QuantColumnParameterTest.java
@@ -48,7 +48,7 @@ public class QuantColumnParameterTest {
 
         z.setColumnSize(10);
         Assertions.assertEquals(10, z.getColumnData().length);
-        Assertions.assertTrue(Double.isNaN(z.getColumnData()[0]));
+        Assertions.assertEquals(1.0, z.getColumnData()[0]);
 
         double[] data = new double[] {2.0, 3.0, 4.0};
         z.setColumnData(data);
@@ -58,12 +58,12 @@ public class QuantColumnParameterTest {
         z.setColumnSize(10);
         Assertions.assertEquals(10, z.getColumnData().length);
         Assertions.assertEquals(2.0, z.getColumnData()[0], 1e-12);
-        Assertions.assertTrue(Double.isNaN(z.getColumnData()[3]));
+        Assertions.assertEquals(1.0, z.getColumnData()[3]);
 
         z.createColumnData(10);
         Assertions.assertEquals(10, z.getColumnData().length);
-        Assertions.assertTrue(Double.isNaN(z.getColumnData()[0]));
-        Assertions.assertTrue(Double.isNaN(z.getColumnData()[3]));
+        Assertions.assertEquals(1.0, z.getColumnData()[0]);
+        Assertions.assertEquals(1.0, z.getColumnData()[3]);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class QuantColumnParameterTest {
 
         z.setColumnData(null, 10);
         Assertions.assertEquals(10, z.getColumnData().length);
-        Assertions.assertTrue(Double.isNaN(z.getColumnData()[0]));
+        Assertions.assertEquals(1.0, z.getColumnData()[0]);
 
         double[] data = new double[] {2.0, 3.0, 4.0};
         z.setColumnData(data, 0);
@@ -84,8 +84,8 @@ public class QuantColumnParameterTest {
 
         z.setColumnData(null, 10);
         Assertions.assertEquals(10, z.getColumnData().length);
-        Assertions.assertTrue(Double.isNaN(z.getColumnData()[0]));
-        Assertions.assertTrue(Double.isNaN(z.getColumnData()[3]));
+        Assertions.assertEquals(1.0, z.getColumnData()[0]);
+        Assertions.assertEquals(1.0, z.getColumnData()[3]);
     }
 
     @Test


### PR DESCRIPTION
### Fixed
  
 - [#892] When `SUBTRACTIVE_DITHER_2` was used (via `QuantizeOption.setDither()` and `.setDither2()`), the library used the wrong 0.0 value indicator (-2147483646), instead of the value -2147483647 prescribed by the standard. Fixed by switching to the standard indicator value.

### Changed

- `QuantizeOption.setDither2()` should not force setting `ZZERO` to 0.0 (it was), or enable dithering itself. Instead, it needs only to enable or disable the special treatment of 0.0 values, as per the FITS specification. Fixed to conform to standard more closely, and updated the Javadoc to reflect its proper usage. The old behavior was not particularly troublesome, but it was an unnecessary quirk of the implementation.
 
 - `QuantizeOption.setCenterOnZero()` did not produce the advertised behavior of keeping ZZERO at 0.0. Changed implementation to match the contract of this method. As such when `ZZERO` is not forced to be 0.0, it will be chosen to try quantize with positive integers only, which can make compression more efficient in some cases.
 
 - Automatic quantization for the compression of floating-point data as integers (via `Quantize.quantize()`) returned `false` (failure to quantize) in more cases than needed. Quantized representation is not possible only if the quantized range exceeds the 32-bit integer data range available, exclusing the special values). The change improves the compression of data. 

 - `TableHDU.getColumn(String)` changed to return `null` when there is no column with the specified name. Previously, it threw an `IndexOutOfBoundsException`.

### Deprecated

- Deprecated `QuantizeOption.setCheckZero()` and `.isCheckZero()` methods. They are duplicates of the `setDither2()` and `isDither2()` methods respectively. Similarly, `.setCheckNull()` and `.isCheckNull()` methods are deprecated as checking for NaN values is automatic when integer compressing floating-point values.

