### PR TITLE
Fix stale option in copied quantize parameters

### DIFF
--- a/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
+++ b/src/main/java/nom/tam/fits/compression/provider/param/quant/QuantizeParameters.java
@@ -122,6 +122,7 @@ public class QuantizeParameters extends CompressParameters {
             QuantizeOption qo = (QuantizeOption) option;
 
             QuantizeParameters p = (QuantizeParameters) super.clone();
+            p.options = qo;
             p.quantz = (ZQuantizeParameter) quantz.copy(qo);
             p.blank = (ZBlankParameter) blank.copy(qo);
             p.seed = (ZDither0Parameter) seed.copy(qo);

--- a/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
+++ b/src/test/java/nom/tam/fits/compression/algorithm/quant/QuantizeTest.java
@@ -582,6 +582,32 @@ public class QuantizeTest {
     }
 
     @Test
+    public void testCopiedParametersUseDestinationBlankValue() throws Exception {
+        QuantizeOption source = new QuantizeOption();
+        QuantizeOption destination = new QuantizeOption().setBNull(-999);
+
+        destination.setParameters(new QuantizeParameters(source));
+
+        Header header = new Header();
+        destination.getCompressionParameters().setValuesInHeader(header);
+
+        Assertions.assertEquals(-999, header.getIntValue(Compression.ZBLANK));
+    }
+
+    @Test
+    public void testCopiedParametersDoNotUseSourceBlankValue() throws Exception {
+        QuantizeOption source = new QuantizeOption().setBNull(-999);
+        QuantizeOption destination = new QuantizeOption();
+
+        destination.setParameters(new QuantizeParameters(source));
+
+        Header header = new Header();
+        destination.getCompressionParameters().setValuesInHeader(header);
+
+        Assertions.assertNull(header.getCard(Compression.ZBLANK));
+    }
+
+    @Test
     public void testColumnParameterCreateData() throws Exception {
         QuantizeOption o = new QuantizeOption();
         ZBlankColumnParameter p = new ZBlankColumnParameter(o);


### PR DESCRIPTION
Copied QuantizeParameters kept the source QuantizeOption, causing ZBLANK to use the wrong BNull value.

This rebinds the copied parameters to the destination option and adds regression tests for both cases.