### PR TITLE
Consolidate FitsDate year formatting and extend year range

### DIFF
--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -48,6 +48,8 @@ public class FitsDate implements Comparable<FitsDate> {
      * logger to log to.
      */
 
+    private static final int FIRST_FOUR_CHARACTER_VALUE = 1000;
+
     private static final int FIRST_THREE_CHARACTER_VALUE = 100;
 
     private static final int FIRST_TWO_CHARACTER_VALUE = 10;
@@ -263,7 +265,7 @@ public class FitsDate implements Comparable<FitsDate> {
             return "";
         }
         StringBuilder buf = new StringBuilder(FitsDate.FITS_DATE_STRING_SIZE);
-        buf.append(year);
+        appendFourDigitValue(buf, year);
         buf.append('-');
         appendTwoDigitValue(buf, month);
         buf.append('-');
@@ -334,6 +336,13 @@ public class FitsDate implements Comparable<FitsDate> {
         }
 
         return Integer.compare(millisecond, fitsDate.millisecond);
+    }
+
+    private void appendFourDigitValue(StringBuilder buf, int value) {
+        if (value < FitsDate.FIRST_FOUR_CHARACTER_VALUE) {
+            buf.append('0');
+        }
+        appendThreeDigitValue(buf, value);
     }
 
     private void appendThreeDigitValue(StringBuilder buf, int value) {

--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -152,7 +152,7 @@ public class FitsDate implements Comparable<FitsDate> {
 
         int fitsYear = toFitsYear(cal.get(Calendar.ERA), cal.get(Calendar.YEAR));
 
-        StringBuilder fitsDate = new StringBuilder(FitsDate.FITS_DATE_STRING_SIZE);
+        StringBuilder fitsDate = new StringBuilder(FITS_DATE_STRING_SIZE);
         appendYear(fitsDate, fitsYear);
         fitsDate.append('-');
         appendTwoDigitValue(fitsDate, cal.get(Calendar.MONTH) + 1);
@@ -188,17 +188,13 @@ public class FitsDate implements Comparable<FitsDate> {
      * @throws FitsException if the year is outside of the range that FITS can represent.
      */
     private static void appendYear(StringBuilder buf, int year) {
-        if (year < -FitsDate.MAX_FITS_YEAR || year > FitsDate.MAX_FITS_YEAR) {
+        if (year < -MAX_FITS_YEAR || year > MAX_FITS_YEAR) {
             throw new FitsException(
-                    "Year " + year + " is outside of the range [-" + FitsDate.MAX_FITS_YEAR + ":" + FitsDate.MAX_FITS_YEAR
+                    "Year " + year + " is outside of the range [-" + MAX_FITS_YEAR + ":" + MAX_FITS_YEAR
                             + "] that a FITS date can represent");
         }
-        if (year > FitsDate.MAX_FOUR_DIGIT_YEAR) {
-            buf.append('+');
+        if (year < 0 || year > MAX_FOUR_DIGIT_YEAR) {
             appendFiveDigitValue(buf, year);
-        } else if (year < 0) {
-            buf.append('-');
-            appendFiveDigitValue(buf, -year);
         } else {
             appendFourDigitValue(buf, year);
         }
@@ -231,53 +227,42 @@ public class FitsDate implements Comparable<FitsDate> {
             return;
         }
 
-        Matcher match = FitsDate.NORMAL_REGEX.matcher(dStr);
+        Matcher match = NORMAL_REGEX.matcher(dStr);
         if (match.matches()) {
             // The regex match ensures we can never get a NumberFormatException here...
-            year = parseYear(match.group(FitsDate.NEW_FORMAT_YEAR_GROUP));
-            month = getInt(match, FitsDate.NEW_FORMAT_MONTH_GROUP);
-            mday = getInt(match, FitsDate.NEW_FORMAT_DAY_OF_MONTH_GROUP);
-            hour = getInt(match, FitsDate.NEW_FORMAT_HOUR_GROUP);
-            minute = getInt(match, FitsDate.NEW_FORMAT_MINUTE_GROUP);
-            second = getInt(match, FitsDate.NEW_FORMAT_SECOND_GROUP);
-            millisecond = getMilliseconds(match, FitsDate.NEW_FORMAT_MILLISECOND_GROUP);
+            year = parseYear(match.group(NEW_FORMAT_YEAR_GROUP));
+            month = getInt(match, NEW_FORMAT_MONTH_GROUP);
+            mday = getInt(match, NEW_FORMAT_DAY_OF_MONTH_GROUP);
+            hour = getInt(match, NEW_FORMAT_HOUR_GROUP);
+            minute = getInt(match, NEW_FORMAT_MINUTE_GROUP);
+            second = getInt(match, NEW_FORMAT_SECOND_GROUP);
+            millisecond = getMilliseconds(match, NEW_FORMAT_MILLISECOND_GROUP);
         } else {
             // The regex match ensures we can never get a NumberFormatException here...
-            match = FitsDate.OLD_REGEX.matcher(dStr);
+            match = OLD_REGEX.matcher(dStr);
             if (!match.matches()) {
                 if (dStr.trim().isEmpty()) {
                     return;
                 }
                 throw new FitsException("Bad FITS date string \"" + dStr + '"');
             }
-            year = getInt(match, FitsDate.OLD_FORMAT_YEAR_GROUP) + FitsDate.YEAR_OFFSET;
-            month = getInt(match, FitsDate.OLD_FORMAT_MONTH_GROUP);
-            mday = getInt(match, FitsDate.OLD_FORMAT_DAY_OF_MONTH_GROUP);
+            year = getInt(match, OLD_FORMAT_YEAR_GROUP) + YEAR_OFFSET;
+            month = getInt(match, OLD_FORMAT_MONTH_GROUP);
+            mday = getInt(match, OLD_FORMAT_DAY_OF_MONTH_GROUP);
         }
     }
 
     /**
      * Parses the signed/unsigned FITS year token matched by {@link #NORMAL_REGEX}.
      *
-     * @throws FitsException if the extended year token is out of range for its sign (e.g. <code>+00001</code> or
-     *                           <code>-00000</code>).
+     * @throws FitsException if the token is not a valid integer.
      */
     private static int parseYear(String yearToken) throws FitsException {
-        char sign = yearToken.charAt(0);
-        if (sign == '+') {
-            int value = Integer.parseInt(yearToken.substring(1));
-            if (value <= FitsDate.MAX_FOUR_DIGIT_YEAR || value > FitsDate.MAX_FITS_YEAR) {
-                throw new FitsException("Bad FITS extended year \"" + yearToken + '"');
-            }
-            return value;
-        } else if (sign == '-') {
-            int value = Integer.parseInt(yearToken.substring(1));
-            if (value <= 0 || value > FitsDate.MAX_FITS_YEAR) {
-                throw new FitsException("Bad FITS extended year \"" + yearToken + '"');
-            }
-            return -value;
+        try {
+            return Integer.parseInt(yearToken);
+        } catch (NumberFormatException e) {
+            throw new FitsException("Invalid year specification: " + yearToken, e);
         }
-        return Integer.parseInt(yearToken);
     }
 
     private static int getInt(Matcher match, int groupIndex) throws NumberFormatException {
@@ -410,28 +395,34 @@ public class FitsDate implements Comparable<FitsDate> {
     }
 
     private static void appendFourDigitValue(StringBuilder buf, int value) {
-        if (value < FitsDate.FIRST_FOUR_CHARACTER_VALUE) {
+        if (value < FIRST_FOUR_CHARACTER_VALUE) {
             buf.append('0');
         }
         appendThreeDigitValue(buf, value);
     }
 
     private static void appendFiveDigitValue(StringBuilder buf, int value) {
-        if (value < FitsDate.FIRST_FIVE_CHARACTER_VALUE) {
+        if (value < 0) {
+            buf.append('-');
+            value = -value;
+        } else {
+            buf.append('+');
+        }
+        if (value < FIRST_FIVE_CHARACTER_VALUE) {
             buf.append('0');
         }
         appendFourDigitValue(buf, value);
     }
 
     private static void appendThreeDigitValue(StringBuilder buf, int value) {
-        if (value < FitsDate.FIRST_THREE_CHARACTER_VALUE) {
+        if (value < FIRST_THREE_CHARACTER_VALUE) {
             buf.append('0');
         }
         appendTwoDigitValue(buf, value);
     }
 
     private static void appendTwoDigitValue(StringBuilder buf, int value) {
-        if (value < FitsDate.FIRST_TWO_CHARACTER_VALUE) {
+        if (value < FIRST_TWO_CHARACTER_VALUE) {
             buf.append('0');
         }
         buf.append(value);

--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -230,7 +230,7 @@ public class FitsDate implements Comparable<FitsDate> {
         Matcher match = NORMAL_REGEX.matcher(dStr);
         if (match.matches()) {
             // The regex match ensures we can never get a NumberFormatException here...
-            year = parseYear(match.group(NEW_FORMAT_YEAR_GROUP));
+            year = Integer.parseInt(match.group(NEW_FORMAT_YEAR_GROUP));
             month = getInt(match, NEW_FORMAT_MONTH_GROUP);
             mday = getInt(match, NEW_FORMAT_DAY_OF_MONTH_GROUP);
             hour = getInt(match, NEW_FORMAT_HOUR_GROUP);
@@ -249,19 +249,6 @@ public class FitsDate implements Comparable<FitsDate> {
             year = getInt(match, OLD_FORMAT_YEAR_GROUP) + YEAR_OFFSET;
             month = getInt(match, OLD_FORMAT_MONTH_GROUP);
             mday = getInt(match, OLD_FORMAT_DAY_OF_MONTH_GROUP);
-        }
-    }
-
-    /**
-     * Parses the signed/unsigned FITS year token matched by {@link #NORMAL_REGEX}.
-     *
-     * @throws FitsException if the token is not a valid integer.
-     */
-    private static int parseYear(String yearToken) throws FitsException {
-        try {
-            return Integer.parseInt(yearToken);
-        } catch (NumberFormatException e) {
-            throw new FitsException("Invalid year specification: " + yearToken, e);
         }
     }
 

--- a/src/main/java/nom/tam/fits/FitsDate.java
+++ b/src/main/java/nom/tam/fits/FitsDate.java
@@ -31,9 +31,9 @@ package nom.tam.fits;
  * #L%
  */
 
-import java.text.DecimalFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -54,7 +54,20 @@ public class FitsDate implements Comparable<FitsDate> {
 
     private static final int FIRST_TWO_CHARACTER_VALUE = 10;
 
-    private static final int FITS_DATE_STRING_SIZE = 23;
+    private static final int FIRST_FIVE_CHARACTER_VALUE = 10000;
+
+    /**
+     * The largest (and, negated, the smallest) year value permitted by FITS Section 9.1.1 ("[{+,-}C]CCYY" extended
+     * to 5 digits).
+     */
+    private static final int MAX_FITS_YEAR = 99999;
+
+    /**
+     * The largest year that is represented with an unsigned, exactly 4-digit value.
+     */
+    private static final int MAX_FOUR_DIGIT_YEAR = 9999;
+
+    private static final int FITS_DATE_STRING_SIZE = 25;
 
     private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
@@ -73,7 +86,7 @@ public class FitsDate implements Comparable<FitsDate> {
     private static final int NEW_FORMAT_YEAR_GROUP = 2;
 
     private static final Pattern NORMAL_REGEX = Pattern
-            .compile("\\s*((\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d))(T(\\d\\d):(\\d\\d):(\\d\\d)(\\.(\\d+))?)?\\s*");
+            .compile("\\s*((\\d{4}|[+-]\\d{5})-(\\d\\d)-(\\d\\d))(T(\\d\\d):(\\d\\d):(\\d\\d)(\\.(\\d+))?)?\\s*");
 
     private static final int OLD_FORMAT_DAY_OF_MONTH_GROUP = 1;
 
@@ -116,40 +129,79 @@ public class FitsDate implements Comparable<FitsDate> {
 
     /**
      * Returns the FITS date string, with or without the time component, for a specific date and time.
+     * <p>
+     * Years are formatted per FITS Section 9.1.1 ("[{+,-}C]CCYY"): <code>0</code>-<code>9999</code> as an unsigned
+     * 4-digit value, <code>10000</code>-<code>99999</code> as <code>+</code> followed by 5 digits, and
+     * <code>-1</code>-<code>-99999</code> as <code>-</code> followed by 5 digits.
+     * </p>
      * 
      * @return           a created FITS format date string. Note that the date is not rounded.
      *
      * @param  epoch     The epoch to be converted to FITS format.
      * @param  timeOfDay Whether the time of day information shouldd be included
      * 
+     * @throws FitsException if the year of <code>epoch</code> is outside of the range <code>-99999</code> to
+     *                           <code>99999</code> that a FITS date can represent.
+     *
      * @see              #getFitsDateString(Date)
      * @see              #getFitsDateString()
      */
     public static String getFitsDateString(Date epoch, boolean timeOfDay) {
-        Calendar cal = Calendar.getInstance(UTC);
+        Calendar cal = new GregorianCalendar(UTC);
         cal.setTime(epoch);
-        StringBuilder fitsDate = new StringBuilder();
-        DecimalFormat df = new DecimalFormat("0000");
-        fitsDate.append(df.format(cal.get(Calendar.YEAR)));
-        fitsDate.append("-");
-        df = new DecimalFormat("00");
 
-        fitsDate.append(df.format(cal.get(Calendar.MONTH) + 1));
-        fitsDate.append("-");
-        fitsDate.append(df.format(cal.get(Calendar.DAY_OF_MONTH)));
+        int fitsYear = toFitsYear(cal.get(Calendar.ERA), cal.get(Calendar.YEAR));
+
+        StringBuilder fitsDate = new StringBuilder(FitsDate.FITS_DATE_STRING_SIZE);
+        appendYear(fitsDate, fitsYear);
+        fitsDate.append('-');
+        appendTwoDigitValue(fitsDate, cal.get(Calendar.MONTH) + 1);
+        fitsDate.append('-');
+        appendTwoDigitValue(fitsDate, cal.get(Calendar.DAY_OF_MONTH));
 
         if (timeOfDay) {
-            fitsDate.append("T");
-            fitsDate.append(df.format(cal.get(Calendar.HOUR_OF_DAY)));
-            fitsDate.append(":");
-            fitsDate.append(df.format(cal.get(Calendar.MINUTE)));
-            fitsDate.append(":");
-            fitsDate.append(df.format(cal.get(Calendar.SECOND)));
-            fitsDate.append(".");
-            df = new DecimalFormat("000");
-            fitsDate.append(df.format(cal.get(Calendar.MILLISECOND)));
+            fitsDate.append('T');
+            appendTwoDigitValue(fitsDate, cal.get(Calendar.HOUR_OF_DAY));
+            fitsDate.append(':');
+            appendTwoDigitValue(fitsDate, cal.get(Calendar.MINUTE));
+            fitsDate.append(':');
+            appendTwoDigitValue(fitsDate, cal.get(Calendar.SECOND));
+            fitsDate.append('.');
+            appendThreeDigitValue(fitsDate, cal.get(Calendar.MILLISECOND));
         }
         return fitsDate.toString();
+    }
+
+    /**
+     * Converts a {@link Calendar} era/year pair into the signed FITS year (BC 1 is FITS 0, BC 2 is FITS -1, etc.).
+     */
+    private static int toFitsYear(int era, int calendarYear) {
+        if (era == GregorianCalendar.BC) {
+            return 1 - calendarYear;
+        }
+        return calendarYear;
+    }
+
+    /**
+     * Appends the FITS Section 9.1.1 representation of a signed astronomical year to the buffer.
+     *
+     * @throws FitsException if the year is outside of the range that FITS can represent.
+     */
+    private static void appendYear(StringBuilder buf, int year) {
+        if (year < -FitsDate.MAX_FITS_YEAR || year > FitsDate.MAX_FITS_YEAR) {
+            throw new FitsException(
+                    "Year " + year + " is outside of the range [-" + FitsDate.MAX_FITS_YEAR + ":" + FitsDate.MAX_FITS_YEAR
+                            + "] that a FITS date can represent");
+        }
+        if (year > FitsDate.MAX_FOUR_DIGIT_YEAR) {
+            buf.append('+');
+            appendFiveDigitValue(buf, year);
+        } else if (year < 0) {
+            buf.append('-');
+            appendFiveDigitValue(buf, -year);
+        } else {
+            appendFourDigitValue(buf, year);
+        }
     }
 
     private int hour = -1;
@@ -182,7 +234,7 @@ public class FitsDate implements Comparable<FitsDate> {
         Matcher match = FitsDate.NORMAL_REGEX.matcher(dStr);
         if (match.matches()) {
             // The regex match ensures we can never get a NumberFormatException here...
-            year = getInt(match, FitsDate.NEW_FORMAT_YEAR_GROUP);
+            year = parseYear(match.group(FitsDate.NEW_FORMAT_YEAR_GROUP));
             month = getInt(match, FitsDate.NEW_FORMAT_MONTH_GROUP);
             mday = getInt(match, FitsDate.NEW_FORMAT_DAY_OF_MONTH_GROUP);
             hour = getInt(match, FitsDate.NEW_FORMAT_HOUR_GROUP);
@@ -202,6 +254,30 @@ public class FitsDate implements Comparable<FitsDate> {
             month = getInt(match, FitsDate.OLD_FORMAT_MONTH_GROUP);
             mday = getInt(match, FitsDate.OLD_FORMAT_DAY_OF_MONTH_GROUP);
         }
+    }
+
+    /**
+     * Parses the signed/unsigned FITS year token matched by {@link #NORMAL_REGEX}.
+     *
+     * @throws FitsException if the extended year token is out of range for its sign (e.g. <code>+00001</code> or
+     *                           <code>-00000</code>).
+     */
+    private static int parseYear(String yearToken) throws FitsException {
+        char sign = yearToken.charAt(0);
+        if (sign == '+') {
+            int value = Integer.parseInt(yearToken.substring(1));
+            if (value <= FitsDate.MAX_FOUR_DIGIT_YEAR || value > FitsDate.MAX_FITS_YEAR) {
+                throw new FitsException("Bad FITS extended year \"" + yearToken + '"');
+            }
+            return value;
+        } else if (sign == '-') {
+            int value = Integer.parseInt(yearToken.substring(1));
+            if (value <= 0 || value > FitsDate.MAX_FITS_YEAR) {
+                throw new FitsException("Bad FITS extended year \"" + yearToken + '"');
+            }
+            return -value;
+        }
+        return Integer.parseInt(yearToken);
     }
 
     private static int getInt(Matcher match, int groupIndex) throws NumberFormatException {
@@ -231,13 +307,19 @@ public class FitsDate implements Comparable<FitsDate> {
      * @return The Java Date object.
      */
     public Date toDate() {
-        if (year == -1) {
+        if (month == -1) {
             return null;
         }
 
-        Calendar cal = Calendar.getInstance(UTC);
+        Calendar cal = new GregorianCalendar(UTC);
 
-        cal.set(Calendar.YEAR, year);
+        if (year > 0) {
+            cal.set(Calendar.ERA, GregorianCalendar.AD);
+            cal.set(Calendar.YEAR, year);
+        } else {
+            cal.set(Calendar.ERA, GregorianCalendar.BC);
+            cal.set(Calendar.YEAR, 1 - year);
+        }
         cal.set(Calendar.MONTH, month - 1);
         cal.set(Calendar.DAY_OF_MONTH, mday);
 
@@ -261,28 +343,17 @@ public class FitsDate implements Comparable<FitsDate> {
 
     @Override
     public String toString() {
-        if (year == -1) {
+        if (month == -1) {
             return "";
         }
-        StringBuilder buf = new StringBuilder(FitsDate.FITS_DATE_STRING_SIZE);
-        appendFourDigitValue(buf, year);
-        buf.append('-');
-        appendTwoDigitValue(buf, month);
-        buf.append('-');
-        appendTwoDigitValue(buf, mday);
-        if (hour != -1) {
-            buf.append('T');
-            appendTwoDigitValue(buf, hour);
-            buf.append(':');
-            appendTwoDigitValue(buf, minute);
-            buf.append(':');
-            appendTwoDigitValue(buf, second);
-            if (millisecond != -1) {
-                buf.append('.');
-                appendThreeDigitValue(buf, millisecond);
-            }
+
+        // Delegate to the centralized Date -> FITS formatter, but keep the original ".000"
+        // omission for values parsed without a fractional-seconds component.
+        String formatted = getFitsDateString(toDate(), hour != -1);
+        if (hour != -1 && millisecond == -1) {
+            return formatted.substring(0, formatted.lastIndexOf('.'));
         }
-        return buf.toString();
+        return formatted;
     }
 
     @Override
@@ -338,21 +409,28 @@ public class FitsDate implements Comparable<FitsDate> {
         return Integer.compare(millisecond, fitsDate.millisecond);
     }
 
-    private void appendFourDigitValue(StringBuilder buf, int value) {
+    private static void appendFourDigitValue(StringBuilder buf, int value) {
         if (value < FitsDate.FIRST_FOUR_CHARACTER_VALUE) {
             buf.append('0');
         }
         appendThreeDigitValue(buf, value);
     }
 
-    private void appendThreeDigitValue(StringBuilder buf, int value) {
+    private static void appendFiveDigitValue(StringBuilder buf, int value) {
+        if (value < FitsDate.FIRST_FIVE_CHARACTER_VALUE) {
+            buf.append('0');
+        }
+        appendFourDigitValue(buf, value);
+    }
+
+    private static void appendThreeDigitValue(StringBuilder buf, int value) {
         if (value < FitsDate.FIRST_THREE_CHARACTER_VALUE) {
             buf.append('0');
         }
         appendTwoDigitValue(buf, value);
     }
 
-    private void appendTwoDigitValue(StringBuilder buf, int value) {
+    private static void appendTwoDigitValue(StringBuilder buf, int value) {
         if (value < FitsDate.FIRST_TWO_CHARACTER_VALUE) {
             buf.append('0');
         }

--- a/src/test/java/nom/tam/fits/FitsDateTest.java
+++ b/src/test/java/nom/tam/fits/FitsDateTest.java
@@ -109,9 +109,13 @@ public class FitsDateTest {
     public void testInvalidExtendedYearParsing() {
         Assertions.assertThrows(FitsException.class, () -> new FitsDate("+100000-01-01"));
         Assertions.assertThrows(FitsException.class, () -> new FitsDate("-100000-01-01"));
-        Assertions.assertThrows(FitsException.class, () -> new FitsDate("+00001-01-01"));
-        Assertions.assertThrows(FitsException.class, () -> new FitsDate("+09999-01-01"));
-        Assertions.assertThrows(FitsException.class, () -> new FitsDate("-00000-01-01"));
+    }
+
+    @Test
+    public void testNonCanonicalExtendedYearParsing() throws Exception {
+        Assertions.assertEquals("0001-01-01", new FitsDate("+00001-01-01").toString());
+        Assertions.assertEquals("9999-01-01", new FitsDate("+09999-01-01").toString());
+        Assertions.assertEquals("0000-01-01", new FitsDate("-00000-01-01").toString());
     }
 
     @Test

--- a/src/test/java/nom/tam/fits/FitsDateTest.java
+++ b/src/test/java/nom/tam/fits/FitsDateTest.java
@@ -1,6 +1,8 @@
 package nom.tam.fits;
 
 import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 /*
@@ -86,6 +88,114 @@ public class FitsDateTest {
     @Test
     public void testEmptyDate() throws Exception {
         Assertions.assertNull(new FitsDate("").toDate());
+    }
+
+    @Test
+    public void testYearFormatting() throws Exception {
+        Assertions.assertEquals("0000-01-01", new FitsDate("0000-01-01").toString());
+        Assertions.assertEquals("0001-01-01", new FitsDate("0001-01-01").toString());
+        Assertions.assertEquals("0099-01-01", new FitsDate("0099-01-01").toString());
+        Assertions.assertEquals("0999-01-01", new FitsDate("0999-01-01").toString());
+        Assertions.assertEquals("9999-01-01", new FitsDate("9999-01-01").toString());
+        Assertions.assertEquals("+10000-01-01", new FitsDate("+10000-01-01").toString());
+        Assertions.assertEquals("+99999-01-01", new FitsDate("+99999-01-01").toString());
+        Assertions.assertEquals("-00001-01-01", new FitsDate("-00001-01-01").toString());
+        Assertions.assertEquals("-00999-01-01", new FitsDate("-00999-01-01").toString());
+        Assertions.assertEquals("-09999-01-01", new FitsDate("-09999-01-01").toString());
+        Assertions.assertEquals("-99999-01-01", new FitsDate("-99999-01-01").toString());
+    }
+
+    @Test
+    public void testInvalidExtendedYearParsing() {
+        Assertions.assertThrows(FitsException.class, () -> new FitsDate("+100000-01-01"));
+        Assertions.assertThrows(FitsException.class, () -> new FitsDate("-100000-01-01"));
+        Assertions.assertThrows(FitsException.class, () -> new FitsDate("+00001-01-01"));
+        Assertions.assertThrows(FitsException.class, () -> new FitsDate("+09999-01-01"));
+        Assertions.assertThrows(FitsException.class, () -> new FitsDate("-00000-01-01"));
+    }
+
+    @Test
+    public void testGetFitsDateStringRangeValidation() {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.set(Calendar.ERA, GregorianCalendar.AD);
+        cal.set(Calendar.YEAR, 99999);
+        cal.set(Calendar.MONTH, Calendar.JANUARY);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        Assertions.assertEquals("+99999-01-01", FitsDate.getFitsDateString(cal.getTime(), false));
+
+        cal.set(Calendar.YEAR, 100000);
+        Assertions.assertThrows(FitsException.class, () -> FitsDate.getFitsDateString(cal.getTime(), false));
+
+        cal.set(Calendar.ERA, GregorianCalendar.BC);
+        cal.set(Calendar.YEAR, 100000); // Calendar YEAR 100000 BC == FITS year -99999
+        Assertions.assertEquals("-99999-01-01", FitsDate.getFitsDateString(cal.getTime(), false));
+
+        cal.set(Calendar.YEAR, 100001); // Calendar YEAR 100001 BC == FITS year -100000
+        Assertions.assertThrows(FitsException.class, () -> FitsDate.getFitsDateString(cal.getTime(), false));
+    }
+
+    @Test
+    public void testCalendarEraMapping() throws Exception {
+        assertEraYear(new FitsDate("0001-06-15"), GregorianCalendar.AD, 1);
+        assertEraYear(new FitsDate("0000-06-15"), GregorianCalendar.BC, 1);
+        assertEraYear(new FitsDate("-00001-06-15"), GregorianCalendar.BC, 2);
+        assertEraYear(new FitsDate("-00999-06-15"), GregorianCalendar.BC, 1000);
+        assertEraYear(new FitsDate("-99999-06-15"), GregorianCalendar.BC, 100000);
+    }
+
+    private static void assertEraYear(FitsDate fitsDate, int expectedEra, int expectedYear) {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.setTime(fitsDate.toDate());
+        Assertions.assertEquals(expectedEra, cal.get(Calendar.ERA));
+        Assertions.assertEquals(expectedYear, cal.get(Calendar.YEAR));
+    }
+
+    @Test
+    public void testBcCalendarYearIsNotMisreadAsPositiveFitsYear() {
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.set(Calendar.ERA, GregorianCalendar.BC);
+        cal.set(Calendar.YEAR, 1);
+        cal.set(Calendar.MONTH, Calendar.JANUARY);
+        cal.set(Calendar.DAY_OF_MONTH, 1);
+        Assertions.assertEquals("0000-01-01", FitsDate.getFitsDateString(cal.getTime(), false));
+
+        cal.set(Calendar.YEAR, 2);
+        Assertions.assertEquals("-00001-01-01", FitsDate.getFitsDateString(cal.getTime(), false));
+    }
+
+    @Test
+    public void testRoundTripExtendedYears() throws Exception {
+        String[] dates = {"0000-05-06", "0001-05-06", "9999-05-06", "+10000-05-06", "+99999-05-06", "-00001-05-06",
+                "-00999-05-06", "-09999-05-06", "-99999-05-06"};
+        for (String d : dates) {
+            Date date = new FitsDate(d).toDate();
+            Assertions.assertEquals(d, FitsDate.getFitsDateString(date, false));
+        }
+    }
+
+    @Test
+    public void testFractionalSecondsPrecisionUnchanged() throws Exception {
+        Assertions.assertEquals("2000-01-01T00:00:00.000", new FitsDate("2000-01-01T00:00:00.0").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.000", new FitsDate("2000-01-01T00:00:00.00").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.000", new FitsDate("2000-01-01T00:00:00.000").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.001", new FitsDate("2000-01-01T00:00:00.001").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.010", new FitsDate("2000-01-01T00:00:00.01").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.100", new FitsDate("2000-01-01T00:00:00.1").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.123", new FitsDate("2000-01-01T00:00:00.123").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.123", new FitsDate("2000-01-01T00:00:00.1234").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.123", new FitsDate("2000-01-01T00:00:00.12345").toString());
+        Assertions.assertEquals("2000-01-01T00:00:00.124", new FitsDate("2000-01-01T00:00:00.123567").toString());
+    }
+
+    @Test
+    public void testToStringAndToDateAgreeOnLenientCalendarNormalization() throws Exception {
+        FitsDate fitsDate = new FitsDate("2023-02-30");
+        Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.setTime(fitsDate.toDate());
+        int rolledOverMonth = cal.get(Calendar.MONTH) + 1;
+        int rolledOverDay = cal.get(Calendar.DAY_OF_MONTH);
+        String expected = String.format("2023-%02d-%02d", rolledOverMonth, rolledOverDay);
+        Assertions.assertEquals(expected, fitsDate.toString());
     }
 
 }

--- a/src/test/java/nom/tam/util/test/FitsDateTest.java
+++ b/src/test/java/nom/tam/util/test/FitsDateTest.java
@@ -94,6 +94,13 @@ public class FitsDateTest {
     }
 
     @Test
+    public void yearZeroPadding() throws FitsException {
+        Assertions.assertEquals("0999-07-25", testArg("0999-07-25"));
+        Assertions.assertEquals("0099-07-25", testArg("0099-07-25"));
+        Assertions.assertEquals("0009-07-25", testArg("0009-07-25"));
+    }
+
+    @Test
     public void testNow() {
         String now = FitsDate.getFitsDateString();
         String now2 = FitsDate.getFitsDateString(new Date());

--- a/src/test/java/nom/tam/util/test/FitsDateTest.java
+++ b/src/test/java/nom/tam/util/test/FitsDateTest.java
@@ -132,6 +132,26 @@ public class FitsDateTest {
         Assertions.assertEquals("1979-09-20", testArg("20/09/79"));
     }
 
+    @Test
+    public void extendedYearGood() {
+        Assertions.assertEquals("0000-07-25", testArg("0000-07-25"));
+        Assertions.assertEquals("+10000-07-25", testArg("+10000-07-25"));
+        Assertions.assertEquals("+99999-07-25", testArg("+99999-07-25"));
+        Assertions.assertEquals("-00001-07-25", testArg("-00001-07-25"));
+        Assertions.assertEquals("-00999-07-25", testArg("-00999-07-25"));
+        Assertions.assertEquals("-09999-07-25", testArg("-09999-07-25"));
+        Assertions.assertEquals("-99999-07-25", testArg("-99999-07-25"));
+    }
+
+    @Test
+    public void extendedYearBad() {
+        Assertions.assertEquals("EX", testArg("+100000-07-25"));
+        Assertions.assertEquals("EX", testArg("-100000-07-25"));
+        Assertions.assertEquals("EX", testArg("+00001-07-25"));
+        Assertions.assertEquals("EX", testArg("+09999-07-25"));
+        Assertions.assertEquals("EX", testArg("-00000-07-25"));
+    }
+
     private String testArg(String arg) {
         try {
             return new FitsDate(arg).toString();

--- a/src/test/java/nom/tam/util/test/FitsDateTest.java
+++ b/src/test/java/nom/tam/util/test/FitsDateTest.java
@@ -147,9 +147,13 @@ public class FitsDateTest {
     public void extendedYearBad() {
         Assertions.assertEquals("EX", testArg("+100000-07-25"));
         Assertions.assertEquals("EX", testArg("-100000-07-25"));
-        Assertions.assertEquals("EX", testArg("+00001-07-25"));
-        Assertions.assertEquals("EX", testArg("+09999-07-25"));
-        Assertions.assertEquals("EX", testArg("-00000-07-25"));
+    }
+
+    @Test
+    public void extendedYearNonCanonical() {
+        Assertions.assertEquals("0001-07-25", testArg("+00001-07-25"));
+        Assertions.assertEquals("9999-07-25", testArg("+09999-07-25"));
+        Assertions.assertEquals("0000-07-25", testArg("-00000-07-25"));
     }
 
     private String testArg(String arg) {


### PR DESCRIPTION
Fixed

- "FitsDate" did not correctly handle FITS dates with years outside the four-digit range. Years before 1000 were formatted without the required leading zeroes, and years outside the supported four- or five-digit FITS representation were not handled correctly. Fixed to support years from "-99999" to "99999" using the FITS-specified year formats.

Changed

- "FitsDate.toString()" now uses the same FITS date formatting logic as "getFitsDateString(Date, boolean)", ensuring consistent handling of astronomical years, including negative and extended years.

- Year parsing now supports both signed and unsigned FITS year representations and allows non-canonical signed forms to be parsed and normalized.

- Added and updated tests covering four-digit, extended, negative, boundary, and non-canonical FITS year representations.